### PR TITLE
name wheel artifact

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Upload wheel to GitHub
         uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.cibw-python }}-${{ matrix.os-arch }}
           path: ./wheels/*.whl
       
       - name: Upload wheel data if the Git tag is set


### PR DESCRIPTION
#101 で修正したつもりでしたが、upload-artifact@v4では同一ワークフローからの同名アーティファクトのアップロードができなくなっていたので環境ごとに名前をつけました。
再度見ていただけないでしょうか。
今回はworkflow_dispatchを実行して正常に終了・アップロードされていることを確認しました。
https://github.com/qulacs/scaluq/actions/runs/9166833240