### PR TITLE
Support macOS arm64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,8 +64,9 @@ jobs:
           key: "${{ github.job }}-${{ matrix.os }}-${{ matrix.architecture }}-${{ matrix.device }}"
           verbose: 2
       
-      - name: which ccache
-        run: which ccache
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ always() }}
 
       - name: Install CUDA toolkit
         if: ${{ matrix.device == 'cuda' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
             runs-on: "macos-14"
     runs-on: ${{ matrix.runs-on }}
     env:
-      CMAKE_C_COMPILER: ${{ matrix.os == 'macos' && '/usr/local/opt/ccache/libexec/gcc-14' || '/usr/lib/ccache/gcc' }}
-      CMAKE_CXX_COMPILER: ${{ matrix.os == 'macos' && '/usr/local/opt/ccache/libexec/g++-14' || '/usr/lib/ccache/g++' }}
+      CMAKE_C_COMPILER: ${{ matrix.runs-on == 'macos-13' && '/usr/local/opt/ccache/libexec/gcc-14'|| matrix.runs-on == 'macos-14' && '/opt/homebrew/opt/ccache/libexec/gcc-14' || '/usr/lib/ccache/gcc' }}
+      CMAKE_CXX_COMPILER: ${{ matrix.runs-on == 'macos-13' && '/usr/local/opt/ccache/libexec/g++-14'|| matrix.runs-on == 'macos-14' && '/opt/homebrew/opt/ccache/libexec/g++-14' || '/usr/lib/ccache/g++' }}
       CMAKE_BUILD_TYPE: ${{ matrix.device == 'cuda' && 'Release' || 'Debug' }}
       SCALUQ_USE_TEST: "ON"
       SCALUQ_USE_CUDA: ${{ matrix.device == 'cuda' && 'ON' || 'OFF' }}
@@ -64,10 +64,6 @@ jobs:
           key: "${{ github.job }}-${{ matrix.os }}-${{ matrix.architecture }}-${{ matrix.device }}"
           verbose: 2
       
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ always() }}
-
       - name: Install CUDA toolkit
         if: ${{ matrix.device == 'cuda' }}
         uses: Jimver/cuda-toolkit@v0.2.11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,16 @@ jobs:
     strategy:
       matrix:
         os: ["linux", "macos"]
-        architecture: ["x86_64"]
+        architecture: ["x86_64", "arm64"]
         device: ["cpu", "cuda"]
         python-version: ["3.10"]
         exclude:
           - os: "macos"
             device: "cuda"
+        exclude:
+          # currently ARM runner is not supported
+          - os: "linux"
+            architecture: "arm64"
         include:
           - os: "linux"
             architecture: "x86_64"
@@ -33,6 +37,9 @@ jobs:
           - os: "macos"
             architecture: "x86_64"
             runs-on: "macos-13"
+          - os: "macos"
+            architecture: "arm64"
+            runs-on: "macos-14"
     runs-on: ${{ matrix.runs-on }}
     env:
       CMAKE_C_COMPILER: ${{ matrix.os == 'macos' && '/usr/local/opt/ccache/libexec/gcc-14' || '/usr/lib/ccache/gcc' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
         exclude:
           - os: "macos"
             device: "cuda"
-        exclude:
           # currently ARM runner is not supported
           - os: "linux"
             architecture: "arm64"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,11 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: "${{ github.job }}-${{ matrix.os }}-${{ matrix.device }}"
+          key: "${{ github.job }}-${{ matrix.os }}-${{ matrix.architecture }}-${{ matrix.device }}"
           verbose: 2
+      
+      - name: which ccache
+        run: which ccache
 
       - name: Install CUDA toolkit
         if: ${{ matrix.device == 'cuda' }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -19,8 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ["linux", "macos"]
-        arch: ["x86_64"]
+        arch: ["x86_64", "arm64"]
         cibw-python: ["cp38", "cp39", "cp310", "cp311", "cp312"]
+        exclude:
+          # currently ARM runner is not supported
+          - os: "linux"
+            arch: "arm64"
         include:
           - os: "linux"
             arch: "x86_64"
@@ -30,6 +34,10 @@ jobs:
             arch: "x86_64"
             runs-on: "macos-13"
             cibw-os-arch: "macosx_x86_64"
+          - os: "macos"
+            arch: "arm64"
+            runs-on: "macos-14"
+            cibw-os-arch: "macosx_arm64"
           - cibw-python: "cp38"
             python-version: "3.8"
           - cibw-python: "cp39"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -54,7 +54,7 @@ jobs:
       CMAKE_CXX_COMPILER: ${{ matrix.os == 'macos' && 'g++-14' || 'g++' }}
       CIBW_BUILD: ${{ matrix.cibw-python }}-${{ matrix.cibw-os-arch }}
       PYTHON: ${{ matrix.python-version }}
-      MACOSX_DEPLOYMENT_TARGET: "13.0"
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.runs-on == 'macos-14' && "14.0" || "13.0" }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -54,7 +54,7 @@ jobs:
       CMAKE_CXX_COMPILER: ${{ matrix.os == 'macos' && 'g++-14' || 'g++' }}
       CIBW_BUILD: ${{ matrix.cibw-python }}-${{ matrix.cibw-os-arch }}
       PYTHON: ${{ matrix.python-version }}
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.runs-on == 'macos-14' && "14.0" || "13.0" }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.runs-on == 'macos-14' && '14.0' || '13.0' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ set_property(TARGET kokkoscore PROPERTY POSITION_INDEPENDENT_CODE ON)
 FetchContent_Declare(
     eigen
     GIT_REPOSITORY https://gitlab.com/libeigen/eigen
-    GIT_TAG 3.4.0
+    GIT_TAG b396a6fbb2e173f52edb3360485dedf3389ef830 # Since Eigen has not released since 3.4.0(3 years ago), a commit hash is directly specified.
 )
 FetchContent_MakeAvailable(eigen)
 


### PR DESCRIPTION
arm64版のmacOSのテストとwheel配布をできるようにしました。
wheelはM1のMacbook実機にインストールできることを確認しました。
Linux arm64もやりたいと思っていて、クロスコンパイルでwheel buildはでますが、テストもしたいしlarge-runnerがまだ確保できていないので後回しにしています。