### PR TITLE
Google Style Docstring

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -23,7 +23,7 @@ autoapi_file_patterns = ["*.py"]
 autoapi_dirs = ["./stub/scaluq"]
 autoapi_add_toctree_entry = True
 
-autoapi_python_class_content = 'both'
+autoapi_python_class_content = 'class'
 autoapi_options = [
     "members",
     "undoc-members",

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from scaluq import StateVector
+
+state = StateVector(2)
+state.get_amplitude_at(2)

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -13,6 +13,8 @@
 #include <nanobind/stl/variant.h>
 #include <nanobind/stl/vector.h>
 
+#include "docstring.hpp"
+
 namespace nb = nanobind;
 using namespace nb::literals;
 

--- a/python/docstring.hpp
+++ b/python/docstring.hpp
@@ -1,0 +1,100 @@
+#include <optional>
+#include <ranges>
+#include <sstream>
+#include <variant>
+#include <vector>
+
+class DocString {
+public:
+    using Code = std::vector<std::string_view>;
+    using Block = std::variant<std::string_view, Code>;
+    using Blocks = std::vector<Block>;
+    struct Arg {
+        std::string_view name;
+        std::string_view type;
+        bool is_optional;
+        Blocks description;
+    };
+    struct Ret {
+        std::string_view type;
+        Blocks description;
+    };
+
+    explicit DocString() {}
+    DocString& desc(const Block& desc) {
+        description.push_back(desc);
+        return *this;
+    }
+    DocString& arg(const Arg& arg) {
+        args.push_back(arg);
+        return *this;
+    }
+    DocString& ret(const Ret& ret) {
+        returns = ret;
+        return *this;
+    }
+    DocString& ex(const Block& ex) {
+        examples.push_back(ex);
+        return *this;
+    }
+    DocString& note(const Block& note) {
+        notes.push_back(note);
+        return *this;
+    }
+
+    std::string build_as_google_style() {
+        std::ostringstream out;
+        auto output = [&](const Block& b, std::string_view indent) {
+            if (b.index() == 0) {
+                out << indent << std::get<0>(b) << "\n\n";
+            } else {
+                const auto& code = std::get<1>(b);
+                for (const auto& line : code) {
+                    out << indent << line << "\n";
+                }
+                out << "\n";
+            }
+        };
+        for (const auto& b : description) {
+            output(b, "");
+        }
+        if (!args.empty()) {
+            out << "Args:\n";
+            for (const auto& arg : args) {
+                out << "    " << arg.name << " (" << arg.type
+                    << (arg.is_optional ? ", optional):\n" : "):\n");
+                for (const auto& b : arg.description) {
+                    output(b, "        ");
+                }
+            }
+        }
+        if (returns.has_value()) {
+            out << "Returns:\n";
+            const auto& ret = returns.value();
+            out << "    " << ret.type << ":\n";
+            for (const auto& b : ret.description) {
+                output(b, "        ");
+            }
+        }
+        if (!examples.empty()) {
+            out << "Examples:\n";
+            for (const auto& b : examples) {
+                output(b, "    ");
+            }
+        }
+        if (!notes.empty()) {
+            out << "Notes:\n";
+            for (const auto& b : notes) {
+                output(b, "    ");
+            }
+        }
+        return out.str();
+    }
+
+private:
+    Blocks description;
+    std::vector<Arg> args;
+    std::optional<Ret> returns;
+    Blocks examples;
+    Blocks notes;
+};

--- a/scaluq/state/state_vector.cpp
+++ b/scaluq/state/state_vector.cpp
@@ -12,9 +12,9 @@ StateVector::StateVector(std::uint64_t n_qubits)
     set_zero_state();
 }
 
