### PR TITLE
定数をinternalにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ int main() {
         circuit.add_gate(scaluq::gate::X(0));
         circuit.add_gate(scaluq::gate::CNot(0, 1));
         circuit.add_gate(scaluq::gate::Y(1));
-        circuit.add_gate(scaluq::gate::RX(1, M_PI / 2));
+        circuit.add_gate(scaluq::gate::RX(1, std::numbers::pi / 2));
         circuit.update_quantum_state(state);
 
         scaluq::Operator observable(n_qubits);

--- a/exe/main.cpp
+++ b/exe/main.cpp
@@ -14,15 +14,7 @@ using namespace std;
 
 void run() {
     std::uint64_t n_qubits = 5;
-    Kokkos::parallel_for(
-        10, KOKKOS_LAMBDA(int i) {
-            Kokkos::printf("{%lf, %lf, %lf, %lf}\n",
-                           EXAMPLE(0).real(),
-                           EXAMPLE(1).real(),
-                           EXAMPLE(2).real(),
-                           EXAMPLE(3).real());
-            Kokkos::printf("%lf\n", INVERSE_SQRT2);
-        });
+    auto state = StateVector::Haar_random_state(n_qubits);
 }
 
 int main() {

--- a/exe/main.cpp
+++ b/exe/main.cpp
@@ -14,7 +14,15 @@ using namespace std;
 
 void run() {
     std::uint64_t n_qubits = 5;
-    auto state = StateVector::Haar_random_state(n_qubits);
+    Kokkos::parallel_for(
+        10, KOKKOS_LAMBDA(int i) {
+            Kokkos::printf("{%lf, %lf, %lf, %lf}\n",
+                           EXAMPLE(0).real(),
+                           EXAMPLE(1).real(),
+                           EXAMPLE(2).real(),
+                           EXAMPLE(3).real());
+            Kokkos::printf("%lf\n", INVERSE_SQRT2);
+        });
 }
 
 int main() {

--- a/scaluq/constant.hpp
+++ b/scaluq/constant.hpp
@@ -7,107 +7,90 @@
 
 namespace scaluq {
 
+namespace internal {
+
 #define DEF_MATH_CONSTANT(TRAIT, VALUE)                                                        \
     template <class T>                                                                         \
     inline constexpr auto TRAIT##_v = std::enable_if_t<std::is_floating_point_v<T>, T>(VALUE); \
     inline constexpr auto TRAIT = TRAIT##_v<double>
 
-#define DEFINE_ACCESSIBLE_ARRAY(NAME, TYPE, SIZE, ...)                 \
-    KOKKOS_INLINE_FUNCTION                                             \
-    Kokkos::Array<TYPE, SIZE> NAME##_ARRAY() { return {__VA_ARGS__}; } \
-    KOKKOS_INLINE_FUNCTION                                             \
-    TYPE NAME(std::size_t i) { return NAME##_ARRAY()[i]; }
-
-KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Complex, 4> EXAMPLE() { return {1.0, 2.0, 3.0, 4.0}; }
-
-//! PI value
-DEF_MATH_CONSTANT(PI, 3.141592653589793);
-
-//! square root of 2
-DEF_MATH_CONSTANT(SQRT2, 1.4142135623730950);
-
 //! inverse square root of 2
-DEF_MATH_CONSTANT(INVERSE_SQRT2, 0.7071067811865475);
+KOKKOS_INLINE_FUNCTION
+double INVERSE_SQRT2() { return Kokkos::numbers::sqrt2 / 2; }
 
 //! cosine pi/8
-DEF_MATH_CONSTANT(COSPI8, 0.923879532511287);
+KOKKOS_INLINE_FUNCTION
+double COSPI8() { return 0.923879532511287; }
 
 //! sine pi/8
-DEF_MATH_CONSTANT(SINPI8, 0.382683432365090);
+KOKKOS_INLINE_FUNCTION
+double SINPI8() { return 0.382683432365090; }
 
 //! identity matrix
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> I_GATE() { return {1, 0, 0, 1}; }
+Matrix2x2 I_GATE() { return {1, 0, 0, 1}; }
 //! Pauli matrix X
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> X_GATE() { return {0, 1, 1, 0}; }
+Matrix2x2 X_GATE() { return {0, 1, 1, 0}; }
 //! Pauli matrix Y
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> Y_GATE() {
-    return {0, Complex(0, -1), Complex(0, 1), 0};
-}
+Matrix2x2 Y_GATE() { return {0, Complex(0, -1), Complex(0, 1), 0}; }
 //! Pauli matrix Z
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> Z_GATE() { return {1, 0, 0, -1}; }
+Matrix2x2 Z_GATE() { return {1, 0, 0, -1}; }
 
 //! list of Pauli matrix I,X,Y,Z
-// std::array<Kokkos::Array<Kokkos::Array<Complex, 2>, 2>, 4> PAULI_MATRIX = {I_GATE, X_GATE,
+// std::array<Matrix2x2, 4> PAULI_MATRIX = {I_GATE, X_GATE,
 // Y_GATE, Z_GATE};
 
 //! S-gate
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> S_GATE_MATRIX() { return {1, 0, 0, Complex(0, 1)}; }
+Matrix2x2 S_GATE_MATRIX() { return {1, 0, 0, Complex(0, 1)}; }
 //! Sdag-gate
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> S_DAG_GATE_MATRIX() {
-    return {1, 0, 0, Complex(0, -1)};
-}
+Matrix2x2 S_DAG_GATE_MATRIX() { return {1, 0, 0, Complex(0, -1)}; }
 //! T-gate
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> T_GATE_MATRIX() {
-    return {COSPI8 - Complex(0, SINPI8), 0., 0., COSPI8 + Complex(0, SINPI8) * SINPI8};
-}
+Matrix2x2 T_GATE_MATRIX() { return {1, 0, 0, Complex(INVERSE_SQRT2(), INVERSE_SQRT2())}; }
 //! Tdag-gate
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> T_DAG_GATE_MATRIX() {
-    return {COSPI8 + Complex(0, SINPI8), 0., 0., COSPI8 - Complex(0, SINPI8)};
-}
+Matrix2x2 T_DAG_GATE_MATRIX() { return {1, 0, 0, Complex(INVERSE_SQRT2(), -INVERSE_SQRT2())}; }
 //! Hadamard gate
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> HADAMARD_MATRIX() {
-    return {0.7071067811865475, 0.7071067811865475, 0.7071067811865475, -0.7071067811865475};
+Matrix2x2 HADAMARD_MATRIX() {
+    return {INVERSE_SQRT2(), INVERSE_SQRT2(), INVERSE_SQRT2(), -INVERSE_SQRT2()};
 }
 //! square root of X gate
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> SQRT_X_GATE_MATRIX() {
+Matrix2x2 SQRT_X_GATE_MATRIX() {
     return {Complex(0.5, 0.5), Complex(0.5, -0.5), Complex(0.5, -0.5), Complex(0.5, 0.5)};
 }
 //! square root of Y gate
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> SQRT_Y_GATE_MATRIX() {
+Matrix2x2 SQRT_Y_GATE_MATRIX() {
     return {Complex(0.5, 0.5), Complex(-0.5, -0.5), Complex(0.5, 0.5), Complex(0.5, 0.5)};
 }
 //! square root dagger of X gate
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> SQRT_X_DAG_GATE_MATRIX() {
+Matrix2x2 SQRT_X_DAG_GATE_MATRIX() {
     return {Complex(0.5, -0.5), Complex(0.5, 0.5), Complex(0.5, 0.5), Complex(0.5, -0.5)};
 }
 //! square root dagger of Y gate
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> SQRT_Y_DAG_GATE_MATRIX() {
+Matrix2x2 SQRT_Y_DAG_GATE_MATRIX() {
     return {Complex(0.5, -0.5), Complex(0.5, -0.5), Complex(-0.5, 0.5), Complex(0.5, -0.5)};
 }
 //! Projection to 0
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> PROJ_0_MATRIX() { return {1, 0, 0, 0}; }
+Matrix2x2 PROJ_0_MATRIX() { return {1, 0, 0, 0}; }
 //! Projection to 1
 KOKKOS_INLINE_FUNCTION
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> PROJ_1_MATRIX() { return {0, 0, 0, 1}; }
+Matrix2x2 PROJ_1_MATRIX() { return {0, 0, 0, 1}; }
 //! complex values for exp(j * i*pi/4 )
 KOKKOS_INLINE_FUNCTION
 Kokkos::Array<Complex, 4> PHASE_90ROT() { return {1., Complex(0, 1), -1, Complex(0, -1)}; }
 //! complex values for exp(-j * i*pi/4 )
 KOKKOS_INLINE_FUNCTION
 Kokkos::Array<Complex, 4> PHASE_M90ROT() { return {1., Complex(0, -1), -1, Complex(0, 1)}; }
+}  // namespace internal
 }  // namespace scaluq

--- a/scaluq/constant.hpp
+++ b/scaluq/constant.hpp
@@ -12,6 +12,15 @@ namespace scaluq {
     inline constexpr auto TRAIT##_v = std::enable_if_t<std::is_floating_point_v<T>, T>(VALUE); \
     inline constexpr auto TRAIT = TRAIT##_v<double>
 
+#define DEFINE_ACCESSIBLE_ARRAY(NAME, TYPE, SIZE, ...)                 \
+    KOKKOS_INLINE_FUNCTION                                             \
+    Kokkos::Array<TYPE, SIZE> NAME##_ARRAY() { return {__VA_ARGS__}; } \
+    KOKKOS_INLINE_FUNCTION                                             \
+    TYPE NAME(std::size_t i) { return NAME##_ARRAY()[i]; }
+
+KOKKOS_INLINE_FUNCTION
+Kokkos::Array<Complex, 4> EXAMPLE() { return {1.0, 2.0, 3.0, 4.0}; }
+
 //! PI value
 DEF_MATH_CONSTANT(PI, 3.141592653589793);
 
@@ -29,71 +38,76 @@ DEF_MATH_CONSTANT(SINPI8, 0.382683432365090);
 
 //! identity matrix
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 I_GATE() { return {1, 0, 0, 1}; }
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> I_GATE() { return {1, 0, 0, 1}; }
 //! Pauli matrix X
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 X_GATE() { return {0, 1, 1, 0}; }
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> X_GATE() { return {0, 1, 1, 0}; }
 //! Pauli matrix Y
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 Y_GATE() { return {0, Complex(0, -1), Complex(0, 1), 0}; }
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> Y_GATE() {
+    return {0, Complex(0, -1), Complex(0, 1), 0};
+}
 //! Pauli matrix Z
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 Z_GATE() { return {1, 0, 0, -1}; }
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> Z_GATE() { return {1, 0, 0, -1}; }
 
 //! list of Pauli matrix I,X,Y,Z
-// std::array<matrix_2_2, 4> PAULI_MATRIX = {I_GATE, X_GATE, Y_GATE, Z_GATE};
+// std::array<Kokkos::Array<Kokkos::Array<Complex, 2>, 2>, 4> PAULI_MATRIX = {I_GATE, X_GATE,
+// Y_GATE, Z_GATE};
 
 //! S-gate
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 S_GATE_MATRIX() { return {1, 0, 0, Complex(0, 1)}; }
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> S_GATE_MATRIX() { return {1, 0, 0, Complex(0, 1)}; }
 //! Sdag-gate
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 S_DAG_GATE_MATRIX() { return {1, 0, 0, Complex(0, -1)}; }
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> S_DAG_GATE_MATRIX() {
+    return {1, 0, 0, Complex(0, -1)};
+}
 //! T-gate
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 T_GATE_MATRIX() {
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> T_GATE_MATRIX() {
     return {COSPI8 - Complex(0, SINPI8), 0., 0., COSPI8 + Complex(0, SINPI8) * SINPI8};
 }
 //! Tdag-gate
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 T_DAG_GATE_MATRIX() {
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> T_DAG_GATE_MATRIX() {
     return {COSPI8 + Complex(0, SINPI8), 0., 0., COSPI8 - Complex(0, SINPI8)};
 }
 //! Hadamard gate
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 HADAMARD_MATRIX() {
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> HADAMARD_MATRIX() {
     return {0.7071067811865475, 0.7071067811865475, 0.7071067811865475, -0.7071067811865475};
 }
 //! square root of X gate
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 SQRT_X_GATE_MATRIX() {
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> SQRT_X_GATE_MATRIX() {
     return {Complex(0.5, 0.5), Complex(0.5, -0.5), Complex(0.5, -0.5), Complex(0.5, 0.5)};
 }
 //! square root of Y gate
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 SQRT_Y_GATE_MATRIX() {
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> SQRT_Y_GATE_MATRIX() {
     return {Complex(0.5, 0.5), Complex(-0.5, -0.5), Complex(0.5, 0.5), Complex(0.5, 0.5)};
 }
 //! square root dagger of X gate
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 SQRT_X_DAG_GATE_MATRIX() {
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> SQRT_X_DAG_GATE_MATRIX() {
     return {Complex(0.5, -0.5), Complex(0.5, 0.5), Complex(0.5, 0.5), Complex(0.5, -0.5)};
 }
 //! square root dagger of Y gate
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 SQRT_Y_DAG_GATE_MATRIX() {
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> SQRT_Y_DAG_GATE_MATRIX() {
     return {Complex(0.5, -0.5), Complex(0.5, -0.5), Complex(-0.5, 0.5), Complex(0.5, -0.5)};
 }
 //! Projection to 0
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 PROJ_0_MATRIX() { return {1, 0, 0, 0}; }
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> PROJ_0_MATRIX() { return {1, 0, 0, 0}; }
 //! Projection to 1
 KOKKOS_INLINE_FUNCTION
-matrix_2_2 PROJ_1_MATRIX() { return {0, 0, 0, 1}; }
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> PROJ_1_MATRIX() { return {0, 0, 0, 1}; }
 //! complex values for exp(j * i*pi/4 )
 KOKKOS_INLINE_FUNCTION
-array_4 PHASE_90ROT() { return {1., Complex(0, 1), -1, Complex(0, -1)}; }
+Kokkos::Array<Complex, 4> PHASE_90ROT() { return {1., Complex(0, 1), -1, Complex(0, -1)}; }
 //! complex values for exp(-j * i*pi/4 )
 KOKKOS_INLINE_FUNCTION
-array_4 PHASE_M90ROT() { return {1., Complex(0, -1), -1, Complex(0, 1)}; }
+Kokkos::Array<Complex, 4> PHASE_M90ROT() { return {1., Complex(0, -1), -1, Complex(0, 1)}; }
 }  // namespace scaluq

--- a/scaluq/constant.hpp
+++ b/scaluq/constant.hpp
@@ -6,25 +6,26 @@
 #include "types.hpp"
 
 namespace scaluq {
+
+#define DEF_MATH_CONSTANT(TRAIT, VALUE)                                                        \
+    template <class T>                                                                         \
+    inline constexpr auto TRAIT##_v = std::enable_if_t<std::is_floating_point_v<T>, T>(VALUE); \
+    inline constexpr auto TRAIT = TRAIT##_v<double>
+
 //! PI value
-KOKKOS_INLINE_FUNCTION
-double PI() { return 3.141592653589793; }
+DEF_MATH_CONSTANT(PI, 3.141592653589793);
 
 //! square root of 2
-KOKKOS_INLINE_FUNCTION
-double SQRT2() { return 1.4142135623730950; }
+DEF_MATH_CONSTANT(SQRT2, 1.4142135623730950);
 
 //! inverse square root of 2
-KOKKOS_INLINE_FUNCTION
-double INVERSE_SQRT2() { return 0.707106781186547; }
+DEF_MATH_CONSTANT(INVERSE_SQRT2, 0.7071067811865475);
 
 //! cosine pi/8
-KOKKOS_INLINE_FUNCTION
-double COSPI8() { return 0.923879532511287; }
+DEF_MATH_CONSTANT(COSPI8, 0.923879532511287);
 
 //! sine pi/8
-KOKKOS_INLINE_FUNCTION
-double SINPI8() { return 0.382683432365090; }
+DEF_MATH_CONSTANT(SINPI8, 0.382683432365090);
 
 //! identity matrix
 KOKKOS_INLINE_FUNCTION
@@ -51,17 +52,17 @@ matrix_2_2 S_DAG_GATE_MATRIX() { return {1, 0, 0, Complex(0, -1)}; }
 //! T-gate
 KOKKOS_INLINE_FUNCTION
 matrix_2_2 T_GATE_MATRIX() {
-    return {COSPI8() - Complex(0, SINPI8()), 0., 0., COSPI8() + Complex(0, SINPI8()) * SINPI8()};
+    return {COSPI8 - Complex(0, SINPI8), 0., 0., COSPI8 + Complex(0, SINPI8) * SINPI8};
 }
 //! Tdag-gate
 KOKKOS_INLINE_FUNCTION
 matrix_2_2 T_DAG_GATE_MATRIX() {
-    return {COSPI8() + Complex(0, SINPI8()), 0., 0., COSPI8() - Complex(0, SINPI8())};
+    return {COSPI8 + Complex(0, SINPI8), 0., 0., COSPI8 - Complex(0, SINPI8)};
 }
 //! Hadamard gate
 KOKKOS_INLINE_FUNCTION
 matrix_2_2 HADAMARD_MATRIX() {
-    return {INVERSE_SQRT2(), INVERSE_SQRT2(), INVERSE_SQRT2(), -INVERSE_SQRT2()};
+    return {0.7071067811865475, 0.7071067811865475, 0.7071067811865475, -0.7071067811865475};
 }
 //! square root of X gate
 KOKKOS_INLINE_FUNCTION

--- a/scaluq/gate/gate.hpp
+++ b/scaluq/gate/gate.hpp
@@ -164,7 +164,7 @@ public:
     }
 
     [[nodiscard]] virtual Gate get_inverse() const = 0;
-    [[nodiscard]] virtual ComplexMatrix get_matrix() const = 0;
+    [[nodiscard]] virtual internal::ComplexMatrix get_matrix() const = 0;
 
     virtual void update_quantum_state(StateVector& state_vector) const = 0;
 };

--- a/scaluq/gate/gate_factory.hpp
+++ b/scaluq/gate/gate_factory.hpp
@@ -163,17 +163,15 @@ inline Gate PauliRotation(const PauliOperator& pauli,
         internal::vector_to_mask(controls), pauli, angle);
 }
 inline Gate DenseMatrix(const std::vector<std::uint64_t>& targets,
-                        const ComplexMatrix& matrix,
+                        const internal::ComplexMatrix& matrix,
                         const std::vector<std::uint64_t>& controls = {}) {
     std::uint64_t nqubits = targets.size();
     std::uint64_t dim = 1ULL << nqubits;
     if (static_cast<std::uint64_t>(matrix.rows()) != dim ||
         static_cast<std::uint64_t>(matrix.cols()) != dim) {
         throw std::runtime_error(
-            "gate::DenseMatrix(const std::vector<std::uint64_t>&, const ComplexMatrix&): matrix "
-            "size "
-            "must "
-            "be 2^{n_qubits} x 2^{n_qubits}.");
+            "gate::DenseMatrix(const std::vector<std::uint64_t>&, const internal::ComplexMatrix&): "
+            "matrix size must be 2^{n_qubits} x 2^{n_qubits}.");
     }
     if (targets.size() == 0) return I();
     if (targets.size() == 1) {
@@ -204,7 +202,8 @@ inline Gate DenseMatrix(const std::vector<std::uint64_t>& targets,
                                controls);
     }
     throw std::runtime_error(
-        "gate::DenseMatrix(const std::vector<std::uint64_t>&, const ComplexMatrix&): DenseMatrix "
+        "gate::DenseMatrix(const std::vector<std::uint64_t>&, const internal::ComplexMatrix&): "
+        "DenseMatrix "
         "gate "
         "more "
         "than two qubits is not implemented yet.");

--- a/scaluq/gate/gate_matrix.hpp
+++ b/scaluq/gate/gate_matrix.hpp
@@ -11,7 +11,7 @@
 namespace scaluq {
 namespace internal {
 class OneTargetMatrixGateImpl : public GateBase {
-    Kokkos::Array<Kokkos::Array<Complex, 2>, 2> _matrix;
+    Matrix2x2 _matrix;
 
 public:
     OneTargetMatrixGateImpl(std::uint64_t target_mask,
@@ -50,7 +50,7 @@ public:
 };
 
 class TwoTargetMatrixGateImpl : public GateBase {
-    Kokkos::Array<Kokkos::Array<Complex, 4>, 4> _matrix;
+    Matrix4x4 _matrix;
 
 public:
     TwoTargetMatrixGateImpl(std::uint64_t target_mask,

--- a/scaluq/gate/gate_matrix.hpp
+++ b/scaluq/gate/gate_matrix.hpp
@@ -11,36 +11,35 @@
 namespace scaluq {
 namespace internal {
 class OneTargetMatrixGateImpl : public GateBase {
-    matrix_2_2 _matrix;
+    Kokkos::Array<Kokkos::Array<Complex, 2>, 2> _matrix;
 
 public:
     OneTargetMatrixGateImpl(std::uint64_t target_mask,
                             std::uint64_t control_mask,
                             const std::array<std::array<Complex, 2>, 2>& matrix)
         : GateBase(target_mask, control_mask) {
-        _matrix.val[0][0] = matrix[0][0];
-        _matrix.val[0][1] = matrix[0][1];
-        _matrix.val[1][0] = matrix[1][0];
-        _matrix.val[1][1] = matrix[1][1];
+        _matrix[0][0] = matrix[0][0];
+        _matrix[0][1] = matrix[0][1];
+        _matrix[1][0] = matrix[1][0];
+        _matrix[1][1] = matrix[1][1];
     }
 
     std::array<std::array<Complex, 2>, 2> matrix() const {
-        return {_matrix.val[0][0], _matrix.val[0][1], _matrix.val[1][0], _matrix.val[1][1]};
+        return {_matrix[0][0], _matrix[0][1], _matrix[1][0], _matrix[1][1]};
     }
 
     Gate get_inverse() const override {
         return std::make_shared<const OneTargetMatrixGateImpl>(
             _target_mask,
             _control_mask,
-            std::array<std::array<Complex, 2>, 2>{Kokkos::conj(_matrix.val[0][0]),
-                                                  Kokkos::conj(_matrix.val[1][0]),
-                                                  Kokkos::conj(_matrix.val[0][1]),
-                                                  Kokkos::conj(_matrix.val[1][1])});
+            std::array<std::array<Complex, 2>, 2>{Kokkos::conj(_matrix[0][0]),
+                                                  Kokkos::conj(_matrix[1][0]),
+                                                  Kokkos::conj(_matrix[0][1]),
+                                                  Kokkos::conj(_matrix[1][1])});
     }
     ComplexMatrix get_matrix() const override {
         ComplexMatrix mat(2, 2);
-        mat << this->_matrix.val[0][0], this->_matrix.val[0][1], this->_matrix.val[1][0],
-            this->_matrix.val[1][1];
+        mat << this->_matrix[0][0], this->_matrix[0][1], this->_matrix[1][0], this->_matrix[1][1];
         return mat;
     }
 
@@ -51,7 +50,7 @@ public:
 };
 
 class TwoTargetMatrixGateImpl : public GateBase {
-    matrix_4_4 _matrix;
+    Kokkos::Array<Kokkos::Array<Complex, 4>, 4> _matrix;
 
 public:
     TwoTargetMatrixGateImpl(std::uint64_t target_mask,
@@ -60,7 +59,7 @@ public:
         : GateBase(target_mask, control_mask) {
         for (std::uint64_t i : std::views::iota(0, 4)) {
             for (std::uint64_t j : std::views::iota(0, 4)) {
-                _matrix.val[i][j] = matrix[i][j];
+                _matrix[i][j] = matrix[i][j];
             }
         }
     }
@@ -69,7 +68,7 @@ public:
         std::array<std::array<Complex, 4>, 4> matrix;
         for (std::uint64_t i : std::views::iota(0, 4)) {
             for (std::uint64_t j : std::views::iota(0, 4)) {
-                matrix[i][j] = _matrix.val[i][j];
+                matrix[i][j] = _matrix[i][j];
             }
         }
         return matrix;
@@ -79,7 +78,7 @@ public:
         std::array<std::array<Complex, 4>, 4> matrix_dag;
         for (std::uint64_t i : std::views::iota(0, 4)) {
             for (std::uint64_t j : std::views::iota(0, 4)) {
-                matrix_dag[i][j] = Kokkos::conj(_matrix.val[j][i]);
+                matrix_dag[i][j] = Kokkos::conj(_matrix[j][i]);
             }
         }
         return std::make_shared<const TwoTargetMatrixGateImpl>(
@@ -87,12 +86,10 @@ public:
     }
     ComplexMatrix get_matrix() const override {
         ComplexMatrix mat(4, 4);
-        mat << this->_matrix.val[0][0], this->_matrix.val[0][1], this->_matrix.val[0][2],
-            this->_matrix.val[0][3], this->_matrix.val[1][0], this->_matrix.val[1][1],
-            this->_matrix.val[1][2], this->_matrix.val[1][3], this->_matrix.val[2][0],
-            this->_matrix.val[2][1], this->_matrix.val[2][2], this->_matrix.val[2][3],
-            this->_matrix.val[3][0], this->_matrix.val[3][1], this->_matrix.val[3][2],
-            this->_matrix.val[3][3];
+        mat << this->_matrix[0][0], this->_matrix[0][1], this->_matrix[0][2], this->_matrix[0][3],
+            this->_matrix[1][0], this->_matrix[1][1], this->_matrix[1][2], this->_matrix[1][3],
+            this->_matrix[2][0], this->_matrix[2][1], this->_matrix[2][2], this->_matrix[2][3],
+            this->_matrix[3][0], this->_matrix[3][1], this->_matrix[3][2], this->_matrix[3][3];
         return mat;
     }
 

--- a/scaluq/gate/gate_matrix.hpp
+++ b/scaluq/gate/gate_matrix.hpp
@@ -37,8 +37,8 @@ public:
                                                   Kokkos::conj(_matrix[0][1]),
                                                   Kokkos::conj(_matrix[1][1])});
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << this->_matrix[0][0], this->_matrix[0][1], this->_matrix[1][0], this->_matrix[1][1];
         return mat;
     }
@@ -84,8 +84,8 @@ public:
         return std::make_shared<const TwoTargetMatrixGateImpl>(
             _target_mask, _control_mask, matrix_dag);
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(4, 4);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(4, 4);
         mat << this->_matrix[0][0], this->_matrix[0][1], this->_matrix[0][2], this->_matrix[0][3],
             this->_matrix[1][0], this->_matrix[1][1], this->_matrix[1][2], this->_matrix[1][3],
             this->_matrix[2][0], this->_matrix[2][1], this->_matrix[2][2], this->_matrix[2][3],

--- a/scaluq/gate/gate_pauli.hpp
+++ b/scaluq/gate/gate_pauli.hpp
@@ -20,7 +20,7 @@ public:
     std::vector<std::uint64_t> get_pauli_id_list() const { return _pauli.get_pauli_id_list(); }
 
     Gate get_inverse() const override { return shared_from_this(); }
-    ComplexMatrix get_matrix() const override { return this->_pauli.get_matrix(); }
+    internal::ComplexMatrix get_matrix() const override { return this->_pauli.get_matrix(); }
 
     void update_quantum_state(StateVector& state_vector) const override {
         pauli_gate(_control_mask, _pauli, state_vector);
@@ -45,12 +45,12 @@ public:
         return std::make_shared<const PauliRotationGateImpl>(_control_mask, _pauli, -_angle);
     }
 
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat = this->_pauli.get_matrix_ignoring_coef();
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat = this->_pauli.get_matrix_ignoring_coef();
         Complex true_angle = _angle * _pauli.get_coef();
         StdComplex imag_unit(0, 1);
         mat = (StdComplex)Kokkos::cos(-true_angle / 2) *
-                  ComplexMatrix::Identity(mat.rows(), mat.cols()) +
+                  internal::ComplexMatrix::Identity(mat.rows(), mat.cols()) +
               imag_unit * (StdComplex)Kokkos::sin(-true_angle / 2) * mat;
         return mat;
     }

--- a/scaluq/gate/gate_probablistic.hpp
+++ b/scaluq/gate/gate_probablistic.hpp
@@ -70,7 +70,7 @@ public:
         });
         return std::make_shared<const ProbablisticGateImpl>(_distribution, inv_gate_list);
     }
-    ComplexMatrix get_matrix() const override {
+    internal::ComplexMatrix get_matrix() const override {
         throw std::runtime_error(
             "ProbablisticGateImpl::get_matrix(): This function must not be used in "
             "ProbablisticGateImpl.");

--- a/scaluq/gate/gate_standard.hpp
+++ b/scaluq/gate/gate_standard.hpp
@@ -11,7 +11,9 @@ public:
     IGateImpl() : GateBase(0, 0) {}
 
     Gate get_inverse() const override { return shared_from_this(); }
-    ComplexMatrix get_matrix() const override { return ComplexMatrix::Identity(1, 1); }
+    internal::ComplexMatrix get_matrix() const override {
+        return internal::ComplexMatrix::Identity(1, 1);
+    }
 
     void update_quantum_state(StateVector& state_vector) const override {
         i_gate(_target_mask, _control_mask, state_vector);
@@ -31,8 +33,8 @@ public:
     Gate get_inverse() const override {
         return std::make_shared<const GlobalPhaseGateImpl>(_control_mask, -_phase);
     }
-    ComplexMatrix get_matrix() const override {
-        return ComplexMatrix::Identity(1, 1) * std::exp(std::complex<double>(0, _phase));
+    internal::ComplexMatrix get_matrix() const override {
+        return internal::ComplexMatrix::Identity(1, 1) * std::exp(std::complex<double>(0, _phase));
     }
 
     void update_quantum_state(StateVector& state_vector) const override {
@@ -57,8 +59,8 @@ public:
     using GateBase::GateBase;
 
     Gate get_inverse() const override { return shared_from_this(); }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 0, 1, 1, 0;
         return mat;
     }
@@ -74,8 +76,8 @@ public:
     using GateBase::GateBase;
 
     Gate get_inverse() const override { return shared_from_this(); }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 0, -1i, 1i, 0;
         return mat;
     }
@@ -91,8 +93,8 @@ public:
     using GateBase::GateBase;
 
     Gate get_inverse() const override { return shared_from_this(); }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 1, 0, 0, -1;
         return mat;
     }
@@ -108,8 +110,8 @@ public:
     using GateBase::GateBase;
 
     Gate get_inverse() const override { return shared_from_this(); }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 1, 1, 1, -1;
         mat /= std::sqrt(2);
         return mat;
@@ -135,8 +137,8 @@ public:
     using GateBase::GateBase;
 
     Gate get_inverse() const override;
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 1, 0, 0, 1i;
         return mat;
     }
@@ -154,8 +156,8 @@ public:
     Gate get_inverse() const override {
         return std::make_shared<const SGateImpl>(_target_mask, _control_mask);
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 1, 0, 0, -1i;
         return mat;
     }
@@ -175,8 +177,8 @@ public:
     using GateBase::GateBase;
 
     Gate get_inverse() const override;
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 1, 0, 0, (1. + 1i) / std::sqrt(2);
         return mat;
     }
@@ -194,8 +196,8 @@ public:
     Gate get_inverse() const override {
         return std::make_shared<const TGateImpl>(_target_mask, _control_mask);
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 1, 0, 0, (1. - 1.i) / std::sqrt(2);
         return mat;
     }
@@ -215,8 +217,8 @@ public:
     using GateBase::GateBase;
 
     Gate get_inverse() const override;
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 0.5 + 0.5i, 0.5 - 0.5i, 0.5 - 0.5i, 0.5 + 0.5i;
         return mat;
     }
@@ -234,8 +236,8 @@ public:
     Gate get_inverse() const override {
         return std::make_shared<const SqrtXGateImpl>(_target_mask, _control_mask);
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 0.5 - 0.5i, 0.5 + 0.5i, 0.5 + 0.5i, 0.5 - 0.5i;
         return mat;
     }
@@ -255,8 +257,8 @@ public:
     using GateBase::GateBase;
 
     Gate get_inverse() const override;
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 0.5 + 0.5i, -0.5 - 0.5i, 0.5 + 0.5i, 0.5 + 0.5i;
         return mat;
     }
@@ -274,8 +276,8 @@ public:
     Gate get_inverse() const override {
         return std::make_shared<const SqrtYGateImpl>(_target_mask, _control_mask);
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 0.5 - 0.5i, 0.5 - 0.5i, -0.5 + 0.5i, 0.5 - 0.5i;
         return mat;
     }
@@ -297,8 +299,8 @@ public:
     Gate get_inverse() const override {
         throw std::runtime_error("P0::get_inverse: Projection gate doesn't have inverse gate");
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 1, 0, 0, 0;
         return mat;
     }
@@ -316,8 +318,8 @@ public:
     Gate get_inverse() const override {
         throw std::runtime_error("P1::get_inverse: Projection gate doesn't have inverse gate");
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 0, 0, 0, 1;
         return mat;
     }
@@ -335,8 +337,8 @@ public:
     Gate get_inverse() const override {
         return std::make_shared<const RXGateImpl>(_target_mask, _control_mask, -_angle);
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << std::cos(_angle / 2), -1i * std::sin(_angle / 2), -1i * std::sin(_angle / 2),
             std::cos(_angle / 2);
         return mat;
@@ -355,8 +357,8 @@ public:
     Gate get_inverse() const override {
         return std::make_shared<const RYGateImpl>(_target_mask, _control_mask, -_angle);
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << std::cos(_angle / 2), -std::sin(_angle / 2), std::sin(_angle / 2),
             std::cos(_angle / 2);
         return mat;
@@ -375,8 +377,8 @@ public:
     Gate get_inverse() const override {
         return std::make_shared<const RZGateImpl>(_target_mask, _control_mask, -_angle);
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << std::exp(-0.5i * _angle), 0, 0, std::exp(0.5i * _angle);
         return mat;
     }
@@ -399,8 +401,8 @@ public:
     Gate get_inverse() const override {
         return std::make_shared<const U1GateImpl>(_target_mask, _control_mask, -_lambda);
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << 1, 0, 0, std::exp(1i * _lambda);
         return mat;
     }
@@ -426,8 +428,8 @@ public:
                                                   -_lambda - Kokkos::numbers::pi,
                                                   -_phi + Kokkos::numbers::pi);
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << std::cos(Kokkos::numbers::pi / 4.),
             -std::exp(1i * _lambda) * std::sin(Kokkos::numbers::pi / 4.),
             std::exp(1i * _phi) * std::sin(Kokkos::numbers::pi / 4.),
@@ -460,8 +462,8 @@ public:
         return std::make_shared<const U3GateImpl>(
             _target_mask, _control_mask, -_theta, -_lambda, -_phi);
     }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat(2, 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat(2, 2);
         mat << std::cos(_theta / 2.), -std::exp(1i * _lambda) * std::sin(_theta / 2.),
             std::exp(1i * _phi) * std::sin(_theta / 2.),
             std::exp(1i * _phi) * std::exp(1i * _lambda) * std::cos(_theta / 2.);
@@ -479,8 +481,8 @@ public:
     using GateBase::GateBase;
 
     Gate get_inverse() const override { return shared_from_this(); }
-    ComplexMatrix get_matrix() const override {
-        ComplexMatrix mat = ComplexMatrix::Identity(1 << 2, 1 << 2);
+    internal::ComplexMatrix get_matrix() const override {
+        internal::ComplexMatrix mat = internal::ComplexMatrix::Identity(1 << 2, 1 << 2);
         mat << 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1;
         return mat;
     }

--- a/scaluq/gate/gate_standard.hpp
+++ b/scaluq/gate/gate_standard.hpp
@@ -422,13 +422,13 @@ public:
 
     Gate get_inverse() const override {
         return std::make_shared<const U2GateImpl>(
-            _target_mask, _control_mask, -_lambda - PI(), -_phi + PI());
+            _target_mask, _control_mask, -_lambda - PI, -_phi + PI);
     }
     ComplexMatrix get_matrix() const override {
         ComplexMatrix mat(2, 2);
-        mat << std::cos(PI() / 4.), -std::exp(1i * _lambda) * std::sin(PI() / 4.),
-            std::exp(1i * _phi) * std::sin(PI() / 4.),
-            std::exp(1i * _phi) * std::exp(1i * _lambda) * std::cos(PI() / 4.);
+        mat << std::cos(PI / 4.), -std::exp(1i * _lambda) * std::sin(PI / 4.),
+            std::exp(1i * _phi) * std::sin(PI / 4.),
+            std::exp(1i * _phi) * std::exp(1i * _lambda) * std::cos(PI / 4.);
         return mat;
     }
 

--- a/scaluq/gate/gate_standard.hpp
+++ b/scaluq/gate/gate_standard.hpp
@@ -421,14 +421,17 @@ public:
     double lambda() const { return _lambda; }
 
     Gate get_inverse() const override {
-        return std::make_shared<const U2GateImpl>(
-            _target_mask, _control_mask, -_lambda - PI, -_phi + PI);
+        return std::make_shared<const U2GateImpl>(_target_mask,
+                                                  _control_mask,
+                                                  -_lambda - Kokkos::numbers::pi,
+                                                  -_phi + Kokkos::numbers::pi);
     }
     ComplexMatrix get_matrix() const override {
         ComplexMatrix mat(2, 2);
-        mat << std::cos(PI / 4.), -std::exp(1i * _lambda) * std::sin(PI / 4.),
-            std::exp(1i * _phi) * std::sin(PI / 4.),
-            std::exp(1i * _phi) * std::exp(1i * _lambda) * std::cos(PI / 4.);
+        mat << std::cos(Kokkos::numbers::pi / 4.),
+            -std::exp(1i * _lambda) * std::sin(Kokkos::numbers::pi / 4.),
+            std::exp(1i * _phi) * std::sin(Kokkos::numbers::pi / 4.),
+            std::exp(1i * _phi) * std::exp(1i * _lambda) * std::cos(Kokkos::numbers::pi / 4.);
         return mat;
     }
 

--- a/scaluq/gate/merge_gate.cpp
+++ b/scaluq/gate/merge_gate.cpp
@@ -37,16 +37,16 @@ std::pair<Gate, double> merge_gate(const Gate& gate1, const Gate& gate2) {
         if (target1 == target2) {
             if (pauli_id1 == pauli_id2) return {gate::I(), 0.};
             if (pauli_id1 == 1) {
-                if (pauli_id2 == 2) return {gate::Z(target1), -PI() / 2};
-                if (pauli_id2 == 3) return {gate::Y(target1), PI() / 2};
+                if (pauli_id2 == 2) return {gate::Z(target1), -PI / 2};
+                if (pauli_id2 == 3) return {gate::Y(target1), PI / 2};
             }
             if (pauli_id1 == 2) {
-                if (pauli_id2 == 3) return {gate::X(target1), -PI() / 2};
-                if (pauli_id2 == 1) return {gate::Z(target1), PI() / 2};
+                if (pauli_id2 == 3) return {gate::X(target1), -PI / 2};
+                if (pauli_id2 == 1) return {gate::Z(target1), PI / 2};
             }
             if (pauli_id1 == 3) {
-                if (pauli_id2 == 1) return {gate::Y(target1), -PI() / 2};
-                if (pauli_id2 == 2) return {gate::X(target1), PI() / 2};
+                if (pauli_id2 == 1) return {gate::Y(target1), -PI / 2};
+                if (pauli_id2 == 2) return {gate::X(target1), PI / 2};
             }
         }
     }
@@ -99,11 +99,11 @@ std::pair<Gate, double> merge_gate(const Gate& gate1, const Gate& gate2) {
         std::uint64_t target1 = gate1->get_target_qubit_list()[0];
         std::uint64_t target2 = gate2->get_target_qubit_list()[0];
         if (target1 == target2) {
-            double phase1 = oct_phase1                   ? oct_phase1.value() * PI() / 4
+            double phase1 = oct_phase1                   ? oct_phase1.value() * PI / 4
                             : gate_type1 == GateType::RZ ? RZGate(gate1)->angle()
                                                          : U1Gate(gate1)->lambda();
             double global_phase1 = gate_type1 == GateType::RZ ? -RZGate(gate1)->angle() / 2 : 0.;
-            double phase2 = oct_phase2                   ? oct_phase2.value() * PI() / 4
+            double phase2 = oct_phase2                   ? oct_phase2.value() * PI / 4
                             : gate_type2 == GateType::RZ ? RZGate(gate2)->angle()
                                                          : U1Gate(gate2)->lambda();
             double global_phase2 = gate_type2 == GateType::RZ ? -RZGate(gate2)->angle() / 2 : 0.;
@@ -114,9 +114,9 @@ std::pair<Gate, double> merge_gate(const Gate& gate1, const Gate& gate2) {
     // Special case: RX
     auto get_rx_angle = [&](Gate gate, GateType gate_type) -> std::optional<double> {
         if (gate_type == GateType::I) return 0.;
-        if (gate_type == GateType::X) return PI();
-        if (gate_type == GateType::SqrtX) return PI() / 2;
-        if (gate_type == GateType::SqrtXdag) return -PI() / 2;
+        if (gate_type == GateType::X) return PI;
+        if (gate_type == GateType::SqrtX) return PI / 2;
+        if (gate_type == GateType::SqrtXdag) return -PI / 2;
         if (gate_type == GateType::RX) return RXGate(gate)->angle();
         return std::nullopt;
     };
@@ -136,9 +136,9 @@ std::pair<Gate, double> merge_gate(const Gate& gate1, const Gate& gate2) {
     // Special case: RY
     auto get_ry_angle = [&](Gate gate, GateType gate_type) -> std::optional<double> {
         if (gate_type == GateType::I) return 0.;
-        if (gate_type == GateType::Y) return PI();
-        if (gate_type == GateType::SqrtY) return PI() / 2;
-        if (gate_type == GateType::SqrtYdag) return -PI() / 2;
+        if (gate_type == GateType::Y) return PI;
+        if (gate_type == GateType::SqrtY) return PI / 2;
+        if (gate_type == GateType::SqrtYdag) return -PI / 2;
         if (gate_type == GateType::RY) return RYGate(gate)->angle();
         return std::nullopt;
     };

--- a/scaluq/gate/merge_gate.cpp
+++ b/scaluq/gate/merge_gate.cpp
@@ -37,16 +37,16 @@ std::pair<Gate, double> merge_gate(const Gate& gate1, const Gate& gate2) {
         if (target1 == target2) {
             if (pauli_id1 == pauli_id2) return {gate::I(), 0.};
             if (pauli_id1 == 1) {
-                if (pauli_id2 == 2) return {gate::Z(target1), -PI / 2};
-                if (pauli_id2 == 3) return {gate::Y(target1), PI / 2};
+                if (pauli_id2 == 2) return {gate::Z(target1), -Kokkos::numbers::pi / 2};
+                if (pauli_id2 == 3) return {gate::Y(target1), Kokkos::numbers::pi / 2};
             }
             if (pauli_id1 == 2) {
-                if (pauli_id2 == 3) return {gate::X(target1), -PI / 2};
-                if (pauli_id2 == 1) return {gate::Z(target1), PI / 2};
+                if (pauli_id2 == 3) return {gate::X(target1), -Kokkos::numbers::pi / 2};
+                if (pauli_id2 == 1) return {gate::Z(target1), Kokkos::numbers::pi / 2};
             }
             if (pauli_id1 == 3) {
-                if (pauli_id2 == 1) return {gate::Y(target1), -PI / 2};
-                if (pauli_id2 == 2) return {gate::X(target1), PI / 2};
+                if (pauli_id2 == 1) return {gate::Y(target1), -Kokkos::numbers::pi / 2};
+                if (pauli_id2 == 2) return {gate::X(target1), Kokkos::numbers::pi / 2};
             }
         }
     }
@@ -99,11 +99,11 @@ std::pair<Gate, double> merge_gate(const Gate& gate1, const Gate& gate2) {
         std::uint64_t target1 = gate1->get_target_qubit_list()[0];
         std::uint64_t target2 = gate2->get_target_qubit_list()[0];
         if (target1 == target2) {
-            double phase1 = oct_phase1                   ? oct_phase1.value() * PI / 4
+            double phase1 = oct_phase1 ? oct_phase1.value() * Kokkos::numbers::pi / 4
                             : gate_type1 == GateType::RZ ? RZGate(gate1)->angle()
                                                          : U1Gate(gate1)->lambda();
             double global_phase1 = gate_type1 == GateType::RZ ? -RZGate(gate1)->angle() / 2 : 0.;
-            double phase2 = oct_phase2                   ? oct_phase2.value() * PI / 4
+            double phase2 = oct_phase2 ? oct_phase2.value() * Kokkos::numbers::pi / 4
                             : gate_type2 == GateType::RZ ? RZGate(gate2)->angle()
                                                          : U1Gate(gate2)->lambda();
             double global_phase2 = gate_type2 == GateType::RZ ? -RZGate(gate2)->angle() / 2 : 0.;
@@ -114,9 +114,9 @@ std::pair<Gate, double> merge_gate(const Gate& gate1, const Gate& gate2) {
     // Special case: RX
     auto get_rx_angle = [&](Gate gate, GateType gate_type) -> std::optional<double> {
         if (gate_type == GateType::I) return 0.;
-        if (gate_type == GateType::X) return PI;
-        if (gate_type == GateType::SqrtX) return PI / 2;
-        if (gate_type == GateType::SqrtXdag) return -PI / 2;
+        if (gate_type == GateType::X) return Kokkos::numbers::pi;
+        if (gate_type == GateType::SqrtX) return Kokkos::numbers::pi / 2;
+        if (gate_type == GateType::SqrtXdag) return -Kokkos::numbers::pi / 2;
         if (gate_type == GateType::RX) return RXGate(gate)->angle();
         return std::nullopt;
     };
@@ -136,9 +136,9 @@ std::pair<Gate, double> merge_gate(const Gate& gate1, const Gate& gate2) {
     // Special case: RY
     auto get_ry_angle = [&](Gate gate, GateType gate_type) -> std::optional<double> {
         if (gate_type == GateType::I) return 0.;
-        if (gate_type == GateType::Y) return PI;
-        if (gate_type == GateType::SqrtY) return PI / 2;
-        if (gate_type == GateType::SqrtYdag) return -PI / 2;
+        if (gate_type == GateType::Y) return Kokkos::numbers::pi;
+        if (gate_type == GateType::SqrtY) return Kokkos::numbers::pi / 2;
+        if (gate_type == GateType::SqrtYdag) return -Kokkos::numbers::pi / 2;
         if (gate_type == GateType::RY) return RYGate(gate)->angle();
         return std::nullopt;
     };

--- a/scaluq/gate/param_gate.hpp
+++ b/scaluq/gate/param_gate.hpp
@@ -80,7 +80,7 @@ public:
     }
 
     [[nodiscard]] virtual ParamGate get_inverse() const = 0;
-    [[nodiscard]] virtual ComplexMatrix get_matrix(double param) const = 0;
+    [[nodiscard]] virtual internal::ComplexMatrix get_matrix(double param) const = 0;
 
     virtual void update_quantum_state(StateVector& state_vector, double param) const = 0;
 };

--- a/scaluq/gate/param_gate_pauli.hpp
+++ b/scaluq/gate/param_gate_pauli.hpp
@@ -24,13 +24,13 @@ public:
     ParamGate get_inverse() const override {
         return std::make_shared<const PPauliRotationGateImpl>(_control_mask, _pauli, -_pcoef);
     }
-    ComplexMatrix get_matrix(double param) const override {
+    internal::ComplexMatrix get_matrix(double param) const override {
         double angle = _pcoef * param;
         Complex true_angle = angle * this->_pauli.get_coef();
-        ComplexMatrix mat = this->_pauli.get_matrix_ignoring_coef();
+        internal::ComplexMatrix mat = this->_pauli.get_matrix_ignoring_coef();
         StdComplex imag_unit(0, 1);
         mat = (StdComplex)Kokkos::cos(-true_angle / 2) *
-                  ComplexMatrix::Identity(mat.rows(), mat.cols()) +
+                  internal::ComplexMatrix::Identity(mat.rows(), mat.cols()) +
               imag_unit * (StdComplex)Kokkos::sin(-true_angle / 2) * mat;
         return mat;
     }

--- a/scaluq/gate/param_gate_probablistic.hpp
+++ b/scaluq/gate/param_gate_probablistic.hpp
@@ -75,7 +75,7 @@ public:
             });
         return std::make_shared<const PProbablisticGateImpl>(_distribution, inv_gate_list);
     }
-    ComplexMatrix get_matrix(double) const override {
+    internal::ComplexMatrix get_matrix(double) const override {
         throw std::runtime_error(
             "PProbablisticGateImpl::get_matrix(): This function must not be used in "
             "PProbablisticGateImpl.");

--- a/scaluq/gate/param_gate_standard.hpp
+++ b/scaluq/gate/param_gate_standard.hpp
@@ -15,9 +15,9 @@ public:
     ParamGate get_inverse() const override {
         return std::make_shared<const PRXGateImpl>(_target_mask, _control_mask, -_pcoef);
     }
-    ComplexMatrix get_matrix(double param) const override {
+    internal::ComplexMatrix get_matrix(double param) const override {
         double angle = _pcoef * param;
-        ComplexMatrix mat(2, 2);
+        internal::ComplexMatrix mat(2, 2);
         mat << std::cos(angle / 2), -1i * std::sin(angle / 2), -1i * std::sin(angle / 2),
             std::cos(angle / 2);
         return mat;
@@ -36,9 +36,9 @@ public:
     ParamGate get_inverse() const override {
         return std::make_shared<const PRYGateImpl>(_target_mask, _control_mask, -_pcoef);
     }
-    ComplexMatrix get_matrix(double param) const override {
+    internal::ComplexMatrix get_matrix(double param) const override {
         double angle = _pcoef * param;
-        ComplexMatrix mat(2, 2);
+        internal::ComplexMatrix mat(2, 2);
         mat << std::cos(angle / 2), -std::sin(angle / 2), std::sin(angle / 2), std::cos(angle / 2);
         return mat;
     }
@@ -56,9 +56,9 @@ public:
     ParamGate get_inverse() const override {
         return std::make_shared<const PRZGateImpl>(_target_mask, _control_mask, -_pcoef);
     }
-    ComplexMatrix get_matrix(double param) const override {
+    internal::ComplexMatrix get_matrix(double param) const override {
         double angle = param * _pcoef;
-        ComplexMatrix mat(2, 2);
+        internal::ComplexMatrix mat(2, 2);
         mat << std::exp(-0.5i * angle), 0, 0, std::exp(0.5i * angle);
         return mat;
     }

--- a/scaluq/gate/update_ops.hpp
+++ b/scaluq/gate/update_ops.hpp
@@ -57,23 +57,21 @@ void rz_gate(std::uint64_t target_mask,
              double angle,
              StateVector& state);
 
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> get_IBMQ_matrix(double _theta,
-                                                            double _phi,
-                                                            double _lambda);
+Matrix2x2 get_IBMQ_matrix(double _theta, double _phi, double _lambda);
 
 void one_target_dense_matrix_gate(std::uint64_t target_mask,
                                   std::uint64_t control_mask,
-                                  const Kokkos::Array<Kokkos::Array<Complex, 2>, 2>& matrix,
+                                  const Matrix2x2& matrix,
                                   StateVector& state);
 
 void two_target_dense_matrix_gate(std::uint64_t target_mask,
                                   std::uint64_t control_mask,
-                                  const Kokkos::Array<Kokkos::Array<Complex, 4>, 4>& matrix,
+                                  const Matrix4x4& matrix,
                                   StateVector& state);
 
 void one_target_diagonal_matrix_gate(std::uint64_t target_mask,
                                      std::uint64_t control_mask,
-                                     const Kokkos::Array<Complex, 2>& diag,
+                                     const DiagonalMatrix2x2& diag,
                                      StateVector& state);
 
 void u1_gate(std::uint64_t target_mask,

--- a/scaluq/gate/update_ops.hpp
+++ b/scaluq/gate/update_ops.hpp
@@ -57,21 +57,23 @@ void rz_gate(std::uint64_t target_mask,
              double angle,
              StateVector& state);
 
-matrix_2_2 get_IBMQ_matrix(double _theta, double _phi, double _lambda);
+Kokkos::Array<Kokkos::Array<Complex, 2>, 2> get_IBMQ_matrix(double _theta,
+                                                            double _phi,
+                                                            double _lambda);
 
 void one_target_dense_matrix_gate(std::uint64_t target_mask,
                                   std::uint64_t control_mask,
-                                  const matrix_2_2& matrix,
+                                  const Kokkos::Array<Kokkos::Array<Complex, 2>, 2>& matrix,
                                   StateVector& state);
 
 void two_target_dense_matrix_gate(std::uint64_t target_mask,
                                   std::uint64_t control_mask,
-                                  const matrix_4_4& matrix,
+                                  const Kokkos::Array<Kokkos::Array<Complex, 4>, 4>& matrix,
                                   StateVector& state);
 
 void one_target_diagonal_matrix_gate(std::uint64_t target_mask,
                                      std::uint64_t control_mask,
-                                     const diagonal_matrix_2_2& diag,
+                                     const Kokkos::Array<Complex, 2>& diag,
                                      StateVector& state);
 
 void u1_gate(std::uint64_t target_mask,

--- a/scaluq/gate/update_ops_dense_matrix.cpp
+++ b/scaluq/gate/update_ops_dense_matrix.cpp
@@ -9,7 +9,7 @@ namespace scaluq {
 namespace internal {
 void one_target_dense_matrix_gate(std::uint64_t target_mask,
                                   std::uint64_t control_mask,
-                                  const matrix_2_2& matrix,
+                                  const Kokkos::Array<Kokkos::Array<Complex, 2>, 2>& matrix,
                                   StateVector& state) {
     Kokkos::parallel_for(
         state.dim() >> std::popcount(target_mask | control_mask), KOKKOS_LAMBDA(std::uint64_t it) {
@@ -18,8 +18,8 @@ void one_target_dense_matrix_gate(std::uint64_t target_mask,
             std::uint64_t basis_1 = basis_0 | target_mask;
             Complex val0 = state._raw[basis_0];
             Complex val1 = state._raw[basis_1];
-            Complex res0 = matrix.val[0][0] * val0 + matrix.val[0][1] * val1;
-            Complex res1 = matrix.val[1][0] * val0 + matrix.val[1][1] * val1;
+            Complex res0 = matrix[0][0] * val0 + matrix[0][1] * val1;
+            Complex res1 = matrix[1][0] * val0 + matrix[1][1] * val1;
             state._raw[basis_0] = res0;
             state._raw[basis_1] = res1;
         });
@@ -28,7 +28,7 @@ void one_target_dense_matrix_gate(std::uint64_t target_mask,
 
 void two_target_dense_matrix_gate(std::uint64_t target_mask,
                                   std::uint64_t control_mask,
-                                  const matrix_4_4& matrix,
+                                  const Kokkos::Array<Kokkos::Array<Complex, 4>, 4>& matrix,
                                   StateVector& state) {
     std::uint64_t lower_target_mask = -target_mask & target_mask;
     std::uint64_t upper_target_mask = target_mask ^ lower_target_mask;
@@ -44,14 +44,14 @@ void two_target_dense_matrix_gate(std::uint64_t target_mask,
             Complex val1 = state._raw[basis_1];
             Complex val2 = state._raw[basis_2];
             Complex val3 = state._raw[basis_3];
-            Complex res0 = matrix.val[0][0] * val0 + matrix.val[0][1] * val1 +
-                           matrix.val[0][2] * val2 + matrix.val[0][3] * val3;
-            Complex res1 = matrix.val[1][0] * val0 + matrix.val[1][1] * val1 +
-                           matrix.val[1][2] * val2 + matrix.val[1][3] * val3;
-            Complex res2 = matrix.val[2][0] * val0 + matrix.val[2][1] * val1 +
-                           matrix.val[2][2] * val2 + matrix.val[2][3] * val3;
-            Complex res3 = matrix.val[3][0] * val0 + matrix.val[3][1] * val1 +
-                           matrix.val[3][2] * val2 + matrix.val[3][3] * val3;
+            Complex res0 = matrix[0][0] * val0 + matrix[0][1] * val1 + matrix[0][2] * val2 +
+                           matrix[0][3] * val3;
+            Complex res1 = matrix[1][0] * val0 + matrix[1][1] * val1 + matrix[1][2] * val2 +
+                           matrix[1][3] * val3;
+            Complex res2 = matrix[2][0] * val0 + matrix[2][1] * val1 + matrix[2][2] * val2 +
+                           matrix[2][3] * val3;
+            Complex res3 = matrix[3][0] * val0 + matrix[3][1] * val1 + matrix[3][2] * val2 +
+                           matrix[3][3] * val3;
             state._raw[basis_0] = res0;
             state._raw[basis_1] = res1;
             state._raw[basis_2] = res2;

--- a/scaluq/gate/update_ops_dense_matrix.cpp
+++ b/scaluq/gate/update_ops_dense_matrix.cpp
@@ -9,7 +9,7 @@ namespace scaluq {
 namespace internal {
 void one_target_dense_matrix_gate(std::uint64_t target_mask,
                                   std::uint64_t control_mask,
-                                  const Kokkos::Array<Kokkos::Array<Complex, 2>, 2>& matrix,
+                                  const Matrix2x2& matrix,
                                   StateVector& state) {
     Kokkos::parallel_for(
         state.dim() >> std::popcount(target_mask | control_mask), KOKKOS_LAMBDA(std::uint64_t it) {
@@ -28,7 +28,7 @@ void one_target_dense_matrix_gate(std::uint64_t target_mask,
 
 void two_target_dense_matrix_gate(std::uint64_t target_mask,
                                   std::uint64_t control_mask,
-                                  const Kokkos::Array<Kokkos::Array<Complex, 4>, 4>& matrix,
+                                  const Matrix4x4& matrix,
                                   StateVector& state) {
     std::uint64_t lower_target_mask = -target_mask & target_mask;
     std::uint64_t upper_target_mask = target_mask ^ lower_target_mask;

--- a/scaluq/gate/update_ops_pauli.cpp
+++ b/scaluq/gate/update_ops_pauli.cpp
@@ -58,11 +58,11 @@ void pauli_rotation_gate(std::uint64_t control_mask,
                 state._raw[basis_0] =
                     cosval * cval_0 +
                     Complex(0, 1) * sinval * cval_1 *
-                        PHASE_M90ROT().val[(global_phase_90_rot_count + bit_parity_0 * 2) % 4];
+                        PHASE_M90ROT()[(global_phase_90_rot_count + bit_parity_0 * 2) % 4];
                 state._raw[basis_1] =
                     cosval * cval_1 +
                     Complex(0, 1) * sinval * cval_0 *
-                        PHASE_M90ROT().val[(global_phase_90_rot_count + bit_parity_1 * 2) % 4];
+                        PHASE_M90ROT()[(global_phase_90_rot_count + bit_parity_1 * 2) % 4];
             });
         Kokkos::fence();
     }

--- a/scaluq/gate/update_ops_standard.cpp
+++ b/scaluq/gate/update_ops_standard.cpp
@@ -79,11 +79,13 @@ void sdag_gate(std::uint64_t target_mask, std::uint64_t control_mask, StateVecto
 }
 
 void t_gate(std::uint64_t target_mask, std::uint64_t control_mask, StateVector& state) {
-    one_target_phase_gate(target_mask, control_mask, Complex(INVERSE_SQRT2, INVERSE_SQRT2), state);
+    one_target_phase_gate(
+        target_mask, control_mask, Complex(INVERSE_SQRT2(), INVERSE_SQRT2()), state);
 }
 
 void tdag_gate(std::uint64_t target_mask, std::uint64_t control_mask, StateVector& state) {
-    one_target_phase_gate(target_mask, control_mask, Complex(INVERSE_SQRT2, -INVERSE_SQRT2), state);
+    one_target_phase_gate(
+        target_mask, control_mask, Complex(INVERSE_SQRT2(), -INVERSE_SQRT2()), state);
 }
 
 void sqrtx_gate(std::uint64_t target_mask, std::uint64_t control_mask, StateVector& state) {
@@ -116,8 +118,7 @@ void rx_gate(std::uint64_t target_mask,
              StateVector& state) {
     const double cosval = std::cos(angle / 2.);
     const double sinval = std::sin(angle / 2.);
-    Kokkos::Array<Kokkos::Array<Complex, 2>, 2> matrix = {
-        cosval, Complex(0, -sinval), Complex(0, -sinval), cosval};
+    Matrix2x2 matrix = {cosval, Complex(0, -sinval), Complex(0, -sinval), cosval};
     one_target_dense_matrix_gate(target_mask, control_mask, matrix, state);
 }
 
@@ -127,13 +128,13 @@ void ry_gate(std::uint64_t target_mask,
              StateVector& state) {
     const double cosval = std::cos(angle / 2.);
     const double sinval = std::sin(angle / 2.);
-    Kokkos::Array<Kokkos::Array<Complex, 2>, 2> matrix = {cosval, -sinval, sinval, cosval};
+    Matrix2x2 matrix = {cosval, -sinval, sinval, cosval};
     one_target_dense_matrix_gate(target_mask, control_mask, matrix, state);
 }
 
 void one_target_diagonal_matrix_gate(std::uint64_t target_mask,
                                      std::uint64_t control_mask,
-                                     const Kokkos::Array<Complex, 2>& diag,
+                                     const DiagonalMatrix2x2& diag,
                                      StateVector& state) {
     Kokkos::parallel_for(
         state.dim() >> std::popcount(target_mask | control_mask), KOKKOS_LAMBDA(std::uint64_t it) {
@@ -151,13 +152,11 @@ void rz_gate(std::uint64_t target_mask,
              StateVector& state) {
     const double cosval = std::cos(angle / 2.);
     const double sinval = std::sin(angle / 2.);
-    Kokkos::Array<Complex, 2> diag = {Complex(cosval, -sinval), Complex(cosval, sinval)};
+    DiagonalMatrix2x2 diag = {Complex(cosval, -sinval), Complex(cosval, sinval)};
     one_target_diagonal_matrix_gate(target_mask, control_mask, diag, state);
 }
 
-Kokkos::Array<Kokkos::Array<Complex, 2>, 2> get_IBMQ_matrix(double theta,
-                                                            double phi,
-                                                            double lambda) {
+Matrix2x2 get_IBMQ_matrix(double theta, double phi, double lambda) {
     Complex exp_val1 = Kokkos::exp(Complex(0, phi));
     Complex exp_val2 = Kokkos::exp(Complex(0, lambda));
     Complex cos_val = Kokkos::cos(theta / 2.);
@@ -187,7 +186,7 @@ void u2_gate(std::uint64_t target_mask,
              double lambda,
              StateVector& state) {
     one_target_dense_matrix_gate(
-        target_mask, control_mask, get_IBMQ_matrix(PI / 2., phi, lambda), state);
+        target_mask, control_mask, get_IBMQ_matrix(Kokkos::numbers::pi / 2., phi, lambda), state);
 }
 
 void u3_gate(std::uint64_t target_mask,

--- a/scaluq/gate/update_ops_standard.cpp
+++ b/scaluq/gate/update_ops_standard.cpp
@@ -79,13 +79,11 @@ void sdag_gate(std::uint64_t target_mask, std::uint64_t control_mask, StateVecto
 }
 
 void t_gate(std::uint64_t target_mask, std::uint64_t control_mask, StateVector& state) {
-    one_target_phase_gate(
-        target_mask, control_mask, Complex(INVERSE_SQRT2(), INVERSE_SQRT2()), state);
+    one_target_phase_gate(target_mask, control_mask, Complex(INVERSE_SQRT2, INVERSE_SQRT2), state);
 }
 
 void tdag_gate(std::uint64_t target_mask, std::uint64_t control_mask, StateVector& state) {
-    one_target_phase_gate(
-        target_mask, control_mask, Complex(INVERSE_SQRT2(), -INVERSE_SQRT2()), state);
+    one_target_phase_gate(target_mask, control_mask, Complex(INVERSE_SQRT2, -INVERSE_SQRT2), state);
 }
 
 void sqrtx_gate(std::uint64_t target_mask, std::uint64_t control_mask, StateVector& state) {
@@ -186,7 +184,7 @@ void u2_gate(std::uint64_t target_mask,
              double lambda,
              StateVector& state) {
     one_target_dense_matrix_gate(
-        target_mask, control_mask, get_IBMQ_matrix(PI() / 2., phi, lambda), state);
+        target_mask, control_mask, get_IBMQ_matrix(PI / 2., phi, lambda), state);
 }
 
 void u3_gate(std::uint64_t target_mask,

--- a/scaluq/operator/operator.cpp
+++ b/scaluq/operator/operator.cpp
@@ -133,7 +133,7 @@ Complex Operator::get_expectation_value(const StateVector& state_vector) const {
                     sizeof(std::uint64_t) * 8 - Kokkos::countl_zero(bit_flip_mask) - 1;
                 std::uint64_t global_phase_90rot_count =
                     Kokkos::popcount(bit_flip_mask & phase_flip_mask);
-                Complex global_phase = PHASE_90ROT()[global_phase_90rot_count % 4];
+                Complex global_phase = internal::PHASE_90ROT()[global_phase_90rot_count % 4];
                 std::uint64_t basis_0 = internal::insert_zero_to_basis_index(state_idx, pivot);
                 std::uint64_t basis_1 = basis_0 ^ bit_flip_mask;
                 double tmp =
@@ -204,7 +204,7 @@ Complex Operator::get_transition_amplitude(const StateVector& state_vector_bra,
                     sizeof(std::uint64_t) * 8 - Kokkos::countl_zero(bit_flip_mask) - 1;
                 std::uint64_t global_phase_90rot_count =
                     Kokkos::popcount(bit_flip_mask & phase_flip_mask);
-                Complex global_phase = PHASE_90ROT()[global_phase_90rot_count % 4];
+                Complex global_phase = internal::PHASE_90ROT()[global_phase_90rot_count % 4];
                 std::uint64_t basis_0 = internal::insert_zero_to_basis_index(state_idx, pivot);
                 std::uint64_t basis_1 = basis_0 ^ bit_flip_mask;
                 Complex tmp1 = Kokkos::conj(state_vector_bra._raw[basis_1]) *

--- a/scaluq/operator/operator.cpp
+++ b/scaluq/operator/operator.cpp
@@ -133,7 +133,7 @@ Complex Operator::get_expectation_value(const StateVector& state_vector) const {
                     sizeof(std::uint64_t) * 8 - Kokkos::countl_zero(bit_flip_mask) - 1;
                 std::uint64_t global_phase_90rot_count =
                     Kokkos::popcount(bit_flip_mask & phase_flip_mask);
-                Complex global_phase = PHASE_90ROT().val[global_phase_90rot_count % 4];
+                Complex global_phase = PHASE_90ROT()[global_phase_90rot_count % 4];
                 std::uint64_t basis_0 = internal::insert_zero_to_basis_index(state_idx, pivot);
                 std::uint64_t basis_1 = basis_0 ^ bit_flip_mask;
                 double tmp =
@@ -204,7 +204,7 @@ Complex Operator::get_transition_amplitude(const StateVector& state_vector_bra,
                     sizeof(std::uint64_t) * 8 - Kokkos::countl_zero(bit_flip_mask) - 1;
                 std::uint64_t global_phase_90rot_count =
                     Kokkos::popcount(bit_flip_mask & phase_flip_mask);
-                Complex global_phase = PHASE_90ROT().val[global_phase_90rot_count % 4];
+                Complex global_phase = PHASE_90ROT()[global_phase_90rot_count % 4];
                 std::uint64_t basis_0 = internal::insert_zero_to_basis_index(state_idx, pivot);
                 std::uint64_t basis_1 = basis_0 ^ bit_flip_mask;
                 Complex tmp1 = Kokkos::conj(state_vector_bra._raw[basis_1]) *

--- a/scaluq/operator/pauli_operator.cpp
+++ b/scaluq/operator/pauli_operator.cpp
@@ -234,7 +234,7 @@ Complex PauliOperator::get_transition_amplitude(const StateVector& state_vector_
     return _ptr->_coef * res;
 }
 
-[[nodiscard]] ComplexMatrix PauliOperator::get_matrix_ignoring_coef() const {
+[[nodiscard]] internal::ComplexMatrix PauliOperator::get_matrix_ignoring_coef() const {
     std::uint64_t flip_mask, phase_mask, rot90_count;
     Kokkos::parallel_reduce(
         Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0, _ptr->_pauli_id_list.size()),
@@ -258,14 +258,14 @@ Complex PauliOperator::get_transition_amplitude(const StateVector& state_vector_
         rot90_count);
     std::vector<StdComplex> rot = {1, -1.i, -1, 1.i};
     std::uint64_t matrix_dim = 1ULL << _ptr->_pauli_id_list.size();
-    ComplexMatrix mat = ComplexMatrix::Zero(matrix_dim, matrix_dim);
+    internal::ComplexMatrix mat = internal::ComplexMatrix::Zero(matrix_dim, matrix_dim);
     for (std::uint64_t index = 0; index < matrix_dim; index++) {
         const StdComplex sign = 1. - 2. * (Kokkos::popcount(index & phase_mask) % 2);
         mat(index, index ^ flip_mask) = rot[rot90_count % 4] * sign;
     }
     return mat;
 }
-[[nodiscard]] ComplexMatrix PauliOperator::get_matrix() const {
+[[nodiscard]] internal::ComplexMatrix PauliOperator::get_matrix() const {
     return get_matrix_ignoring_coef() * StdComplex(_ptr->_coef);
 }
 

--- a/scaluq/operator/pauli_operator.cpp
+++ b/scaluq/operator/pauli_operator.cpp
@@ -131,7 +131,7 @@ void PauliOperator::apply_to_state(StateVector& state_vector) const {
     }
     std::uint64_t pivot = sizeof(std::uint64_t) * 8 - std::countl_zero(bit_flip_mask) - 1;
     std::uint64_t global_phase_90rot_count = std::popcount(bit_flip_mask & phase_flip_mask);
-    Complex global_phase = PHASE_M90ROT()[global_phase_90rot_count % 4];
+    Complex global_phase = internal::PHASE_M90ROT()[global_phase_90rot_count % 4];
     Kokkos::parallel_for(
         state_vector.dim() >> 1, KOKKOS_LAMBDA(std::uint64_t state_idx) {
             std::uint64_t basis_0 = internal::insert_zero_to_basis_index(state_idx, pivot);
@@ -170,7 +170,7 @@ Complex PauliOperator::get_expectation_value(const StateVector& state_vector) co
     }
     std::uint64_t pivot = sizeof(std::uint64_t) * 8 - std::countl_zero(bit_flip_mask) - 1;
     std::uint64_t global_phase_90rot_count = std::popcount(bit_flip_mask & phase_flip_mask);
-    Complex global_phase = PHASE_90ROT()[global_phase_90rot_count % 4];
+    Complex global_phase = internal::PHASE_90ROT()[global_phase_90rot_count % 4];
     double res;
     Kokkos::parallel_reduce(
         state_vector.dim() >> 1,
@@ -214,7 +214,7 @@ Complex PauliOperator::get_transition_amplitude(const StateVector& state_vector_
     }
     std::uint64_t pivot = sizeof(std::uint64_t) * 8 - std::countl_zero(bit_flip_mask) - 1;
     std::uint64_t global_phase_90rot_count = std::popcount(bit_flip_mask & phase_flip_mask);
-    Complex global_phase = PHASE_90ROT()[global_phase_90rot_count % 4];
+    Complex global_phase = internal::PHASE_90ROT()[global_phase_90rot_count % 4];
     Complex res;
     Kokkos::parallel_reduce(
         state_vector_bra.dim() >> 1,
@@ -285,9 +285,10 @@ PauliOperator PauliOperator::operator*(const PauliOperator& target) const {
     extra_90rot_cnt -= (z_left & y_right).popcount();  // ZY = -iX
     extra_90rot_cnt %= 4;
     if (extra_90rot_cnt < 0) extra_90rot_cnt += 4;
-    return PauliOperator(_ptr->_bit_flip_mask ^ target._ptr->_bit_flip_mask,
-                         _ptr->_phase_flip_mask ^ target._ptr->_phase_flip_mask,
-                         _ptr->_coef * target._ptr->_coef * PHASE_90ROT()[extra_90rot_cnt]);
+    return PauliOperator(
+        _ptr->_bit_flip_mask ^ target._ptr->_bit_flip_mask,
+        _ptr->_phase_flip_mask ^ target._ptr->_phase_flip_mask,
+        _ptr->_coef * target._ptr->_coef * internal::PHASE_90ROT()[extra_90rot_cnt]);
 }
 
 }  // namespace scaluq

--- a/scaluq/operator/pauli_operator.cpp
+++ b/scaluq/operator/pauli_operator.cpp
@@ -131,7 +131,7 @@ void PauliOperator::apply_to_state(StateVector& state_vector) const {
     }
     std::uint64_t pivot = sizeof(std::uint64_t) * 8 - std::countl_zero(bit_flip_mask) - 1;
     std::uint64_t global_phase_90rot_count = std::popcount(bit_flip_mask & phase_flip_mask);
-    Complex global_phase = PHASE_M90ROT().val[global_phase_90rot_count % 4];
+    Complex global_phase = PHASE_M90ROT()[global_phase_90rot_count % 4];
     Kokkos::parallel_for(
         state_vector.dim() >> 1, KOKKOS_LAMBDA(std::uint64_t state_idx) {
             std::uint64_t basis_0 = internal::insert_zero_to_basis_index(state_idx, pivot);
@@ -170,7 +170,7 @@ Complex PauliOperator::get_expectation_value(const StateVector& state_vector) co
     }
     std::uint64_t pivot = sizeof(std::uint64_t) * 8 - std::countl_zero(bit_flip_mask) - 1;
     std::uint64_t global_phase_90rot_count = std::popcount(bit_flip_mask & phase_flip_mask);
-    Complex global_phase = PHASE_90ROT().val[global_phase_90rot_count % 4];
+    Complex global_phase = PHASE_90ROT()[global_phase_90rot_count % 4];
     double res;
     Kokkos::parallel_reduce(
         state_vector.dim() >> 1,
@@ -214,7 +214,7 @@ Complex PauliOperator::get_transition_amplitude(const StateVector& state_vector_
     }
     std::uint64_t pivot = sizeof(std::uint64_t) * 8 - std::countl_zero(bit_flip_mask) - 1;
     std::uint64_t global_phase_90rot_count = std::popcount(bit_flip_mask & phase_flip_mask);
-    Complex global_phase = PHASE_90ROT().val[global_phase_90rot_count % 4];
+    Complex global_phase = PHASE_90ROT()[global_phase_90rot_count % 4];
     Complex res;
     Kokkos::parallel_reduce(
         state_vector_bra.dim() >> 1,
@@ -287,7 +287,7 @@ PauliOperator PauliOperator::operator*(const PauliOperator& target) const {
     if (extra_90rot_cnt < 0) extra_90rot_cnt += 4;
     return PauliOperator(_ptr->_bit_flip_mask ^ target._ptr->_bit_flip_mask,
                          _ptr->_phase_flip_mask ^ target._ptr->_phase_flip_mask,
-                         _ptr->_coef * target._ptr->_coef * PHASE_90ROT().val[extra_90rot_cnt]);
+                         _ptr->_coef * target._ptr->_coef * PHASE_90ROT()[extra_90rot_cnt]);
 }
 
 }  // namespace scaluq

--- a/scaluq/operator/pauli_operator.hpp
+++ b/scaluq/operator/pauli_operator.hpp
@@ -88,8 +88,8 @@ public:
     [[nodiscard]] Complex get_expectation_value(const StateVector& state_vector) const;
     [[nodiscard]] Complex get_transition_amplitude(const StateVector& state_vector_bra,
                                                    const StateVector& state_vector_ket) const;
-    [[nodiscard]] ComplexMatrix get_matrix() const;
-    [[nodiscard]] ComplexMatrix get_matrix_ignoring_coef() const;
+    [[nodiscard]] internal::ComplexMatrix get_matrix() const;
+    [[nodiscard]] internal::ComplexMatrix get_matrix_ignoring_coef() const;
 
     [[nodiscard]] PauliOperator operator*(const PauliOperator& target) const;
     [[nodiscard]] inline PauliOperator operator*(Complex target) const {

--- a/scaluq/state/state_vector.hpp
+++ b/scaluq/state/state_vector.hpp
@@ -15,7 +15,7 @@ class StateVector {
 
 public:
     static constexpr std::uint64_t UNMEASURED = 2;
-    StateVectorView _raw;
+    Kokkos::View<Complex*> _raw;
     StateVector() = default;
     StateVector(std::uint64_t n_qubits);
     StateVector(const StateVector& other) = default;

--- a/scaluq/state/state_vector_batched.cpp
+++ b/scaluq/state/state_vector_batched.cpp
@@ -7,7 +7,7 @@ StateVectorBatched::StateVectorBatched(std::uint64_t batch_size, std::uint64_t n
     : _batch_size(batch_size),
       _n_qubits(n_qubits),
       _dim(1ULL << _n_qubits),
-      _raw(StateVectorBatchedView(
+      _raw(Kokkos::View<Complex**, Kokkos::LayoutRight>(
           Kokkos::ViewAllocateWithoutInitializing("states"), _batch_size, _dim)) {
     set_zero_state();
 }

--- a/scaluq/state/state_vector_batched.hpp
+++ b/scaluq/state/state_vector_batched.hpp
@@ -10,7 +10,7 @@ class StateVectorBatched {
     std::uint64_t _dim;
 
 public:
-    StateVectorBatchedView _raw;
+    Kokkos::View<Complex**, Kokkos::LayoutRight> _raw;
     StateVectorBatched() = default;
     StateVectorBatched(std::uint64_t batch_size, std::uint64_t n_qubits);
     StateVectorBatched(const StateVectorBatched& other) = default;

--- a/scaluq/types.hpp
+++ b/scaluq/types.hpp
@@ -27,4 +27,8 @@ using SparseComplexMatrix = Eigen::SparseMatrix<StdComplex>;
 using StateVectorView = Kokkos::View<Complex*>;
 using StateVectorBatchedView = Kokkos::View<Complex**, Kokkos::LayoutRight>;
 
+using Matrix2x2 = Kokkos::Array<Kokkos::Array<Complex, 2>, 2>;
+using Matrix4x4 = Kokkos::Array<Kokkos::Array<Complex, 4>, 4>;
+using DiagonalMatrix2x2 = Kokkos::Array<Complex, 2>;
+
 }  // namespace scaluq

--- a/scaluq/types.hpp
+++ b/scaluq/types.hpp
@@ -17,18 +17,18 @@ inline void finalize() { Kokkos::finalize(); }
 inline bool is_initialized() { return Kokkos::is_initialized(); }
 inline bool is_finalized() { return Kokkos::is_finalized(); }
 
+using StdComplex = std::complex<double>;
 using Complex = Kokkos::complex<double>;
 using namespace std::complex_literals;
 
-using StdComplex = std::complex<double>;
+namespace internal {
+
 using ComplexMatrix = Eigen::Matrix<StdComplex, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
 using SparseComplexMatrix = Eigen::SparseMatrix<StdComplex>;
-
-using StateVectorView = Kokkos::View<Complex*>;
-using StateVectorBatchedView = Kokkos::View<Complex**, Kokkos::LayoutRight>;
 
 using Matrix2x2 = Kokkos::Array<Kokkos::Array<Complex, 2>, 2>;
 using Matrix4x4 = Kokkos::Array<Kokkos::Array<Complex, 4>, 4>;
 using DiagonalMatrix2x2 = Kokkos::Array<Complex, 2>;
 
+}  // namespace internal
 }  // namespace scaluq

--- a/scaluq/types.hpp
+++ b/scaluq/types.hpp
@@ -27,20 +27,4 @@ using SparseComplexMatrix = Eigen::SparseMatrix<StdComplex>;
 using StateVectorView = Kokkos::View<Complex*>;
 using StateVectorBatchedView = Kokkos::View<Complex**, Kokkos::LayoutRight>;
 
-struct array_4 {
-    Complex val[4];
-};
-
-struct matrix_2_2 {
-    Complex val[2][2];
-};
-
-struct matrix_4_4 {
-    Complex val[4][4];
-};
-
-struct diagonal_matrix_2_2 {
-    Complex val[2];
-};
-
 }  // namespace scaluq

--- a/scaluq/util/utility.hpp
+++ b/scaluq/util/utility.hpp
@@ -75,8 +75,9 @@ KOKKOS_INLINE_FUNCTION Matrix2x2 matrix_multiply(const Matrix2x2& matrix1,
             matrix1[1][0] * matrix2[0][1] + matrix1[1][1] * matrix2[1][1]};
 }
 
-inline ComplexMatrix kronecker_product(const ComplexMatrix& lhs, const ComplexMatrix& rhs) {
-    ComplexMatrix result(lhs.rows() * rhs.rows(), lhs.cols() * rhs.cols());
+inline internal::ComplexMatrix kronecker_product(const internal::ComplexMatrix& lhs,
+                                                 const internal::ComplexMatrix& rhs) {
+    internal::ComplexMatrix result(lhs.rows() * rhs.rows(), lhs.cols() * rhs.cols());
     for (int i = 0; i < lhs.rows(); i++) {
         for (int j = 0; j < lhs.cols(); j++) {
             result.block(i * rhs.rows(), j * rhs.cols(), rhs.rows(), rhs.cols()) = lhs(i, j) * rhs;
@@ -85,9 +86,9 @@ inline ComplexMatrix kronecker_product(const ComplexMatrix& lhs, const ComplexMa
     return result;
 }
 
-inline ComplexMatrix get_expanded_matrix(const ComplexMatrix& from_matrix,
-                                         const std::vector<std::uint64_t>& from_targets,
-                                         std::vector<std::uint64_t>& to_targets) {
+inline internal::ComplexMatrix get_expanded_matrix(const internal::ComplexMatrix& from_matrix,
+                                                   const std::vector<std::uint64_t>& from_targets,
+                                                   std::vector<std::uint64_t>& to_targets) {
     std::vector<std::uint64_t> targets_map(from_targets.size());
     std::ranges::transform(from_targets, targets_map.begin(), [&](std::uint64_t x) {
         return std::ranges::lower_bound(to_targets, x) - to_targets.begin();
@@ -105,8 +106,8 @@ inline ComplexMatrix get_expanded_matrix(const ComplexMatrix& from_matrix,
     for (std::uint64_t i : std::views::iota(0ULL, 1ULL << to_targets.size())) {
         if ((i & targets_idx_mask) == 0) outer_indices.push_back(i);
     }
-    ComplexMatrix to_matrix =
-        ComplexMatrix::Zero(1ULL << to_targets.size(), 1ULL << to_targets.size());
+    internal::ComplexMatrix to_matrix =
+        internal::ComplexMatrix::Zero(1ULL << to_targets.size(), 1ULL << to_targets.size());
     for (std::uint64_t i : std::views::iota(0ULL, 1ULL << from_targets.size())) {
         for (std::uint64_t j : std::views::iota(0ULL, 1ULL << from_targets.size())) {
             for (std::uint64_t o : outer_indices) {

--- a/scaluq/util/utility.hpp
+++ b/scaluq/util/utility.hpp
@@ -67,9 +67,8 @@ inline std::vector<std::uint64_t> mask_to_vector(std::uint64_t mask) {
     return indices;
 }
 
-KOKKOS_INLINE_FUNCTION Kokkos::Array<Kokkos::Array<Complex, 2>, 2> matrix_multiply(
-    const Kokkos::Array<Kokkos::Array<Complex, 2>, 2>& matrix1,
-    const Kokkos::Array<Kokkos::Array<Complex, 2>, 2>& matrix2) {
+KOKKOS_INLINE_FUNCTION Matrix2x2 matrix_multiply(const Matrix2x2& matrix1,
+                                                 const Matrix2x2& matrix2) {
     return {matrix1[0][0] * matrix2[0][0] + matrix1[0][1] * matrix2[1][0],
             matrix1[0][0] * matrix2[0][1] + matrix1[0][1] * matrix2[1][1],
             matrix1[1][0] * matrix2[0][0] + matrix1[1][1] * matrix2[1][0],

--- a/scaluq/util/utility.hpp
+++ b/scaluq/util/utility.hpp
@@ -67,12 +67,13 @@ inline std::vector<std::uint64_t> mask_to_vector(std::uint64_t mask) {
     return indices;
 }
 
-KOKKOS_INLINE_FUNCTION matrix_2_2 matrix_multiply(const matrix_2_2& matrix1,
-                                                  const matrix_2_2& matrix2) {
-    return {matrix1.val[0][0] * matrix2.val[0][0] + matrix1.val[0][1] * matrix2.val[1][0],
-            matrix1.val[0][0] * matrix2.val[0][1] + matrix1.val[0][1] * matrix2.val[1][1],
-            matrix1.val[1][0] * matrix2.val[0][0] + matrix1.val[1][1] * matrix2.val[1][0],
-            matrix1.val[1][0] * matrix2.val[0][1] + matrix1.val[1][1] * matrix2.val[1][1]};
+KOKKOS_INLINE_FUNCTION Kokkos::Array<Kokkos::Array<Complex, 2>, 2> matrix_multiply(
+    const Kokkos::Array<Kokkos::Array<Complex, 2>, 2>& matrix1,
+    const Kokkos::Array<Kokkos::Array<Complex, 2>, 2>& matrix2) {
+    return {matrix1[0][0] * matrix2[0][0] + matrix1[0][1] * matrix2[1][0],
+            matrix1[0][0] * matrix2[0][1] + matrix1[0][1] * matrix2[1][1],
+            matrix1[1][0] * matrix2[0][0] + matrix1[1][1] * matrix2[1][0],
+            matrix1[1][0] * matrix2[0][1] + matrix1[1][1] * matrix2[1][1]};
 }
 
 inline ComplexMatrix kronecker_product(const ComplexMatrix& lhs, const ComplexMatrix& rhs) {

--- a/tests/circuit/circuit_test.cpp
+++ b/tests/circuit/circuit_test.cpp
@@ -243,7 +243,7 @@ TEST(CircuitTest, CircuitRev) {
 
     /*
     Observable observable(n);
-    angle = 2 * PI * random.uniform();
+    angle = 2 * Kokkos::numbers::pi * random.uniform();
 
     observable.add_operator(1.0, "Z 0");
     observable.add_operator(2.0, "Z 0 Z 1");

--- a/tests/circuit/circuit_test.cpp
+++ b/tests/circuit/circuit_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <Eigen/Core>
+#include <numbers>
 
 #include "../util/util.hpp"
 #include "gate/gate_factory.hpp"
@@ -124,11 +125,11 @@ TEST(CircuitTest, CircuitBasic) {
     state_eigen = get_eigen_matrix_full_qubit_Swap(target, target_sub, n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::U1(target, M_PI));
+    circuit.add_gate(gate::U1(target, std::numbers::pi));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_Z(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::U2(target, 0, M_PI));
+    circuit.add_gate(gate::U2(target, 0, std::numbers::pi));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_H(), n) * state_eigen;
 
     target = random.int32() % n;
@@ -243,7 +244,7 @@ TEST(CircuitTest, CircuitRev) {
 
     /*
     Observable observable(n);
-    angle = 2 * M_PI * random.uniform();
+    angle = 2 * std::numbers::pi * random.uniform();
 
     observable.add_operator(1.0, "Z 0");
     observable.add_operator(2.0, "Z 0 Z 1");

--- a/tests/circuit/circuit_test.cpp
+++ b/tests/circuit/circuit_test.cpp
@@ -243,7 +243,7 @@ TEST(CircuitTest, CircuitRev) {
 
     /*
     Observable observable(n);
-    angle = 2 * Kokkos::numbers::pi * random.uniform();
+    angle = 2 * M_PI * random.uniform();
 
     observable.add_operator(1.0, "Z 0");
     observable.add_operator(2.0, "Z 0 Z 1");

--- a/tests/circuit/circuit_test.cpp
+++ b/tests/circuit/circuit_test.cpp
@@ -146,7 +146,7 @@ TEST(CircuitTest, CircuitBasic) {
     PauliOperator pauli = PauliOperator("I 0 X 1 Y 2 Z 3");
     circuit.add_gate(multi_Pauli(pauli));
 
-    ComplexMatrix mat_x(2, 2);
+    internal::ComplexMatrix mat_x(2, 2);
     target = random.int32() % n;
     mat_x << 0, 1, 1, 0;
     circuit.add_gate(dense_matrix(target, mat_x));

--- a/tests/circuit/param_circuit_test.cpp
+++ b/tests/circuit/param_circuit_test.cpp
@@ -3,6 +3,7 @@
 #include <circuit/circuit.hpp>
 #include <gate/gate_factory.hpp>
 #include <gate/param_gate_factory.hpp>
+#include <numbers>
 #include <state/state_vector.hpp>
 #include <types.hpp>
 #include <util/random.hpp>
@@ -25,7 +26,7 @@ TEST(ParamCircuitTest, ApplyParamCircuit) {
             pkeys[pidx] = "p" + std::to_string(pidx);
         std::array<double, nparams> params = {};
         for (std::uint64_t pidx : std::views::iota(std::uint64_t{0}, nparams))
-            params[pidx] = random.uniform() * M_PI * 2;
+            params[pidx] = random.uniform() * std::numbers::pi * 2;
         std::map<std::string, double> pmap;
         for (std::uint64_t pidx : std::views::iota(std::uint64_t{0}, nparams))
             pmap[pkeys[pidx]] = params[pidx];

--- a/tests/gate/gate_test.cpp
+++ b/tests/gate/gate_test.cpp
@@ -333,7 +333,7 @@ void run_random_gate_apply_pauli(std::uint64_t n_qubits) {
             }
         }
         matrix = std::cos(angle / 2) * Eigen::MatrixXcd::Identity(dim, dim) -
-                 Complex(0, 1) * std::sin(angle / 2) * matrix;
+                 StdComplex(0, 1) * std::sin(angle / 2) * matrix;
         PauliOperator pauli(target_vec, pauli_id_vec, 1.0);
         Gate pauli_gate = gate::PauliRotation(pauli, angle);
         pauli_gate->update_quantum_state(state);

--- a/tests/gate/gate_test.cpp
+++ b/tests/gate/gate_test.cpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <gate/gate.hpp>
 #include <gate/gate_factory.hpp>
+#include <numbers>
 #include <state/state_vector.hpp>
 #include <types.hpp>
 #include <util/random.hpp>
@@ -53,7 +54,7 @@ void run_random_gate_apply(std::uint64_t n_qubits) {
             test_state[i] = state_cp[i];
         }
 
-        const double angle = M_PI * random.uniform();
+        const double angle = std::numbers::pi * random.uniform();
         const Gate gate = QuantumGateConstructor(angle, {});
         gate->update_quantum_state(state);
         state_cp = state.amplitudes();
@@ -108,7 +109,7 @@ void run_random_gate_apply(std::uint64_t n_qubits,
             test_state[i] = state_cp[i];
         }
 
-        const double angle = M_PI * random.uniform();
+        const double angle = std::numbers::pi * random.uniform();
         const auto matrix = matrix_factory(angle);
         const std::uint64_t target = random.int64() % n_qubits;
         const Gate gate = QuantumGateConstructor(target, angle, {});
@@ -138,14 +139,14 @@ void run_random_gate_apply_IBMQ(
                 test_state[i] = state_cp[i];
             }
 
-            double theta = M_PI * random.uniform();
-            double phi = M_PI * random.uniform();
-            double lambda = M_PI * random.uniform();
+            double theta = std::numbers::pi * random.uniform();
+            double phi = std::numbers::pi * random.uniform();
+            double lambda = std::numbers::pi * random.uniform();
             if (gate_type == 0) {
                 theta = 0;
                 phi = 0;
             } else if (gate_type == 1) {
-                theta = M_PI / 2;
+                theta = std::numbers::pi / 2;
             }
             const auto matrix = matrix_factory(theta, phi, lambda);
             const std::uint64_t target = random.int64() % n_qubits;
@@ -305,7 +306,7 @@ void run_random_gate_apply_pauli(std::uint64_t n_qubits) {
         for (std::uint64_t i = 0; i < dim; i++) {
             test_state[i] = state_cp[i];
         }
-        const double angle = M_PI * random.uniform();
+        const double angle = std::numbers::pi * random.uniform();
         std::vector<std::uint64_t> target_vec, pauli_id_vec;
         for (std::uint64_t target = 0; target < n_qubits; target++) {
             target_vec.emplace_back(target);

--- a/tests/gate/merge_test.cpp
+++ b/tests/gate/merge_test.cpp
@@ -29,15 +29,15 @@ TEST(GateTest, MergeGate) {
         gates.push_back(gate::SqrtYdag(target));
         gates.push_back(gate::P0(target));
         gates.push_back(gate::P1(target));
-        gates.push_back(gate::RX(target, random.uniform() * PI() * 2));
-        gates.push_back(gate::RY(target, random.uniform() * PI() * 2));
-        gates.push_back(gate::RZ(target, random.uniform() * PI() * 2));
-        gates.push_back(gate::U1(target, random.uniform() * PI() * 2));
-        gates.push_back(gate::U2(target, random.uniform() * PI() * 2, random.uniform() * PI() * 2));
+        gates.push_back(gate::RX(target, random.uniform() * PI * 2));
+        gates.push_back(gate::RY(target, random.uniform() * PI * 2));
+        gates.push_back(gate::RZ(target, random.uniform() * PI * 2));
+        gates.push_back(gate::U1(target, random.uniform() * PI * 2));
+        gates.push_back(gate::U2(target, random.uniform() * PI * 2, random.uniform() * PI * 2));
         gates.push_back(gate::U3(target,
-                                 random.uniform() * PI() * 2,
-                                 random.uniform() * PI() * 2,
-                                 random.uniform() * PI() * 2));
+                                 random.uniform() * PI * 2,
+                                 random.uniform() * PI * 2,
+                                 random.uniform() * PI * 2));
         gates.push_back(
             gate::OneTargetMatrix(target,
                                   {std::array{Complex(random.uniform(), random.uniform()),
@@ -49,7 +49,7 @@ TEST(GateTest, MergeGate) {
         gates.push_back(gate::Swap(target, target ^ 1));
     }
     gates.push_back(gate::I());
-    gates.push_back(gate::GlobalPhase(random.uniform() * PI() * 2));
+    gates.push_back(gate::GlobalPhase(random.uniform() * PI * 2));
     gates.push_back(
         gate::TwoTargetMatrix(0,
                               1,
@@ -72,12 +72,12 @@ TEST(GateTest, MergeGate) {
     gates.push_back(gate::Pauli(PauliOperator("X 0 Y 1", random.uniform())));
     gates.push_back(gate::Pauli(PauliOperator("Z 0", random.uniform())));
     gates.push_back(gate::Pauli(PauliOperator("Z 1", random.uniform())));
-    gates.push_back(gate::PauliRotation(PauliOperator("X 0 Y 1", random.uniform()),
-                                        random.uniform() * PI() * 2));
     gates.push_back(
-        gate::PauliRotation(PauliOperator("Z 0", random.uniform()), random.uniform() * PI() * 2));
+        gate::PauliRotation(PauliOperator("X 0 Y 1", random.uniform()), random.uniform() * PI * 2));
     gates.push_back(
-        gate::PauliRotation(PauliOperator("Z 1", random.uniform()), random.uniform() * PI() * 2));
+        gate::PauliRotation(PauliOperator("Z 0", random.uniform()), random.uniform() * PI * 2));
+    gates.push_back(
+        gate::PauliRotation(PauliOperator("Z 1", random.uniform()), random.uniform() * PI * 2));
     for (auto&& g1 : gates) {
         for (auto&& g2 : gates) {
             std::uint64_t n = 2;

--- a/tests/gate/merge_test.cpp
+++ b/tests/gate/merge_test.cpp
@@ -29,15 +29,17 @@ TEST(GateTest, MergeGate) {
         gates.push_back(gate::SqrtYdag(target));
         gates.push_back(gate::P0(target));
         gates.push_back(gate::P1(target));
-        gates.push_back(gate::RX(target, random.uniform() * PI * 2));
-        gates.push_back(gate::RY(target, random.uniform() * PI * 2));
-        gates.push_back(gate::RZ(target, random.uniform() * PI * 2));
-        gates.push_back(gate::U1(target, random.uniform() * PI * 2));
-        gates.push_back(gate::U2(target, random.uniform() * PI * 2, random.uniform() * PI * 2));
+        gates.push_back(gate::RX(target, random.uniform() * Kokkos::numbers::pi * 2));
+        gates.push_back(gate::RY(target, random.uniform() * Kokkos::numbers::pi * 2));
+        gates.push_back(gate::RZ(target, random.uniform() * Kokkos::numbers::pi * 2));
+        gates.push_back(gate::U1(target, random.uniform() * Kokkos::numbers::pi * 2));
+        gates.push_back(gate::U2(target,
+                                 random.uniform() * Kokkos::numbers::pi * 2,
+                                 random.uniform() * Kokkos::numbers::pi * 2));
         gates.push_back(gate::U3(target,
-                                 random.uniform() * PI * 2,
-                                 random.uniform() * PI * 2,
-                                 random.uniform() * PI * 2));
+                                 random.uniform() * Kokkos::numbers::pi * 2,
+                                 random.uniform() * Kokkos::numbers::pi * 2,
+                                 random.uniform() * Kokkos::numbers::pi * 2));
         gates.push_back(
             gate::OneTargetMatrix(target,
                                   {std::array{Complex(random.uniform(), random.uniform()),
@@ -49,7 +51,7 @@ TEST(GateTest, MergeGate) {
         gates.push_back(gate::Swap(target, target ^ 1));
     }
     gates.push_back(gate::I());
-    gates.push_back(gate::GlobalPhase(random.uniform() * PI * 2));
+    gates.push_back(gate::GlobalPhase(random.uniform() * Kokkos::numbers::pi * 2));
     gates.push_back(
         gate::TwoTargetMatrix(0,
                               1,
@@ -72,12 +74,12 @@ TEST(GateTest, MergeGate) {
     gates.push_back(gate::Pauli(PauliOperator("X 0 Y 1", random.uniform())));
     gates.push_back(gate::Pauli(PauliOperator("Z 0", random.uniform())));
     gates.push_back(gate::Pauli(PauliOperator("Z 1", random.uniform())));
-    gates.push_back(
-        gate::PauliRotation(PauliOperator("X 0 Y 1", random.uniform()), random.uniform() * PI * 2));
-    gates.push_back(
-        gate::PauliRotation(PauliOperator("Z 0", random.uniform()), random.uniform() * PI * 2));
-    gates.push_back(
-        gate::PauliRotation(PauliOperator("Z 1", random.uniform()), random.uniform() * PI * 2));
+    gates.push_back(gate::PauliRotation(PauliOperator("X 0 Y 1", random.uniform()),
+                                        random.uniform() * Kokkos::numbers::pi * 2));
+    gates.push_back(gate::PauliRotation(PauliOperator("Z 0", random.uniform()),
+                                        random.uniform() * Kokkos::numbers::pi * 2));
+    gates.push_back(gate::PauliRotation(PauliOperator("Z 1", random.uniform()),
+                                        random.uniform() * Kokkos::numbers::pi * 2));
     for (auto&& g1 : gates) {
         for (auto&& g2 : gates) {
             std::uint64_t n = 2;

--- a/tests/gate/merge_test.cpp
+++ b/tests/gate/merge_test.cpp
@@ -29,17 +29,15 @@ TEST(GateTest, MergeGate) {
         gates.push_back(gate::SqrtYdag(target));
         gates.push_back(gate::P0(target));
         gates.push_back(gate::P1(target));
-        gates.push_back(gate::RX(target, random.uniform() * Kokkos::numbers::pi * 2));
-        gates.push_back(gate::RY(target, random.uniform() * Kokkos::numbers::pi * 2));
-        gates.push_back(gate::RZ(target, random.uniform() * Kokkos::numbers::pi * 2));
-        gates.push_back(gate::U1(target, random.uniform() * Kokkos::numbers::pi * 2));
-        gates.push_back(gate::U2(target,
-                                 random.uniform() * Kokkos::numbers::pi * 2,
-                                 random.uniform() * Kokkos::numbers::pi * 2));
+        gates.push_back(gate::RX(target, random.uniform() * M_PI * 2));
+        gates.push_back(gate::RY(target, random.uniform() * M_PI * 2));
+        gates.push_back(gate::RZ(target, random.uniform() * M_PI * 2));
+        gates.push_back(gate::U1(target, random.uniform() * M_PI * 2));
+        gates.push_back(gate::U2(target, random.uniform() * M_PI * 2, random.uniform() * M_PI * 2));
         gates.push_back(gate::U3(target,
-                                 random.uniform() * Kokkos::numbers::pi * 2,
-                                 random.uniform() * Kokkos::numbers::pi * 2,
-                                 random.uniform() * Kokkos::numbers::pi * 2));
+                                 random.uniform() * M_PI * 2,
+                                 random.uniform() * M_PI * 2,
+                                 random.uniform() * M_PI * 2));
         gates.push_back(
             gate::OneTargetMatrix(target,
                                   {std::array{Complex(random.uniform(), random.uniform()),
@@ -51,7 +49,7 @@ TEST(GateTest, MergeGate) {
         gates.push_back(gate::Swap(target, target ^ 1));
     }
     gates.push_back(gate::I());
-    gates.push_back(gate::GlobalPhase(random.uniform() * Kokkos::numbers::pi * 2));
+    gates.push_back(gate::GlobalPhase(random.uniform() * M_PI * 2));
     gates.push_back(
         gate::TwoTargetMatrix(0,
                               1,
@@ -75,11 +73,11 @@ TEST(GateTest, MergeGate) {
     gates.push_back(gate::Pauli(PauliOperator("Z 0", random.uniform())));
     gates.push_back(gate::Pauli(PauliOperator("Z 1", random.uniform())));
     gates.push_back(gate::PauliRotation(PauliOperator("X 0 Y 1", random.uniform()),
-                                        random.uniform() * Kokkos::numbers::pi * 2));
-    gates.push_back(gate::PauliRotation(PauliOperator("Z 0", random.uniform()),
-                                        random.uniform() * Kokkos::numbers::pi * 2));
-    gates.push_back(gate::PauliRotation(PauliOperator("Z 1", random.uniform()),
-                                        random.uniform() * Kokkos::numbers::pi * 2));
+                                        random.uniform() * M_PI * 2));
+    gates.push_back(
+        gate::PauliRotation(PauliOperator("Z 0", random.uniform()), random.uniform() * M_PI * 2));
+    gates.push_back(
+        gate::PauliRotation(PauliOperator("Z 1", random.uniform()), random.uniform() * M_PI * 2));
     for (auto&& g1 : gates) {
         for (auto&& g2 : gates) {
             std::uint64_t n = 2;

--- a/tests/gate/merge_test.cpp
+++ b/tests/gate/merge_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gate/gate_factory.hpp>
 #include <gate/merge_gate.hpp>
+#include <numbers>
 #include <state/state_vector.hpp>
 #include <types.hpp>
 #include <util/random.hpp>
@@ -29,15 +30,17 @@ TEST(GateTest, MergeGate) {
         gates.push_back(gate::SqrtYdag(target));
         gates.push_back(gate::P0(target));
         gates.push_back(gate::P1(target));
-        gates.push_back(gate::RX(target, random.uniform() * M_PI * 2));
-        gates.push_back(gate::RY(target, random.uniform() * M_PI * 2));
-        gates.push_back(gate::RZ(target, random.uniform() * M_PI * 2));
-        gates.push_back(gate::U1(target, random.uniform() * M_PI * 2));
-        gates.push_back(gate::U2(target, random.uniform() * M_PI * 2, random.uniform() * M_PI * 2));
+        gates.push_back(gate::RX(target, random.uniform() * std::numbers::pi * 2));
+        gates.push_back(gate::RY(target, random.uniform() * std::numbers::pi * 2));
+        gates.push_back(gate::RZ(target, random.uniform() * std::numbers::pi * 2));
+        gates.push_back(gate::U1(target, random.uniform() * std::numbers::pi * 2));
+        gates.push_back(gate::U2(target,
+                                 random.uniform() * std::numbers::pi * 2,
+                                 random.uniform() * std::numbers::pi * 2));
         gates.push_back(gate::U3(target,
-                                 random.uniform() * M_PI * 2,
-                                 random.uniform() * M_PI * 2,
-                                 random.uniform() * M_PI * 2));
+                                 random.uniform() * std::numbers::pi * 2,
+                                 random.uniform() * std::numbers::pi * 2,
+                                 random.uniform() * std::numbers::pi * 2));
         gates.push_back(
             gate::OneTargetMatrix(target,
                                   {std::array{Complex(random.uniform(), random.uniform()),
@@ -49,7 +52,7 @@ TEST(GateTest, MergeGate) {
         gates.push_back(gate::Swap(target, target ^ 1));
     }
     gates.push_back(gate::I());
-    gates.push_back(gate::GlobalPhase(random.uniform() * M_PI * 2));
+    gates.push_back(gate::GlobalPhase(random.uniform() * std::numbers::pi * 2));
     gates.push_back(
         gate::TwoTargetMatrix(0,
                               1,
@@ -73,11 +76,11 @@ TEST(GateTest, MergeGate) {
     gates.push_back(gate::Pauli(PauliOperator("Z 0", random.uniform())));
     gates.push_back(gate::Pauli(PauliOperator("Z 1", random.uniform())));
     gates.push_back(gate::PauliRotation(PauliOperator("X 0 Y 1", random.uniform()),
-                                        random.uniform() * M_PI * 2));
-    gates.push_back(
-        gate::PauliRotation(PauliOperator("Z 0", random.uniform()), random.uniform() * M_PI * 2));
-    gates.push_back(
-        gate::PauliRotation(PauliOperator("Z 1", random.uniform()), random.uniform() * M_PI * 2));
+                                        random.uniform() * std::numbers::pi * 2));
+    gates.push_back(gate::PauliRotation(PauliOperator("Z 0", random.uniform()),
+                                        random.uniform() * std::numbers::pi * 2));
+    gates.push_back(gate::PauliRotation(PauliOperator("Z 1", random.uniform()),
+                                        random.uniform() * std::numbers::pi * 2));
     for (auto&& g1 : gates) {
         for (auto&& g2 : gates) {
             std::uint64_t n = 2;

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -103,7 +103,7 @@ TEST(ParamGateTest, ApplyPProbablisticGate) {
     StateVector state(1);
     for ([[maybe_unused]] auto _ : std::views::iota(0, 100)) {
         std::uint64_t before = state.sampling(1)[0];
-        probgate->update_quantum_state(state, scaluq::PI());
+        probgate->update_quantum_state(state, scaluq::PI);
         std::uint64_t after = state.sampling(1)[0];
         if (before != after) {
             x_cnt++;

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -103,7 +103,7 @@ TEST(ParamGateTest, ApplyPProbablisticGate) {
     StateVector state(1);
     for ([[maybe_unused]] auto _ : std::views::iota(0, 100)) {
         std::uint64_t before = state.sampling(1)[0];
-        probgate->update_quantum_state(state, scaluq::Kokkos::numbers::pi);
+        probgate->update_quantum_state(state, M_PI);
         std::uint64_t after = state.sampling(1)[0];
         if (before != after) {
             x_cnt++;

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gate/gate_factory.hpp>
 #include <gate/param_gate_factory.hpp>
+#include <numbers>
 #include <state/state_vector.hpp>
 #include <types.hpp>
 #include <util/random.hpp>
@@ -25,7 +26,7 @@ void test_apply_parametric_single_pauli_rotation(std::uint64_t n_qubits,
         auto state_bef = state.copy();
 
         const std::uint64_t target = random.int32() % n_qubits;
-        const double param = M_PI * random.uniform();
+        const double param = std::numbers::pi * random.uniform();
         const double pcoef = random.uniform() * 2 - 1;
         const Gate gate = factory_fixed(target, pcoef * param, {});
         const ParamGate pgate = factory_parametric(target, pcoef, {});
@@ -56,7 +57,7 @@ void test_apply_parametric_multi_pauli_rotation(std::uint64_t n_qubits) {
         StateVector state = StateVector::Haar_random_state(n_qubits);
         auto state_cp = state.copy();
         auto state_bef = state.copy();
-        const double param = M_PI * random.uniform();
+        const double param = std::numbers::pi * random.uniform();
         const double pcoef = random.uniform() * 2 - 1;
         std::vector<std::uint64_t> target_vec, pauli_id_vec;
         for (std::uint64_t target = 0; target < n_qubits; target++) {
@@ -103,7 +104,7 @@ TEST(ParamGateTest, ApplyPProbablisticGate) {
     StateVector state(1);
     for ([[maybe_unused]] auto _ : std::views::iota(0, 100)) {
         std::uint64_t before = state.sampling(1)[0];
-        probgate->update_quantum_state(state, M_PI);
+        probgate->update_quantum_state(state, std::numbers::pi);
         std::uint64_t after = state.sampling(1)[0];
         if (before != after) {
             x_cnt++;

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -28,7 +28,7 @@ void test_apply_parametric_single_pauli_rotation(std::uint64_t n_qubits,
         const std::uint64_t target = random.int32() % n_qubits;
         const double param = std::numbers::pi * random.uniform();
         const double param_coef = random.uniform() * 2 - 1;
-        const Gate gate = factory_fixed(target, pcoef * param, {});
+        const Gate gate = factory_fixed(target, param_coef * param, {});
         const ParamGate pgate = factory_parametric(target, param_coef, {});
         gate->update_quantum_state(state);
         pgate->update_quantum_state(state_cp, param);

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -103,7 +103,7 @@ TEST(ParamGateTest, ApplyPProbablisticGate) {
     StateVector state(1);
     for ([[maybe_unused]] auto _ : std::views::iota(0, 100)) {
         std::uint64_t before = state.sampling(1)[0];
-        probgate->update_quantum_state(state, scaluq::PI);
+        probgate->update_quantum_state(state, scaluq::Kokkos::numbers::pi);
         std::uint64_t after = state.sampling(1)[0];
         if (before != after) {
             x_cnt++;


### PR DESCRIPTION
定数を `internal` 名前空間に押し込みます
ついでに `matrix_2_2` などの型を `Kokkos::Array` で代替できることが分かったのでそちらに切り替えます。