### PR TITLE
Wheel ci os

### DIFF
--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -17,7 +17,7 @@ jobs:
     name: Source distribution
     strategy:
       matrix:
-        os: ["ubuntu22.04"]
+        os: ["ubuntu-22.04"]
         python-verson: ["3.12"]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -51,7 +51,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheels
           
       - name: Upload wheel to GitHub
-        uses: action/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           path: ./wheels/*.whl
       

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -22,7 +22,7 @@ jobs:
         cibw-python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
         include:
           - os-arch: "manylinux_x86_64"
-            os: "ubuntu22.04"
+            os: "ubuntu-22.04"
           - cibw-python: "cp38"
             python-version: "3.8"
           - cibw-python: "cp39"


### PR DESCRIPTION
`ubuntu-22.04`・`actions/artifact`の名前を間違えてしまってリリースのCIが動かなかったので修正しました。