### PR TITLE
suppress nvcc warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,14 @@ if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") OR (${CMAKE_CXX_COMPILER_ID} STREQ
         -Wuninitialized
     )
 
+    if(SCALUQ_USE_CUDA)
+        # to remove tremendous warnings of Eigen
+        target_compile_options(scaluq PUBLIC
+            -Wno-unknown-pragmas
+            --expt-relaxed-constexpr
+        ) 
+    endif()
+
     # Enable pthread
     target_compile_options(scaluq PUBLIC -pthread)
 


### PR DESCRIPTION
GPUでビルドする際にEigenが以下のような大量のwarningを吐くので、これを抑制するオプションを追加します。
```
/workspaces/scaluq/build/_deps/eigen_fetch-src/Eigen/src/Core/util/DisableStupidWarnings.h:89: warning: ignoring ‘#pragma diag_suppress ’ [-Wunknown-pragmas]
   89 |   #pragma diag_suppress 2668
      | 
/workspaces/scaluq/build/_deps/eigen_fetch-src/Eigen/src/Core/util/DisableStupidWarnings.h:90: warning: ignoring ‘#pragma diag_suppress ’ [-Wunknown-pragmas]
   90 |   #pragma diag_suppress 2669
      | 
/workspaces/scaluq/build/_deps/eigen_fetch-src/Eigen/src/Core/util/DisableStupidWarnings.h:91: warning: ignoring ‘#pragma diag_suppress ’ [-Wunknown-pragmas]
   91 |   #pragma diag_suppress 2670
      | 
/workspaces/scaluq/build/_deps/eigen_fetch-src/Eigen/src/Core/util/DisableStupidWarnings.h:92: warning: ignoring ‘#pragma diag_suppress ’ [-Wunknown-pragmas]
   92 |   #pragma diag_suppress 2671
      | 
/workspaces/scaluq/build/_deps/eigen_fetch-src/Eigen/src/Core/util/DisableStupidWarnings.h:93: warning: ignoring ‘#pragma diag_suppress ’ [-Wunknown-pragmas]
   93 |   #pragma diag_suppress 2735
      | 
/workspaces/scaluq/build/_deps/eigen_fetch-src/Eigen/src/Core/util/DisableStupidWarnings.h:94: warning: ignoring ‘#pragma diag_suppress ’ [-Wunknown-pragmas]
   94 |   #pragma diag_suppress 2737
      | 
/workspaces/scaluq/build/_deps/eigen_fetch-src/Eigen/src/Core/util/DisableStupidWarnings.h:95: warning: ignoring ‘#pragma diag_suppress ’ [-Wunknown-pragmas]
   95 |   #pragma diag_suppress 2739
      | 
```