### PR TITLE
nlohmann_json

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -31,8 +31,9 @@
 				"C_Cpp.default.includePath": [
 					"scaluq",
 					"/usr/local/include/kokkos",
-					"build/_deps/eigen_fetch-src",
-					"build/_deps/googletest_fetch-src/googletest/include",
+					"build/_deps/eigen-src",
+					"build/_deps/googletest-src/googletest/include",
+					"build/_deps/json-src/include",
 					"~/.local/lib/python3.10/site-packages/nanobind/include",
 					"/usr/include/python3.10"
 				],

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -33,8 +33,9 @@
 				"C_Cpp.default.includePath": [
 					"scaluq",
 					"/usr/local/include/kokkos",
-					"build/_deps/eigen_fetch-src",
-					"build/_deps/googletest_fetch-src/googletest/include",
+					"build/_deps/eigen-src",
+					"build/_deps/googletest-src/googletest/include",
+					"build/_deps/json-src/include",
 					"~/.local/lib/python3.10/site-packages/nanobind/include",
 					"/usr/include/python3.10"
 				],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,14 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(eigen)
 
+# nlohmann_json
+FetchContent_Declare(
+    json
+    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+FetchContent_MakeAvailable(json)
+
 # nanobind
 if(SKBUILD)
     find_package(Python 3.8

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -6,6 +6,7 @@ function(exe name)
         scaluq
         Eigen3::Eigen
         Kokkos::kokkos
+        nlohmann_json::nlohmann_json
         GTest::gtest_main
     )
     target_include_directories(${name} PRIVATE ${PROJECT_SOURCE_DIR}/scaluq)

--- a/exe/main.cpp
+++ b/exe/main.cpp
@@ -9,32 +9,11 @@ using namespace scaluq;
 using namespace std;
 
 void run() {
-    auto y_gate = gate::Y(2);
-    std::cout << y_gate->to_string() << "\n\n";
-
-    auto cx_gate = gate::CX(0, 2);
-    std::cout << cx_gate << "\n\n";
-
-    auto swap_gate = gate::Swap(2, 3, {4, 6});
-    std::cout << swap_gate << "\n\n";
-
-    auto rx_gate = gate::RX(2, 0.5);
-    std::cout << rx_gate << "\n\n";
-
-    auto prob_gate = gate::Probablistic({0.1, 0.1, 0.8}, {cx_gate, y_gate, swap_gate});
-    std::cout << prob_gate << "\n\n";
-
-    auto prob_prob_gate = gate::Probablistic({0.5, 0.5}, {cx_gate, prob_gate});
-    std::cout << prob_prob_gate << "\n\n";
-
-    auto prx_gate = gate::ParamRX(2);
-    std::cout << prx_gate << "\n\n";
-
-    auto pry_gate = gate::ParamRY(2, 2.5, {1, 3});
-    std::cout << pry_gate << "\n\n";
-
-    auto pprob_gate = gate::ParamProbablistic({0.7, 0.3}, {prx_gate, pry_gate});
-    std::cout << pprob_gate << std::endl;
+    StateVector state = StateVector::Haar_random_state(3);
+    Json j = state;
+    cout << j.dump() << endl;
+    StateVector state2 = j.get<StateVector>();
+    cout << state2 << endl;
 }
 
 int main() {

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,6 +7,7 @@ nanobind_add_module(scaluq_core STABLE_ABI binding.cpp)
 target_link_libraries(scaluq_core PRIVATE scaluq
     Kokkos::kokkos
     Eigen3::Eigen
+    nlohmann_json::nlohmann_json
 )
 target_include_directories(scaluq_core PRIVATE ${PROJECT_SOURCE_DIR}/scaluq)
 install(TARGETS scaluq_core LIBRARY DESTINATION scaluq)

--- a/scaluq/CMakeLists.txt
+++ b/scaluq/CMakeLists.txt
@@ -14,5 +14,6 @@ target_sources(scaluq PRIVATE
 target_link_libraries(scaluq PRIVATE 
     Kokkos::kokkos
     Eigen3::Eigen
+    nlohmann_json::nlohmann_json
 )
 target_include_directories(scaluq PRIVATE ${PROJECT_SOURCE_DIR}/scaluq)

--- a/scaluq/state/state_vector.hpp
+++ b/scaluq/state/state_vector.hpp
@@ -71,6 +71,14 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const StateVector& state);
 
     [[nodiscard]] std::string to_string() const;
+
+    friend void to_json(Json& j, const StateVector& state) {
+        j = Json{{"n_qubits", state._n_qubits}, {"amplitudes", state.get_amplitudes()}};
+    }
+    friend void from_json(const Json& j, StateVector& state) {
+        state = StateVector(j.at("n_qubits").get<std::uint64_t>());
+        state.load(j.at("amplitudes").get<std::vector<Complex>>());
+    }
 };
 
 #ifdef SCALUQ_USE_NANOBIND

--- a/scaluq/types.hpp
+++ b/scaluq/types.hpp
@@ -5,6 +5,7 @@
 #include <Kokkos_Core.hpp>
 #include <complex>
 #include <cstdint>
+#include <nlohmann/json.hpp>
 
 namespace scaluq {
 
@@ -20,6 +21,8 @@ inline bool is_finalized() { return Kokkos::is_finalized(); }
 using StdComplex = std::complex<double>;
 using Complex = Kokkos::complex<double>;
 using namespace std::complex_literals;
+
+using Json = nlohmann::json;
 
 namespace internal {
 template <typename DummyType>
@@ -48,3 +51,16 @@ void bind_types_hpp(nb::module_& m) {
 }  // namespace internal
 #endif
 }  // namespace scaluq
+
+namespace nlohmann {
+template <>
+struct adl_serializer<scaluq::Complex> {
+    static void to_json(json& j, const scaluq::Complex& c) {
+        j = json{{"real", c.real()}, {"imag", c.imag()}};
+    }
+    static void from_json(const json& j, scaluq::Complex& c) {
+        j.at("real").get_to(c.real());
+        j.at("imag").get_to(c.imag());
+    }
+};
+}  // namespace nlohmann

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(scaluq_test PRIVATE
     Kokkos::kokkos
     GTest::gtest_main
     Eigen3::Eigen
+    nlohmann_json::nlohmann_json
 )
 
 target_include_directories(scaluq_test PRIVATE ${PROJECT_SOURCE_DIR}/scaluq)


### PR DESCRIPTION
close #151 
StateVectorや回路などをJSONにダンプできるようにします。
本家ではBoost::ptreeを使ってJSONとやりとりしていましたが、JSONだけならnlohmann_jsonのほうが軽くて便利なのでこっちを採用しました。

とりあえずStateVectorだけやっていて、#177 に合わせてどう対応するか考えないといけないのでそれが終わってから他のやつも実装していきます。