### PR TITLE
untrack dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@
 /bin
 /build
 /typings
+/dist


### PR DESCRIPTION
sdist buildをローカルで走らせたときに`dist/`に`tar.gz`が残ってしまって、実際 #83 で誤ってプッシュされてしまったのでignoreします。