### PR TITLE
run wheel/sdist build on tag push

### DIFF
--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -8,6 +8,8 @@ on:
       - "*.md"
     branches:
       - "main"
+    tags:
+      - "v*"
   workflow_dispatch:
   
 jobs:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -8,6 +8,8 @@ on:
       - "*.md"
     branches:
       - "main"
+    tags:
+      - "v*"
   workflow_dispatch:
   
 jobs:


### PR DESCRIPTION
タグをプッシュすればリリースする仕組みを作っていましたが、タグをプッシュしたときに自動で走らなかったので修正です。
`v0.0.0`はworkflow_dispatchで回したので大丈夫です。