### PR TITLE
update readthedocs.yml correspond to #106

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,10 +5,11 @@ build:
     python: "3.12"
 
 sphinx:
-  configuration: tutorials/source/conf.py
+  configuration: doc/source/conf.py
 
 python:
   install:
-    - requirements: tutorials/requirements.txt
     - method: pip
       path: .
+      extra_requirements:
+        - doc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,5 +69,6 @@ doc = [
     "sphinx-autoapi == 3.1.1",
     "sphinxcontrib-napoleon == 0.7",
     "sphinx_rtd_theme == 2.0.0",
-    "sphinx-math-dollar == 1.2.1"
+    "sphinx-math-dollar == 1.2.1",
+    "nanobind == 2.0.0"
 ]


### PR DESCRIPTION
ドキュメントのパスが`doc`になったので変えたのと、`pip install .[doc]`でドキュメントをビルドするための依存パッケージごとscaluqをインストールできるようになったのでそれに対応しました。