### PR TITLE
Resolve Eigen warnings on CUDA environment

### DIFF
--- a/scaluq/gate/gate_pauli.hpp
+++ b/scaluq/gate/gate_pauli.hpp
@@ -49,8 +49,9 @@ public:
         ComplexMatrix mat = this->_pauli.get_matrix_ignoring_coef();
         Complex true_angle = _angle * _pauli.get_coef();
         StdComplex imag_unit(0, 1);
-        mat = Kokkos::cos(-true_angle / 2) * ComplexMatrix::Identity(mat.rows(), mat.cols()) +
-              imag_unit * Kokkos::sin(-true_angle / 2) * mat;
+        mat = (StdComplex)Kokkos::cos(-true_angle / 2) *
+                  ComplexMatrix::Identity(mat.rows(), mat.cols()) +
+              imag_unit * (StdComplex)Kokkos::sin(-true_angle / 2) * mat;
         return mat;
     }
     void update_quantum_state(StateVector& state_vector) const override {

--- a/scaluq/gate/param_gate_pauli.hpp
+++ b/scaluq/gate/param_gate_pauli.hpp
@@ -27,8 +27,9 @@ public:
         Complex true_angle = angle * this->_pauli.get_coef();
         ComplexMatrix mat = this->_pauli.get_matrix_ignoring_coef();
         StdComplex imag_unit(0, 1);
-        mat = Kokkos::cos(-true_angle / 2) * ComplexMatrix::Identity(mat.rows(), mat.cols()) +
-              imag_unit * Kokkos::sin(-true_angle / 2) * mat;
+        mat = (StdComplex)Kokkos::cos(-true_angle / 2) *
+                  ComplexMatrix::Identity(mat.rows(), mat.cols()) +
+              imag_unit * (StdComplex)Kokkos::sin(-true_angle / 2) * mat;
         return mat;
     }
     void update_quantum_state(StateVector& state_vector, double param) const override {

--- a/scaluq/operator/pauli_operator.cpp
+++ b/scaluq/operator/pauli_operator.cpp
@@ -262,7 +262,7 @@ Complex PauliOperator::get_transition_amplitude(const StateVector& state_vector_
     return mat;
 }
 [[nodiscard]] ComplexMatrix PauliOperator::get_matrix() const {
-    return get_matrix_ignoring_coef() * _ptr->_coef;
+    return get_matrix_ignoring_coef() * StdComplex(_ptr->_coef);
 }
 
 PauliOperator PauliOperator::operator*(const PauliOperator& target) const {


### PR DESCRIPTION
GPUでのビルドの際、今まで以下のような長いwarningが複数出ていた。`Kokkos::complex<double>`を正しくキャストできてないことが原因だった。
```
[20/53] Building CXX object CMakeFiles/scaluq.dir/scaluq/operator/pauli_operator.cpp.o
/workspaces/scaluq/build/_deps/eigen_fetch-src/Eigen/src/Core/../plugins/CommonCwiseBinaryOps.h(50): warning #20014-D: calling a __host__ function from a __host__ __device__ function is not allowed
  inline const CwiseBinaryOp<internal::scalar_product_op<typename internal::traits<Derived>::Scalar,typename internal::promote_scalar_arg<Scalar , T , (Eigen::internal::has_ReturnType<Eigen::ScalarBinaryOpTraits<Scalar,T,Eigen::internal::scalar_product_op<Scalar,T> > >::value)>::type>, const Derived, const typename internal::plain_constant_type<Derived,typename internal::promote_scalar_arg<Scalar , T , (Eigen::internal::has_ReturnType<Eigen::ScalarBinaryOpTraits<Scalar,T,Eigen::internal::scalar_product_op<Scalar,T> > >::value)>::type>::type> (operator*)(const T& scalar) const { typedef typename internal::promote_scalar_arg<Scalar,T,(Eigen::internal::has_ReturnType<Eigen::ScalarBinaryOpTraits<Scalar,T,Eigen::internal::scalar_product_op<Scalar,T> > >::value)>::type PromotedT; return CwiseBinaryOp<internal::scalar_product_op<typename internal::traits<Derived>::Scalar,PromotedT>, const Derived, const typename internal::plain_constant_type<Derived,PromotedT>::type>(derived(), typename internal::plain_constant_type<Derived,PromotedT>::type(derived().rows(), derived().cols(), internal::scalar_constant_op<PromotedT>(scalar))); }
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 ^
          detected during instantiation of "const Eigen::CwiseBinaryOp<Eigen::internal::scalar_product_op<Eigen::internal::traits<Derived>::Scalar, Eigen::internal::promote_scalar_arg<Eigen::MatrixBase<Derived>::Scalar, T, Eigen::internal::has_ReturnType<Eigen::ScalarBinaryOpTraits<Eigen::MatrixBase<Derived>::Scalar, T, Eigen::internal::scalar_product_op<Eigen::MatrixBase<Derived>::Scalar, T>>>::value>::type>, const Derived, const Eigen::internal::plain_constant_type<Derived, Eigen::internal::promote_scalar_arg<Eigen::MatrixBase<Derived>::Scalar, T, Eigen::internal::has_ReturnType<Eigen::ScalarBinaryOpTraits<Eigen::MatrixBase<Derived>::Scalar, T, Eigen::internal::scalar_product_op<Eigen::MatrixBase<Derived>::Scalar, T>>>::value>::type>::type> Eigen::MatrixBase<Derived>::operator*(const T &) const [with Derived=Eigen::Matrix<scaluq::StdComplex, -1, -1, 1, -1, -1>, T=scaluq::Complex]" at line 265 of /workspaces/scaluq/scaluq/operator/pauli_operator.cpp

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/workspaces/scaluq/build/_deps/eigen_fetch-src/Eigen/src/Core/../plugins/CommonCwiseBinaryOps.h(50): warning #20011-D: calling a __host__ function("Kokkos::complex<double> ::operator     ::std::complex<double> () const") from a __host__ __device__ function("Eigen::MatrixBase< ::Eigen::Matrix<    ::std::complex<double> , (int)-1, (int)-1, (int)1, (int)-1, (int)-1> > ::operator *< ::Kokkos::complex<double> >  const") is not allowed
```