### PR TITLE
add fence

### DIFF
--- a/scaluq/gate/update_ops_dense_matrix.cpp
+++ b/scaluq/gate/update_ops_dense_matrix.cpp
@@ -20,6 +20,7 @@ void single_qubit_dense_matrix_gate(UINT target_qubit_index,
             state._raw[basis_0] = res0;
             state._raw[basis_1] = res1;
         });
+    Kokkos::fence();
 }
 
 void double_qubit_dense_matrix_gate(UINT target0,
@@ -49,6 +50,7 @@ void double_qubit_dense_matrix_gate(UINT target0,
             state._raw[basis_2] = res2;
             state._raw[basis_3] = res3;
         });
+    Kokkos::fence();
 }
 }  // namespace internal
 }  // namespace scaluq

--- a/scaluq/gate/update_ops_npair_qubit.cpp
+++ b/scaluq/gate/update_ops_npair_qubit.cpp
@@ -31,6 +31,7 @@ void fusedswap_gate(UINT target_qubit_index_0,
                 Kokkos::Experimental::swap(state._raw[i], state._raw[j]);
             }
         });
+    Kokkos::fence();
 }
 }  // namespace internal
 }  // namespace scaluq

--- a/scaluq/gate/update_ops_one_control_one_target.cpp
+++ b/scaluq/gate/update_ops_one_control_one_target.cpp
@@ -16,6 +16,7 @@ void cx_gate(UINT control_qubit_index, UINT target_qubit_index, StateVector& sta
             i |= 1ULL << control_qubit_index;
             Kokkos::Experimental::swap(state._raw[i], state._raw[i | (1ULL << target_qubit_index)]);
         });
+    Kokkos::fence();
 }
 
 void cz_gate(UINT control_qubit_index, UINT target_qubit_index, StateVector& state) {
@@ -27,6 +28,7 @@ void cz_gate(UINT control_qubit_index, UINT target_qubit_index, StateVector& sta
             i |= 1ULL << target_qubit_index;
             state._raw[i] *= -1;
         });
+    Kokkos::fence();
 }
 }  // namespace internal
 }  // namespace scaluq

--- a/scaluq/gate/update_ops_one_qubit.cpp
+++ b/scaluq/gate/update_ops_one_qubit.cpp
@@ -14,6 +14,7 @@ void x_gate(UINT target_qubit_index, StateVector& state) {
             UINT i = internal::insert_zero_to_basis_index(it, target_qubit_index);
             Kokkos::Experimental::swap(state._raw[i], state._raw[i | (1ULL << target_qubit_index)]);
         });
+    Kokkos::fence();
 }
 
 void y_gate(UINT target_qubit_index, StateVector& state) {
@@ -24,6 +25,7 @@ void y_gate(UINT target_qubit_index, StateVector& state) {
             state._raw[i | (1ULL << target_qubit_index)] *= Complex(0, -1);
             Kokkos::Experimental::swap(state._raw[i], state._raw[i | (1ULL << target_qubit_index)]);
         });
+    Kokkos::fence();
 }
 
 void z_gate(UINT target_qubit_index, StateVector& state) {
@@ -32,6 +34,7 @@ void z_gate(UINT target_qubit_index, StateVector& state) {
             UINT i = internal::insert_zero_to_basis_index(it, target_qubit_index);
             state._raw[i | (1ULL << target_qubit_index)] *= Complex(-1, 0);
         });
+    Kokkos::fence();
 }
 
 void h_gate(UINT target_qubit_index, StateVector& state) {
@@ -43,6 +46,7 @@ void h_gate(UINT target_qubit_index, StateVector& state) {
             state._raw[i] = (a + b) * INVERSE_SQRT2();
             state._raw[i | (1ULL << target_qubit_index)] = (a - b) * INVERSE_SQRT2();
         });
+    Kokkos::fence();
 }
 
 void single_qubit_phase_gate(UINT target_qubit_index, Complex phase, StateVector& state) {
@@ -51,6 +55,7 @@ void single_qubit_phase_gate(UINT target_qubit_index, Complex phase, StateVector
             UINT i = internal::insert_zero_to_basis_index(it, target_qubit_index);
             state._raw[i | (1ULL << target_qubit_index)] *= phase;
         });
+    Kokkos::fence();
 }
 
 void s_gate(UINT target_qubit_index, StateVector& state) {
@@ -113,6 +118,7 @@ void single_qubit_diagonal_matrix_gate(UINT target_qubit_index,
     Kokkos::parallel_for(
         state.dim(),
         KOKKOS_LAMBDA(UINT it) { state._raw[it] *= diag.val[(it >> target_qubit_index) & 1]; });
+    Kokkos::fence();
 }
 
 void rz_gate(UINT target_qubit_index, double angle, StateVector& state) {

--- a/scaluq/gate/update_ops_pauli.cpp
+++ b/scaluq/gate/update_ops_pauli.cpp
@@ -31,6 +31,7 @@ void pauli_rotation_gate(const PauliOperator& pauli, double angle, StateVector& 
                 }
                 state._raw[state_idx] *= coef;
             });
+        Kokkos::fence();
         return;
     } else {
         const UINT insert_idx = internal::BitVector(bit_flip_mask_vector).msb();
@@ -58,6 +59,7 @@ void pauli_rotation_gate(const PauliOperator& pauli, double angle, StateVector& 
                 state._raw[basis_0] *= coef;
                 state._raw[basis_1] *= coef;
             });