-void StateVector::set_amplitude_at(std::uint64_t index, const Complex& c) {
+void StateVector::set_amplitude_at(std::uint64_t index, const Complex& value) {
     Kokkos::View<Complex, Kokkos::HostSpace> host_view("single_value");
-    host_view() = c;
+    host_view() = value;
     Kokkos::deep_copy(Kokkos::subview(_raw, index), host_view());
 }
 
@@ -156,7 +156,7 @@ double StateVector::get_entropy() const {
         KOKKOS_CLASS_LAMBDA(std::uint64_t idx, double& lsum) {
             double prob = internal::squared_norm(_raw[idx]);
             prob = (prob > eps) ? prob : eps;
-            lsum += -prob * Kokkos::log(prob);
+            lsum += -prob * Kokkos::log2(prob);
         },
         ent);
     return ent;

--- a/scaluq/state/state_vector.hpp
+++ b/scaluq/state/state_vector.hpp
@@ -104,7 +104,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
                  .desc("Construct with specified number of qubits.")
                  .desc("Vector is initialized with computational "
                        "basis $\\ket{0\\dots0}$.")
-                 .arg({"n_qubits", "int", false, {"number of qubits"}})
+                 .arg("n_qubits", "int", "number of qubits")
                  .ex(DocString::Code({">>> state1 = StateVector(2)",
                                       ">>> print(state1)",
                                       " *** Quantum State ***",
@@ -127,11 +127,12 @@ void bind_state_state_vector_hpp(nb::module_& m) {
             "seed"_a = std::nullopt,
             DocString()
                 .desc("Construct :class:`StateVector` with Haar random state.")
-                .arg({"n_qubits", "int | None", false, {"number of qubits"}})
-                .arg({"seed",
-                      "int",
-                      true,
-                      {"random seed", "If not specified, the value from random device is used."}})
+                .arg("n_qubits", "int", "number of qubits")
+                .arg("seed",
+                     "int | None",
+                     true,
+                     "random seed",
+                     "If not specified, the value from random device is used.")
                 .ex(DocString::Code(
                     {">>> state = StateVector.Haar_random_state(2)",
                      ">>> print(state.get_amplitudes())",
@@ -164,12 +165,11 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              "value"_a,
              DocString()
                  .desc("Manually set amplitude at one index.")
-                 .arg({"index",
-                       "int",
-                       false,
-                       {"index of state vector",
-                        "This is read as binary.k-th bit of index represents k-th qubit."}})
-                 .arg({"value", "complex", false, {"amplitude value to set at index"}})
+                 .arg("index",
+                      "int",
+                      "index of state vector",
+                      "This is read as binary.k-th bit of index represents k-th qubit.")
+                 .arg("value", "complex", "amplitude value to set at index")
                  .ex(DocString::Code({">>> state = StateVector(2)",
                                       ">>> state.get_amplitudes()",
                                       "[(1+0j), 0j, 0j, 0j]",
@@ -185,12 +185,11 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              "index"_a,
              DocString()
                  .desc("Get amplitude at one index.")
-                 .arg({"index",
-                       "int",
-                       false,
-                       {"index of state vector",
-                        "This is read as binary. k-th bit of index represents k-th qubit."}})
-                 .ret({"complex", {"Amplitude at specified index"}})
+                 .arg("index",
+                      "int",
+                      "index of state vector",
+                      "This is read as binary. k-th bit of index represents k-th qubit.")
+                 .ret("complex", "Amplitude at specified index")
                  .ex(DocString::Code{">>> state = StateVector(2)",
                                      ">>> state.load([1+2j, 3+4j, 5+6j, 7+8j])",
                                      ">>> state.get_amplitude_at(0)",
@@ -237,11 +236,10 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              "basis"_a,
              DocString()
                  .desc("Initialize with computational basis \\ket{\\mathrm{basis}}.")
-                 .arg({"basis",
-                       "int",
-                       false,
-                       {"basis as integer format ($0 \\leq \\mathrm{basis} \\leq "
-                        "2^{\\mathrm{n\\_qubits}}-1$)"}})
+                 .arg("basis",
+                      "int",
+                      "basis as integer format ($0 \\leq \\mathrm{basis} \\leq "
+                      "2^{\\mathrm{n\\_qubits}}-1$)")
                  .ex(DocString::Code{">>> state = StateVector(2)",
                                      ">>> state.set_computational_basis(0) # |00>",
                                      ">>> state.get_amplitudes()",
@@ -261,7 +259,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              &StateVector::get_amplitudes,
              DocString()
                  .desc("Get all amplitudes as `list[complex]`.")
-                 .ret({"list[complex]", {"amplitudes of list with len $2^{\\mathrm{n\\_qubits}}$"}})
+                 .ret("list[complex]", "amplitudes of list with len $2^{\\mathrm{n\\_qubits}}$")
                  .ex(DocString::Code{">>> state = StateVector(2)",
                                      ">>> state.get_amplitudes()",
                                      "[(1+0j), 0j, 0j, 0j]"})
@@ -271,7 +269,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              &StateVector::n_qubits,
              DocString()
                  .desc("Get num of qubits.")
-                 .ret({"int", {"num of qubits"}})
+                 .ret("int", "num of qubits")
                  .ex(DocString::Code{">>> state = StateVector(2)", ">>> state.n_qubits()", "2"})
                  .build_as_google_style()
                  .c_str())
@@ -279,7 +277,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              &StateVector::dim,
              DocString()
                  .desc("Get dimension of the vector ($=2^\\mathrm{n\\_qubits}$).")
-                 .ret({"int", {"dimension of the vector"}})
+                 .ret("int", "dimension of the vector")
                  .ex(DocString::Code{">>> state = StateVector(2)", ">>> state.dim()", "4"})
                  .build_as_google_style()
                  .c_str())
@@ -287,7 +285,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              &StateVector::get_squared_norm,
              DocString()
                  .desc("Get squared norm of the state. $\\braket{\\psi|\\psi}$.")
-                 .ret({"float", {"squared norm of the state"}})
+                 .ret("float", "squared norm of the state")
                  .ex(DocString::Code{">>> v = [1+2j, 3+4j, 5+6j, 7+8j]",
                                      ">>> state = StateVector(2)",
                                      ">>> state.load(v)",
@@ -326,8 +324,8 @@ void bind_state_state_vector_hpp(nb::module_& m) {
             DocString()
                 .desc("Get the probability to observe $\\ket{0}$ at specified index.")
                 .desc("**State must be normalized.**")
-                .arg({"index", "int", false, {"qubit index to be observed"}})
-                .ret({"float", {"probability to observe $\\ket{0}$"}})
+                .arg("index", "int", "qubit index to be observed")
+                .ret("float", "probability to observe $\\ket{0}$")
                 .ex(DocString::Code{">>> v = [1 / 6**.5, 2j / 6**.5 * 1j, -1 / 6**.5, -2j / 6**.5]",
                                     ">>> state = StateVector(2)",
                                     ">>> state.load(v)",
@@ -347,14 +345,13 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              DocString()
                  .desc("Get the marginal probability to observe as given.")
                  .desc("**State must be normalized.**")
-                 .arg({"measured_values",
-                       "list[int]",
-                       false,
-                       {"list with len n_qubits.",
-                        "`0`, `1` or :attr:`.UNMEASURED` is allowed for each elements. `0` or `1` "
-                        "shows the qubit is observed and the value is got. :attr:`.UNMEASURED` "
-                        "shows the the qubit is not observed."}})
-                 .ret({"float", {"probability to observe as given"}})
+                 .arg("measured_values",
+                      "list[int]",
+                      "list with len n_qubits.",
+                      "`0`, `1` or :attr:`.UNMEASURED` is allowed for each elements. `0` or `1` "
+                      "shows the qubit is observed and the value is got. :attr:`.UNMEASURED` "
+                      "shows the the qubit is not observed.")
+                 .ret("float", "probability to observe as given")
                  .ex(DocString::Code{
                      ">>> v = [1/4, 1/2, 0, 1/4, 1/4, 1/2, 1/4, 1/2]",
                      "state = StateVector(3)",
@@ -370,7 +367,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              DocString()
                  .desc("Get the entropy of the vector.")
                  .desc("**State must be normalized.**")
-                 .ret({"float", {"entropy"}})
+                 .ret("float", "entropy")
                  .ex(DocString::Code{
                      ">>> v = [1/4, 1/2, 0, 1/4, 1/4, 1/2, 1/4, 1/2]",
                      ">>> state = StateVector(3)",
@@ -392,7 +389,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
                  .desc("Add other state vector and make superposition.")
                  .desc("$\\ket{\\mathrm{this}} \\leftarrow \\ket{\\mathrm{this}} + "
                        "\\ket{\\mathrm{state}}$.")
-                 .arg({"state", ":class:`StateVector`", false, {"state to be added"}})
+                 .arg("state", ":class:`StateVector`", "state to be added")
                  .ex(DocString::Code{">>> state1 = StateVector(1)",
                                      ">>> state1.load([1, 2])",
                                      ">>> state2 = StateVector(1)",
@@ -410,8 +407,8 @@ void bind_state_state_vector_hpp(nb::module_& m) {
                  .desc("Add other state vector with multiplying the coef and make superposition.")
                  .desc("$\\ket{\\mathrm{this}}\\leftarrow\\ket{\\mathrm{this}}+\\mathrm{coef} "
                        "\\ket{\\mathrm{state}}$.")
-                 .arg({"coef", "complex", false, {"coefficient to multiply to `state`"}})
-                 .arg({"state", ":class:`StateVector`", false, {"state to be added"}})
+                 .arg("coef", "complex", "coefficient to multiply to `state`")
+                 .arg("state", ":class:`StateVector`", "state to be added")
                  .ex(DocString::Code{">>> state1 = StateVector(1)",
                                      ">>> state1.load([1, 2])",
                                      ">>> state2 = StateVector(1)",
@@ -427,7 +424,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              DocString()
                  .desc("Multiply coef.")
                  .desc("$\\ket{\\mathrm{this}}\\leftarrow\\mathrm{coef}\\ket{\\mathrm{this}}$.")
-                 .arg({"coef", "complex", false, {"coefficient to multiply"}})
+                 .arg("coef", "complex", "coefficient to multiply")
                  .ex(DocString::Code{">>> state = StateVector(1)",
                                      ">>> state.load([1, 2])",
                                      ">>> state.multiply_coef(2j)",
@@ -446,18 +443,19 @@ void bind_state_state_vector_hpp(nb::module_& m) {
             "seed"_a = std::nullopt,
             DocString()
                 .desc("Sampling state vector independently and get list of computational basis")
-                .arg({"sampling_count", "int", false, {"how many times to apply sampling"}})
-                .arg({"seed",
-                      "int | None",
-                      true,
-                      {"random seed", "If not specified, the value from random device is used."}})
-                .ret({"list[int]",
-                      {"result of sampling",
-                       "list of `sampling_count` length. Each element is in "
-                       "$[0,2^{\\mathrm{n\\_qubits}})$"}})
+                .arg("sampling_count", "int", "how many times to apply sampling")
+                .arg("seed",
+                     "int | None",
+                     true,
+                     "random seed",
+                     "If not specified, the value from random device is used.")
+                .ret("list[int]",
+                     "result of sampling",
+                     "list of `sampling_count` length. Each element is in "
+                     "$[0,2^{\\mathrm{n\\_qubits}})$")
                 .ex(DocString::Code{" >>> state = StateVector(2)",
                                     ">>> state.load([1/2, 0, -3**.5/2, 0])",
-                                    " >>> state.sampling(8) ",
+                                    ">>> state.sampling(8) ",
                                     "[0, 2, 2, 2, 2, 0, 0, 2]"})
                 .build_as_google_style()
                 .c_str())
@@ -466,7 +464,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
             &StateVector::to_string,
             DocString()
                 .desc("Information as `str`.")
-                .ret({"str", {"information as str"}})
+                .ret("str", "information as str")
                 .ex(DocString::Code{
                     ">>> state = StateVector(1)",
                     ">>> state.to_string()",
@@ -478,10 +476,9 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              "other"_a,
              DocString()
                  .desc("Load amplitudes of `Sequence`")
-                 .arg({"other",
-                       "collections.abc.Sequence[complex]",
-                       false,
-                       {"list of complex amplitudes with len $2^{\\mathrm{n_qubits}}$"}})
+                 .arg("other",
+                      "collections.abc.Sequence[complex]",
+                      "list of complex amplitudes with len $2^{\\mathrm{n_qubits}}$")
                  .build_as_google_style()
                  .c_str())
         .def("__str__",

--- a/scaluq/state/state_vector.hpp
+++ b/scaluq/state/state_vector.hpp
@@ -78,12 +78,20 @@ namespace internal {
 void bind_state_state_vector_hpp(nb::module_& m) {
     nb::class_<StateVector>(m,
                             "StateVector",
-                            "Vector representation of quantum state.\n\n.. note:: Qubit index is "
-                            "start from 0. If the amplitudes of $\\ket{b_{n-1}\\dots b_0}$ is "
-                            "$b_i$, the state is $\\sum_i b_i 2^i$.")
+                            DocString()
+                                .desc("Vector representation of quantum state.")
+                                .desc("Qubit index is "
+                                      "start from 0. If the i-th value of the vector is "
+                                      "$a_i$, the state is $\\sum_i a_i \\ket{i}$.")
+                                .build_as_google_style()
+                                .c_str())
         .def(nb::init<std::uint64_t>(),
-             "Construct state vector with specified qubits, initialized with computational "
-             "basis $\\ket{0\\dots0}$.")
+             DocString()
+                 .desc(
+                     "Construct state vector with specified qubits, initialized with computational "
+                     "basis $\\ket{0\\dots0}$.")
+                 .build_as_google_style()
+                 .c_str())
         .def(nb::init<const StateVector&>(), "Constructing state vector by copying other state.")
         .def_static(
             "Haar_random_state",
@@ -100,9 +108,29 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              "Manually set amplitude at one index.")
         .def("get_amplitude_at",
              &StateVector::get_amplitude_at,
-             "Get amplitude at one index.\n\n.. note:: If you want to get all amplitudes, you "
-             "should "
-             "use `StateVector::get_amplitudes()`.")
+             "index"_a,
+             DocString()
+                 .desc("Get amplitude at one index.")
+                 .arg({"index",
+                       "int",
+                       false,
+                       {"Index of state vector.",
+                        "This is read as binary. k-th bit of index represents k-th qubit."}})
+                 .ret({"complex", {"Amplitude at specified index"}})
+                 .ex(DocString::Code{">>> state = StateVector(2)",
+                                     ">>> state.load([1+2j, 3+4j, 5+6j, 7+8j])",
+                                     ">>> state.get_amplitude_at(0)",
+                                     "(1+2j)",
+                                     ">>> state.get_amplitude_at(1)",
+                                     "(3+4j)",
+                                     ">>> state.get_amplitude_at(2)",
+                                     "(5+6j)",
+                                     ">>> state.get_amplitude_at(3)",
+                                     "(7+8j)"})
+                 .note("If you want to get amplitudes at all indices, you should use "
+                       ":meth:`.get_amplitudes`.")
+                 .build_as_google_style()
+                 .c_str())
         .def("set_zero_state",
              &StateVector::set_zero_state,
              "Initialize with computational basis $\\ket{00\\dots0}$.")
@@ -112,7 +140,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
         .def("set_computational_basis",
              &StateVector::set_computational_basis,
              "Initialize with computational basis \\ket{\\mathrm{basis}}.")
-        .def("amplitudes",
+        .def("get_amplitudes",
              &StateVector::get_amplitudes,
              "Get all amplitudes with as `list[complex]`.")
         .def("n_qubits", &StateVector::n_qubits, "Get num of qubits.")

--- a/scaluq/state/state_vector_batched.cpp
+++ b/scaluq/state/state_vector_batched.cpp
@@ -280,7 +280,7 @@ std::vector<double> StateVectorBatched::get_entropy() const {
                 [&](std::uint64_t idx, double& lsum) {
                     double prob = internal::squared_norm(_raw(batch_id, idx));
                     prob = Kokkos::max(prob, eps);
-                    lsum += -prob * Kokkos::log(prob);
+                    lsum += -prob * Kokkos::log2(prob);
                 },
                 sum);
             team.team_barrier();

--- a/tests/state/state_vector_test.cpp
+++ b/tests/state/state_vector_test.cpp
@@ -170,7 +170,7 @@ TEST(StateVectorTest, EntropyCalculation) {
             for (std::uint64_t ind = 0; ind < dim; ++ind) {
                 CComplex z = test_state[ind];
                 double prob = z.real() * z.real() + z.imag() * z.imag();
-                if (prob > eps) ent += -prob * log2(prob);
+                if (prob > eps) ent += -prob * std::log2(prob);
             }
             ASSERT_NEAR(ent, state.get_entropy(), eps);
         }

--- a/tests/state/state_vector_test.cpp
+++ b/tests/state/state_vector_test.cpp
@@ -170,7 +170,7 @@ TEST(StateVectorTest, EntropyCalculation) {
             for (std::uint64_t ind = 0; ind < dim; ++ind) {
                 CComplex z = test_state[ind];
                 double prob = z.real() * z.real() + z.imag() * z.imag();
-                if (prob > eps) ent += -prob * log(prob);
+                if (prob > eps) ent += -prob * log2(prob);
             }
             ASSERT_NEAR(ent, state.get_entropy(), eps);
         }


### PR DESCRIPTION
close #170 
とてもリッチなdocstringを作りました
以下のようなGoogle-styleのdocstringが生成され、エディタのホバーやドキュメントが生成できます。

```py
    def get_amplitude_at(self, index: int) -> complex:
        """
        Get amplitude at one index.

        Args:
            index (int):
                index of state vector

                This is read as binary. k-th bit of index represents k-th qubit.

        Returns:
            complex:
                Amplitude at specified index

        Examples:
            >>> state = StateVector(2)
            >>> state.load([1+2j, 3+4j, 5+6j, 7+8j])
            >>> state.get_amplitude_at(0)
            (1+2j)
            >>> state.get_amplitude_at(1)
            (3+4j)
            >>> state.get_amplitude_at(2)
            (5+6j)
            >>> state.get_amplitude_at(3)
            (7+8j)

        Notes:
            If you want to get amplitudes at all indices, you should use :meth:`.get_amplitudes`.
        """
```