+        Kokkos::fence();
     }
 }
 

--- a/scaluq/gate/update_ops_two_qubit.cpp
+++ b/scaluq/gate/update_ops_two_qubit.cpp
@@ -15,6 +15,7 @@ void swap_gate(UINT target0, UINT target1, StateVector& state) {
             Kokkos::Experimental::swap(state._raw[basis | (1ULL << target0)],
                                        state._raw[basis | (1ULL << target1)]);
         });
+    Kokkos::fence();
 }
 }  // namespace internal
 }  // namespace scaluq

--- a/scaluq/gate/update_ops_zero_qubit.cpp
+++ b/scaluq/gate/update_ops_zero_qubit.cpp
@@ -8,6 +8,7 @@ void global_phase_gate(double phase, StateVector& state) {
     Complex coef = Kokkos::polar(1., phase);
     Kokkos::parallel_for(
         state.dim(), KOKKOS_LAMBDA(UINT i) { state._raw[i] *= coef; });
+    Kokkos::fence();
 }
 }  // namespace internal
 }  // namespace scaluq

--- a/scaluq/operator/pauli_operator.cpp
+++ b/scaluq/operator/pauli_operator.cpp
@@ -125,6 +125,7 @@ void PauliOperator::apply_to_state(StateVector& state_vector) const {
                     state_vector._raw[state_idx] *= coef;
                 }
             });
+        Kokkos::fence();
         return;
     }
     UINT pivot = sizeof(UINT) * 8 - std::countl_zero(bit_flip_mask) - 1;
@@ -141,6 +142,7 @@ void PauliOperator::apply_to_state(StateVector& state_vector) const {
             state_vector._raw[basis_0] = tmp2 * coef;
             state_vector._raw[basis_1] = tmp1 * coef;
         });
+    Kokkos::fence();
 }
 
 Complex PauliOperator::get_expectation_value(const StateVector& state_vector) const {

--- a/scaluq/operator/pauli_operator.cpp
+++ b/scaluq/operator/pauli_operator.cpp
@@ -208,6 +208,7 @@ Complex PauliOperator::get_transition_amplitude(const StateVector& state_vector_
                 sum += tmp;
             },
             res);
+        Kokkos::fence();
         return _coef * res;
     }
     UINT pivot = sizeof(UINT) * 8 - std::countl_zero(bit_flip_mask) - 1;
@@ -228,6 +229,7 @@ Complex PauliOperator::get_transition_amplitude(const StateVector& state_vector_
             sum += tmp1 + tmp2;
         },
         res);
+    Kokkos::fence();
     return _coef * res;
 }
 

--- a/scaluq/state/state_vector.cpp
+++ b/scaluq/state/state_vector.cpp
@@ -161,16 +161,19 @@ double StateVector::get_entropy() const {
 void StateVector::add_state_vector(const StateVector& state) {
     Kokkos::parallel_for(
         this->_dim, KOKKOS_CLASS_LAMBDA(UINT i) { this->_raw[i] += state._raw[i]; });
+    Kokkos::fence();
 }
 
 void StateVector::add_state_vector_with_coef(const Complex& coef, const StateVector& state) {
     Kokkos::parallel_for(
         this->_dim, KOKKOS_CLASS_LAMBDA(UINT i) { this->_raw[i] += coef * state._raw[i]; });
+    Kokkos::fence();
 }
 
 void StateVector::multiply_coef(const Complex& coef) {
     Kokkos::parallel_for(
         this->_dim, KOKKOS_CLASS_LAMBDA(UINT i) { this->_raw[i] *= coef; });
+    Kokkos::fence();
 }
 
 std::vector<UINT> StateVector::sampling(UINT sampling_count, UINT seed) const {

--- a/scaluq/state/state_vector.cpp
+++ b/scaluq/state/state_vector.cpp
@@ -49,6 +49,7 @@ StateVector StateVector::Haar_random_state(UINT n_qubits, UINT seed) {
             state._raw[i] = Complex(rand_gen.normal(0.0, 1.0), rand_gen.normal(0.0, 1.0));
             rand_pool.free_state(rand_gen);
         });
+    Kokkos::fence();
     state.normalize();
     return state;
 }
@@ -74,6 +75,7 @@ void StateVector::normalize() {
     const auto norm = std::sqrt(this->get_squared_norm());
     Kokkos::parallel_for(
         this->_dim, KOKKOS_CLASS_LAMBDA(UINT it) { this->_raw[it] /= norm; });
+    Kokkos::fence();
 }
 
 double StateVector::get_zero_probability(UINT target_qubit_index) const {
@@ -198,6 +200,7 @@ std::vector<UINT> StateVector::sampling(UINT sampling_count, UINT seed) const {
             result[i] = lo;
             rand_pool.free_state(rand_gen);
         });
+    Kokkos::fence();
     return internal::convert_device_view_to_host_vector<UINT>(result);
 }
 


### PR DESCRIPTION
Kokkosではいくつか非同期な関数があるので、`Kokkos::fence`を入れて同期をとる必要がありましたが、いままで入れていなかった+テストも通っていたので見逃されていました。本PRで同期をとって安全にします。
ちなみに、（私が把握している）非同期な関数は以下の通りです。
- parallel_for
- parallel_reduce (reduce先がスカラーではないとき)
- deep_copy (実行スペースが明示されているとき)