### PR TITLE
Python precision

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -158,6 +158,6 @@ jobs:
       - name: Run / Test stub
         if: ${{ matrix.device == 'cpu' }} # currently GPU runner is not supported
         run: |
-          echo -e "from scaluq import StateVector, gate\nstate = StateVector(2)\nx = gate.X(0)\nx.update_quantum_state(state)\nprint(state.get_amplitudes())" > /tmp/sample.py
+          echo -e "from scaluq.f64 import StateVector, gate\nstate = StateVector(2)\nx = gate.X(0)\nx.update_quantum_state(state)\nprint(state.get_amplitudes())" > /tmp/sample.py
           python /tmp/sample.py
           python -m mypy /tmp/sample.py

--- a/README.md
+++ b/README.md
@@ -77,17 +77,17 @@ int main() {
     scaluq::initialize();  // must be called before using any scaluq methods
     {
         const std::uint64_t n_qubits = 3;
-        scaluq::StateVector state = scaluq::StateVector::Haar_random_state(n_qubits, 0);
+        scaluq::StateVector<std::float64_t> state = scaluq::StateVector::Haar_random_state(n_qubits, 0);
         std::cout << state << std::endl;
 
-        scaluq::Circuit circuit(n_qubits);
+        scaluq::Circuit<std::float64_t> circuit(n_qubits);
         circuit.add_gate(scaluq::gate::X(0));
         circuit.add_gate(scaluq::gate::CNot(0, 1));
         circuit.add_gate(scaluq::gate::Y(1));
         circuit.add_gate(scaluq::gate::RX(1, std::numbers::pi / 2));
         circuit.update_quantum_state(state);
 
-        scaluq::Operator observable(n_qubits);
+        scaluq::Operator<std::float64_t> observable(n_qubits);
         observable.add_random_operator(1, 0);
         auto value = observable.get_expectation_value(state);
         std::cout << value << std::endl;
@@ -99,7 +99,7 @@ int main() {
 ## サンプルコード(Python)
 
 ```Python
-from scaluq import *
+from scaluq.f64 import *
 import math
 
 n_qubits = 3
@@ -118,3 +118,14 @@ value = observable.get_expectation_value(state)
 print(value)
 
 ```
+
+# 精度指定について
+scaluqでは、計算に使用する浮動小数点数のサイズとして32bitと64bitが選択できます。
+通常は64bitの使用が推奨されますが、量子機械学習での利用などあまり精度が必要でない場合は32bitを使用すると最大2倍程度の高速化が見込めます。
+
+同じ精度のオブジェクト同士でしか演算を行うことができません。
+例えば32bit用に作成したゲートでは64bitの`StateVector`を更新できません。
+
+C++の場合、状態、ゲート、演算子、回路のクラスやゲートを生成する関数が、テンプレート引数を取るようになっており、そこに`float`または`double`を指定することで選択します。
+
+Pythonの場合、精度に合わせて`scaluq.f32`と`scaluq.f64`のどちらかのサブモジュールからオブジェクトを`import`します。

--- a/README.md
+++ b/README.md
@@ -77,17 +77,17 @@ int main() {
     scaluq::initialize();  // must be called before using any scaluq methods
     {
         const std::uint64_t n_qubits = 3;
-        scaluq::StateVector<std::float64_t> state = scaluq::StateVector::Haar_random_state(n_qubits, 0);
+        scaluq::StateVector<double> state = scaluq::StateVector::Haar_random_state(n_qubits, 0);
         std::cout << state << std::endl;
 
-        scaluq::Circuit<std::float64_t> circuit(n_qubits);
+        scaluq::Circuit<double> circuit(n_qubits);
         circuit.add_gate(scaluq::gate::X(0));
         circuit.add_gate(scaluq::gate::CNot(0, 1));
         circuit.add_gate(scaluq::gate::Y(1));
         circuit.add_gate(scaluq::gate::RX(1, std::numbers::pi / 2));
         circuit.update_quantum_state(state);
 
-        scaluq::Operator<std::float64_t> observable(n_qubits);
+        scaluq::Operator<double> observable(n_qubits);
         observable.add_random_operator(1, 0);
         auto value = observable.get_expectation_value(state);
         std::cout << value << std::endl;

--- a/exe/main.cpp
+++ b/exe/main.cpp
@@ -1,31 +1,28 @@
-#include <Kokkos_Core.hpp>
-#include <functional>
+#include <cstdint>
 #include <iostream>
-#include <memory>
+#include <scaluq/circuit/circuit.hpp>
+#include <scaluq/gate/gate_factory.hpp>
+#include <scaluq/operator/operator.hpp>
 #include <scaluq/state/state_vector.hpp>
-#include <sstream>
-#include <stdexcept>
-#include <type_traits>
-#include <vector>
-
-using Fp = float;
 
 int main() {
-    Kokkos::initialize();
+    scaluq::initialize();  // must be called before using any scaluq methods
     {
-        std::uint64_t n_qubits = 3;
-        scaluq::StateVector<Fp> state(n_qubits);
-        state.load({0, 1, 2, 3, 4, 5, 6, 7});
-        /*
-        auto x_gate = scaluq::gate::X<Fp>(1, {0, 2});
-        x_gate->update_quantum_state(state);
-        auto sqrtx_gate = scaluq::gate::SqrtX<Fp>(1, {0});
-        sqrtx_gate->update_quantum_state(state);
-        auto sqrtxdag_gate = scaluq::gate::SqrtXdag<Fp>(0);
-        sqrtxdag_gate->update_quantum_state(state);
-        */
-
+        const std::uint64_t n_qubits = 3;
+        scaluq::StateVector state = scaluq::StateVector<double>::Haar_random_state(n_qubits, 0);
         std::cout << state << std::endl;
+
+        scaluq::Circuit<double> circuit(n_qubits);
+        circuit.add_gate(scaluq::gate::X<double>(0));
+        circuit.add_gate(scaluq::gate::CNot<double>(0, 1));
+        circuit.add_gate(scaluq::gate::Y<double>(1));
+        circuit.add_gate(scaluq::gate::RX<double>(1, std::numbers::pi / 2));
+        circuit.update_quantum_state(state);
+
+        scaluq::Operator<double> observable(n_qubits);
+        observable.add_random_operator(1, 0);
+        auto value = observable.get_expectation_value(state);
+        std::cout << value << std::endl;
     }
-    Kokkos::finalize();
+    scaluq::finalize();  // must be called last
 }

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -76,42 +76,43 @@ private:
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_circuit_circuit_hpp(nb::module_& m) {
-    nb::class_<Circuit<double>>(m, "Circuit", "Quantum circuit represented as gate array")
+    nb::class_<Circuit<Fp>>(m, "Circuit", "Quantum circuit represented as gate array")
         .def(nb::init<std::uint64_t>(), "Initialize empty circuit of specified qubits.")
-        .def("n_qubits", &Circuit<double>::n_qubits, "Get property of `n_qubits`.")
+        .def("n_qubits", &Circuit<Fp>::n_qubits, "Get property of `n_qubits`.")
         .def("gate_list",
-             &Circuit<double>::gate_list,
+             &Circuit<Fp>::gate_list,
              "Get property of `gate_list`.",
              nb::rv_policy::reference)
-        .def("n_gates", &Circuit<double>::n_gates, "Get property of `n_gates`.")
-        .def("key_set", &Circuit<double>::key_set, "Get set of keys of parameters.")
-        .def("get_gate_at", &Circuit<double>::get_gate_at, "Get reference of i-th gate.")
+        .def("n_gates", &Circuit<Fp>::n_gates, "Get property of `n_gates`.")
+        .def("key_set", &Circuit<Fp>::key_set, "Get set of keys of parameters.")
+        .def("get_gate_at", &Circuit<Fp>::get_gate_at, "Get reference of i-th gate.")
         .def("get_param_key_at",
-             &Circuit<double>::get_param_key_at,
+             &Circuit<Fp>::get_param_key_at,
              "Get parameter key of i-th gate. If it is not parametric, return None.")
-        .def("calculate_depth", &Circuit<double>::calculate_depth, "Get depth of circuit.")
+        .def("calculate_depth", &Circuit<Fp>::calculate_depth, "Get depth of circuit.")
         .def("add_gate",
-             nb::overload_cast<const Gate<double>&>(&Circuit<double>::add_gate),
+             nb::overload_cast<const Gate<Fp>&>(&Circuit<Fp>::add_gate),
              "Add gate. Given gate is copied.")
-        .def("add_param_gate",
-             nb::overload_cast<const ParamGate<double>&, std::string_view>(
-                 &Circuit<double>::add_param_gate),
-             "Add parametric gate with specifing key. Given param_gate is copied.")
+        .def(
+            "add_param_gate",
+            nb::overload_cast<const ParamGate<Fp>&, std::string_view>(&Circuit<Fp>::add_param_gate),
+            "Add parametric gate with specifing key. Given param_gate is copied.")
         .def("add_circuit",
-             nb::overload_cast<const Circuit<double>&>(&Circuit<double>::add_circuit),
+             nb::overload_cast<const Circuit<Fp>&>(&Circuit<Fp>::add_circuit),
              "Add all gates in specified circuit. Given gates are copied.")
         .def("update_quantum_state",
-             &Circuit<double>::update_quantum_state,
+             &Circuit<Fp>::update_quantum_state,
              "Apply gate to the StateVector. StateVector in args is directly updated. If the "
              "circuit contains parametric gate, you have to give real value of parameter as "
              "dict[str, float] in 2nd arg.")
         .def(
             "update_quantum_state",
-            [&](const Circuit<double>& circuit, StateVector<double>& state, nb::kwargs kwargs) {
-                std::map<std::string, double> parameters;
+            [&](const Circuit<Fp>& circuit, StateVector<Fp>& state, nb::kwargs kwargs) {
+                std::map<std::string, Fp> parameters;
                 for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<double>(param);
+                    parameters[nb::cast<std::string>(key)] = nb::cast<Fp>(param);
                 }
                 circuit.update_quantum_state(state, parameters);
             },
@@ -119,12 +120,12 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
             "circuit contains parametric gate, you have to give real value of parameter as "
             "\"name=value\" format in kwargs.")
         .def("update_quantum_state",
-             [](const Circuit<double>& circuit, StateVector<double>& state) {
+             [](const Circuit<Fp>& circuit, StateVector<Fp>& state) {
                  circuit.update_quantum_state(state);
              })
-        .def("copy", &Circuit<double>::copy, "Copy circuit. All the gates inside is copied.")
+        .def("copy", &Circuit<Fp>::copy, "Copy circuit. All the gates inside is copied.")
         .def("get_inverse",
-             &Circuit<double>::get_inverse,
+             &Circuit<Fp>::get_inverse,
              "Get inverse of circuit. All the gates are newly created.");
 }
 }  // namespace internal

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -343,6 +343,7 @@ namespace internal {
             "Get string representation of the gate.")
 
 nb::class_<Gate<double>> gate_base_def_double;
+nb::class_<Gate<float>> gate_base_def_float;
 
 #define DEF_GATE(GATE_TYPE, FLOAT, DESCRIPTION)                                                 \
     ::scaluq::internal::gate_base_def_##FLOAT.def(nb::init<GATE_TYPE<FLOAT>>(),                 \
@@ -354,6 +355,7 @@ nb::class_<Gate<double>> gate_base_def_double;
         "\n\n.. note:: Upcast is required to use gate-general functions (ex: add to Circuit).") \
         .def(nb::init<Gate<FLOAT>>())
 
+template <std::floating_point Fp>
 void bind_gate_gate_hpp(nb::module_& m) {
     nb::enum_<GateType>(m, "GateType", "Enum of Gate Type.")
         .value("I", GateType::I)
@@ -384,12 +386,23 @@ void bind_gate_gate_hpp(nb::module_& m) {
         .value("Pauli", GateType::Pauli)
         .value("PauliRotation", GateType::PauliRotation);
 
-    gate_base_def_double =
-        DEF_GATE_BASE(Gate,
-                      double,
-                      "General class of QuantumGate.\n\n.. note:: Downcast to requred to use "
-                      "gate-specific functions.")
-            .def(nb::init<Gate<double>>(), "Just copy shallowly.");
+    if constexpr (std::is_same_v<Fp, double>) {
+        gate_base_def_double =
+            DEF_GATE_BASE(Gate,
+                          double,
+                          "General class of QuantumGate.\n\n.. note:: Downcast to requred to use "
+                          "gate-specific functions.")
+                .def(nb::init<Gate<double>>(), "Just copy shallowly.");
+    } else if constexpr (std::is_same_v<Fp, float>) {
+        gate_base_def_float =
+            DEF_GATE_BASE(Gate,
+                          float,
+                          "General class of QuantumGate.\n\n.. note:: Downcast to requred to use "
+                          "gate-specific functions.")
+                .def(nb::init<Gate<float>>(), "Just copy shallowly.");
+    } else {
+        static_assert(internal::lazy_false_v<void>);
+    }
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -342,12 +342,12 @@ namespace internal {
             [](const GATE_TYPE<FLOAT>& gate) { return gate->to_string(""); },                \
             "Get string representation of the gate.")
 
-nb::class_<Gate<double>> gate_base_def_double;
-nb::class_<Gate<float>> gate_base_def_float;
+template <std::floating_point Fp>
+nb::class_<Gate<Fp>> gate_base_def;
 
 #define DEF_GATE(GATE_TYPE, FLOAT, DESCRIPTION)                                                 \
-    ::scaluq::internal::gate_base_def_##FLOAT.def(nb::init<GATE_TYPE<FLOAT>>(),                 \
-                                                  "Upcast from `" #GATE_TYPE "`.");             \
+    ::scaluq::internal::gate_base_def<FLOAT>.def(nb::init<GATE_TYPE<FLOAT>>(),                  \
+                                                 "Upcast from `" #GATE_TYPE "`.");              \
     DEF_GATE_BASE(                                                                              \
         GATE_TYPE,                                                                              \
         FLOAT,                                                                                  \
@@ -355,8 +355,7 @@ nb::class_<Gate<float>> gate_base_def_float;
         "\n\n.. note:: Upcast is required to use gate-general functions (ex: add to Circuit).") \
         .def(nb::init<Gate<FLOAT>>())
 
-template <std::floating_point Fp>
-void bind_gate_gate_hpp(nb::module_& m) {
+void bind_gate_gate_hpp_without_precision(nb::module_& m) {
     nb::enum_<GateType>(m, "GateType", "Enum of Gate Type.")
         .value("I", GateType::I)
         .value("GlobalPhase", GateType::GlobalPhase)
@@ -385,24 +384,16 @@ void bind_gate_gate_hpp(nb::module_& m) {
         .value("TwoTargetMatrix", GateType::TwoTargetMatrix)
         .value("Pauli", GateType::Pauli)
         .value("PauliRotation", GateType::PauliRotation);
+}
 
-    if constexpr (std::is_same_v<Fp, double>) {
-        gate_base_def_double =
-            DEF_GATE_BASE(Gate,
-                          double,
-                          "General class of QuantumGate.\n\n.. note:: Downcast to requred to use "
-                          "gate-specific functions.")
-                .def(nb::init<Gate<double>>(), "Just copy shallowly.");
-    } else if constexpr (std::is_same_v<Fp, float>) {
-        gate_base_def_float =
-            DEF_GATE_BASE(Gate,
-                          float,
-                          "General class of QuantumGate.\n\n.. note:: Downcast to requred to use "
-                          "gate-specific functions.")
-                .def(nb::init<Gate<float>>(), "Just copy shallowly.");
-    } else {
-        static_assert(internal::lazy_false_v<void>);
-    }
+template <std::floating_point Fp>
+void bind_gate_gate_hpp(nb::module_& m) {
+    gate_base_def<Fp> =
+        DEF_GATE_BASE(Gate,
+                      Fp,
+                      "General class of QuantumGate.\n\n.. note:: Downcast to requred to use "
+                      "gate-specific functions.")
+            .def(nb::init<Gate<Fp>>(), "Just copy shallowly.");
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/gate/gate_factory.hpp
+++ b/include/scaluq/gate/gate_factory.hpp
@@ -251,116 +251,117 @@ inline Gate<Fp> Probablistic(const std::vector<Fp>& distribution,
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_gate_gate_factory_hpp(nb::module_& mgate) {
-    mgate.def("I", &gate::I<double>, "Generate general Gate class instance of I.");
+    mgate.def("I", &gate::I<Fp>, "Generate general Gate class instance of I.");
     mgate.def("GlobalPhase",
-              &gate::GlobalPhase<double>,
+              &gate::GlobalPhase<Fp>,
               "Generate general Gate class instance of GlobalPhase.",
               "phase"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("X",
-              &gate::X<double>,
+              &gate::X<Fp>,
               "Generate general Gate class instance of X.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("Y",
-              &gate::Y<double>,
+              &gate::Y<Fp>,
               "Generate general Gate class instance of Y.",
               "taget"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("Z",
-              &gate::Z<double>,
+              &gate::Z<Fp>,
               "Generate general Gate class instance of Z.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("H",
-              &gate::H<double>,
+              &gate::H<Fp>,
               "Generate general Gate class instance of H.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("S",
-              &gate::S<double>,
+              &gate::S<Fp>,
               "Generate general Gate class instance of S.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("Sdag",
-              &gate::Sdag<double>,
+              &gate::Sdag<Fp>,
               "Generate general Gate class instance of Sdag.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("T",
-              &gate::T<double>,
+              &gate::T<Fp>,
               "Generate general Gate class instance of T.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("Tdag",
-              &gate::Tdag<double>,
+              &gate::Tdag<Fp>,
               "Generate general Gate class instance of Tdag.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("SqrtX",
-              &gate::SqrtX<double>,
+              &gate::SqrtX<Fp>,
               "Generate general Gate class instance of SqrtX.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("SqrtXdag",
-              &gate::SqrtXdag<double>,
+              &gate::SqrtXdag<Fp>,
               "Generate general Gate class instance of SqrtXdag.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("SqrtY",
-              &gate::SqrtY<double>,
+              &gate::SqrtY<Fp>,
               "Generate general Gate class instance of SqrtY.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("SqrtYdag",
-              &gate::SqrtYdag<double>,
+              &gate::SqrtYdag<Fp>,
               "Generate general Gate class instance of SqrtYdag.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("P0",
-              &gate::P0<double>,
+              &gate::P0<Fp>,
               "Generate general Gate class instance of P0.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("P1",
-              &gate::P1<double>,
+              &gate::P1<Fp>,
               "Generate general Gate class instance of P1.",
               "target"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("RX",
-              &gate::RX<double>,
+              &gate::RX<Fp>,
               "Generate general Gate class instance of RX.",
               "target"_a,
               "angle"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("RY",
-              &gate::RY<double>,
+              &gate::RY<Fp>,
               "Generate general Gate class instance of RY.",
               "target"_a,
               "angle"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("RZ",
-              &gate::RZ<double>,
+              &gate::RZ<Fp>,
               "Generate general Gate class instance of RZ.",
               "target"_a,
               "angle"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("U1",
-              &gate::U1<double>,
+              &gate::U1<Fp>,
               "Generate general Gate class instance of U1.",
               "target"_a,
               "lambda_"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("U2",
-              &gate::U2<double>,
+              &gate::U2<Fp>,
               "Generate general Gate class instance of U2.",
               "target"_a,
               "phi"_a,
               "lambda_"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("U3",
-              &gate::U3<double>,
+              &gate::U3<Fp>,
               "Generate general Gate class instance of U3.",
               "target"_a,
               "theta"_a,
@@ -368,73 +369,73 @@ void bind_gate_gate_factory_hpp(nb::module_& mgate) {
               "lambda_"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("Swap",
-              &gate::Swap<double>,
+              &gate::Swap<Fp>,
               "Generate general Gate class instance of Swap.",
               "target1"_a,
               "target2"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def(
         "CX",
-        &gate::CX<double>,
+        &gate::CX<Fp>,
         "Generate general Gate class instance of CX.\n\n.. note:: CX is a specialization of X.");
     mgate.def("CNot",
-              &gate::CX<double>,
+              &gate::CX<Fp>,
               "Generate general Gate class instance of CNot.\n\n.. note:: CNot is an alias of CX.");
     mgate.def(
         "CZ",
-        &gate::CZ<double>,
+        &gate::CZ<Fp>,
         "Generate general Gate class instance of CZ.\n\n.. note:: CZ is a specialization of Z.");
     mgate.def(
         "CCX",
-        &gate::CCX<double>,
+        &gate::CCX<Fp>,
         "Generate general Gate class instance of CXX.\n\n.. note:: CX is a specialization of X.");
     mgate.def(
         "CCNot",
-        &gate::CCX<double>,
+        &gate::CCX<Fp>,
         "Generate general Gate class instance of CCNot.\n\n.. note:: CCNot is an alias of CCX.");
     mgate.def("Toffoli",
-              &gate::CCX<double>,
+              &gate::CCX<Fp>,
               "Generate general Gate class instance of Toffoli.\n\n.. note:: Toffoli is an alias "
               "of CCX.");
     mgate.def("OneTargetMatrix",
-              &gate::OneTargetMatrix<double>,
+              &gate::OneTargetMatrix<Fp>,
               "Generate general Gate class instance of OneTargetMatrix.",
               "target"_a,
               "matrix"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("TwoTargetMatrix",
-              &gate::TwoTargetMatrix<double>,
+              &gate::TwoTargetMatrix<Fp>,
               "Generate general Gate class instance of TwoTargetMatrix.",
               "target1"_a,
               "target2"_a,
               "matrix"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("DenseMatrix",
-              &gate::DenseMatrix<double>,
+              &gate::DenseMatrix<Fp>,
               "Generate general Gate class instance of DenseMatrix.",
               "targets"_a,
               "matrix"_a,
               "controls"_a = std::vector<std::uint64_t>{},
               "is_unitary"_a = false);
     mgate.def("SparseMatrix",
-              &gate::SparseMatrix<double>,
+              &gate::SparseMatrix<Fp>,
               "Generate general Gate class instance of SparseMatrix.",
               "targets"_a,
               "matrix"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("Pauli",
-              &gate::Pauli<double>,
+              &gate::Pauli<Fp>,
               "Generate general Gate class instance of Pauli.",
               "pauli"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("PauliRotation",
-              &gate::PauliRotation<double>,
+              &gate::PauliRotation<Fp>,
               "Generate general Gate class instance of PauliRotation.",
               "pauli"_a,
               "angle"_a,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("Probablistic",
-              &gate::Probablistic<double>,
+              &gate::Probablistic<Fp>,
               "Generate general Gate class instance of Probablistic.",
               "distribution"_a,
               "gate_list"_a);

--- a/include/scaluq/gate/gate_factory.hpp
+++ b/include/scaluq/gate/gate_factory.hpp
@@ -155,7 +155,9 @@ inline Gate<Fp> CX(std::uint64_t control, std::uint64_t target) {
         internal::vector_to_mask({target}), internal::vector_to_mask({control}));
 }
 template <std::floating_point Fp>
-inline auto& CNot = CX;
+inline Gate<Fp> CNot(std::uint64_t control, std::uint64_t target) {
+    return CX<Fp>(control, target);
+}
 template <std::floating_point Fp>
 inline Gate<Fp> CZ(std::uint64_t control, std::uint64_t target) {
     return internal::GateFactory::create_gate<internal::ZGateImpl<Fp>>(

--- a/include/scaluq/gate/gate_matrix.hpp
+++ b/include/scaluq/gate/gate_matrix.hpp
@@ -147,17 +147,18 @@ using DenseMatrixGate = internal::GatePtr<internal::DenseMatrixGateImpl<Fp>>;
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_gate_gate_matrix_hpp(nb::module_& m) {
-    DEF_GATE(OneTargetMatrixGate, double, "Specific class of one-qubit dense matrix gate.")
+    DEF_GATE(OneTargetMatrixGate, Fp, "Specific class of one-qubit dense matrix gate.")
         .def("matrix", [](const OneTargetMatrixGate<double>& gate) { return gate->matrix(); });
-    DEF_GATE(TwoTargetMatrixGate, double, "Specific class of two-qubit dense matrix gate.")
+    DEF_GATE(TwoTargetMatrixGate, Fp, "Specific class of two-qubit dense matrix gate.")
         .def("matrix", [](const TwoTargetMatrixGate<double>& gate) { return gate->matrix(); });
-    DEF_GATE(SparseMatrixGate, double, "Specific class of sparse matrix gate.")
+    DEF_GATE(SparseMatrixGate, Fp, "Specific class of sparse matrix gate.")
         .def("matrix", [](const SparseMatrixGate<double>& gate) { return gate->get_matrix(); })
         .def("sparse_matrix",
-             [](const SparseMatrixGate<double>& gate) { return gate->get_sparse_matrix(); });
-    DEF_GATE(DenseMatrixGate, double, "Specific class of dense matrix gate.")
-        .def("matrix", [](const DenseMatrixGate<double>& gate) { return gate->get_matrix(); });
+             [](const SparseMatrixGate<Fp>& gate) { return gate->get_sparse_matrix(); });
+    DEF_GATE(DenseMatrixGate, Fp, "Specific class of dense matrix gate.")
+        .def("matrix", [](const DenseMatrixGate<Fp>& gate) { return gate->get_matrix(); });
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/gate/gate_pauli.hpp
+++ b/include/scaluq/gate/gate_pauli.hpp
@@ -66,14 +66,15 @@ using PauliRotationGate = internal::GatePtr<internal::PauliRotationGateImpl<Fp>>
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_gate_gate_pauli_hpp(nb::module_& m) {
     DEF_GATE(PauliGate,
-             double,
+             Fp,
              "Specific class of multi-qubit pauli gate, which applies single-qubit Pauli "
              "gate to "
              "each of qubit.");
     DEF_GATE(PauliRotationGate,
-             double,
+             Fp,
              "Specific class of multi-qubit pauli-rotation gate, represented as "
              "$e^{-i\\frac{\\mathrm{angle}}{2}P}$.");
 }

--- a/include/scaluq/gate/gate_probablistic.hpp
+++ b/include/scaluq/gate/gate_probablistic.hpp
@@ -67,18 +67,19 @@ using ProbablisticGate = internal::GatePtr<internal::ProbablisticGateImpl<Fp>>;
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_gate_gate_probablistic(nb::module_& m) {
     DEF_GATE(ProbablisticGate,
-             double,
+             Fp,
              "Specific class of probablistic gate. The gate to apply is picked from a cirtain "
              "distribution.")
         .def(
             "gate_list",
-            [](const ProbablisticGate<double>& gate) { return gate->gate_list(); },
+            [](const ProbablisticGate<Fp>& gate) { return gate->gate_list(); },
             nb::rv_policy::reference)
         .def(
             "distribution",
-            [](const ProbablisticGate<double>& gate) { return gate->distribution(); },
+            [](const ProbablisticGate<Fp>& gate) { return gate->distribution(); },
             nb::rv_policy::reference);
 }
 }  // namespace internal

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -466,48 +466,49 @@ using SwapGate = internal::GatePtr<internal::SwapGateImpl<Fp>>;
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_gate_gate_standard_hpp(nb::module_& m) {
-    DEF_GATE(IGate, double, "Specific class of Pauli-I gate.");
+    DEF_GATE(IGate, Fp, "Specific class of Pauli-I gate.");
     DEF_GATE(GlobalPhaseGate,
-             double,
+             Fp,
              "Specific class of gate, which rotate global phase, represented as "
              "$e^{i\\mathrm{phase}}I$.")
         .def(
             "phase",
-            [](const GlobalPhaseGate<double>& gate) { return gate->phase(); },
+            [](const GlobalPhaseGate<Fp>& gate) { return gate->phase(); },
             "Get `phase` property");
-    DEF_GATE(XGate, double, "Specific class of Pauli-X gate.");
-    DEF_GATE(YGate, double, "Specific class of Pauli-Y gate.");
-    DEF_GATE(ZGate, double, "Specific class of Pauli-Z gate.");
-    DEF_GATE(HGate, double, "Specific class of Hadamard gate.");
+    DEF_GATE(XGate, Fp, "Specific class of Pauli-X gate.");
+    DEF_GATE(YGate, Fp, "Specific class of Pauli-Y gate.");
+    DEF_GATE(ZGate, Fp, "Specific class of Pauli-Z gate.");
+    DEF_GATE(HGate, Fp, "Specific class of Hadamard gate.");
     DEF_GATE(SGate,
-             double,
+             Fp,
              "Specific class of S gate, represented as $\\begin { bmatrix }\n1 & 0\\\\\n0 &"
              "i\n\\end{bmatrix}$.");
-    DEF_GATE(SdagGate, double, "Specific class of inverse of S gate.");
+    DEF_GATE(SdagGate, Fp, "Specific class of inverse of S gate.");
     DEF_GATE(TGate,
-             double,
+             Fp,
              "Specific class of T gate, represented as $\\begin { bmatrix }\n1 & 0\\\\\n0 &"
              "e^{i\\pi/4}\n\\end{bmatrix}$.");
-    DEF_GATE(TdagGate, double, "Specific class of inverse of T gate.");
+    DEF_GATE(TdagGate, Fp, "Specific class of inverse of T gate.");
     DEF_GATE(
         SqrtXGate,
-        double,
+        Fp,
         "Specific class of sqrt(X) gate, represented as $\\begin{ bmatrix }\n1+i & 1-i\\\\\n1-i "
         "& 1+i\n\\end{bmatrix}$.");
-    DEF_GATE(SqrtXdagGate, double, "Specific class of inverse of sqrt(X) gate.");
+    DEF_GATE(SqrtXdagGate, Fp, "Specific class of inverse of sqrt(X) gate.");
     DEF_GATE(SqrtYGate,
-             double,
+             Fp,
              "Specific class of sqrt(Y) gate, represented as $\\begin{ bmatrix }\n1+i & -1-i "
              "\\\\\n1+i & 1+i\n\\end{bmatrix}$.");
-    DEF_GATE(SqrtYdagGate, double, "Specific class of inverse of sqrt(Y) gate.");
+    DEF_GATE(SqrtYdagGate, Fp, "Specific class of inverse of sqrt(Y) gate.");
     DEF_GATE(
         P0Gate,
-        double,
+        Fp,
         "Specific class of projection gate to $\\ket{0}$.\n\n.. note:: This gate is not unitary.");
     DEF_GATE(
         P1Gate,
-        double,
+        Fp,
         "Specific class of projection gate to $\\ket{1}$.\n\n.. note:: This gate is not unitary.");
 
 #define DEF_ROTATION_GATE(GATE_TYPE, FLOAT, DESCRIPTION)                \
@@ -519,40 +520,40 @@ void bind_gate_gate_standard_hpp(nb::module_& m) {
 
     DEF_ROTATION_GATE(
         RXGate,
-        double,
+        Fp,
         "Specific class of X rotation gate, represented as $e^{-i\\frac{\\mathrm{angle}}{2}X}$.");
     DEF_ROTATION_GATE(
         RYGate,
-        double,
+        Fp,
         "Specific class of Y rotation gate, represented as $e^{-i\\frac{\\mathrm{angle}}{2}Y}$.");
     DEF_ROTATION_GATE(
         RZGate,
-        double,
+        Fp,
         "Specific class of Z rotation gate, represented as $e^{-i\\frac{\\mathrm{angle}}{2}Z}$.");
 
     DEF_GATE(U1Gate,
-             double,
+             Fp,
              "Specific class of IBMQ's U1 Gate, which is a rotation abount Z-axis, "
              "represented as "
              "$\\begin{bmatrix}\n1 & 0\\\\\n0 & e^{i\\lambda}\n\\end{bmatrix}$.")
         .def(
             "lambda_",
-            [](const U1Gate<double>& gate) { return gate->lambda(); },
+            [](const U1Gate<Fp>& gate) { return gate->lambda(); },
             "Get `lambda` property.");
     DEF_GATE(U2Gate,
-             double,
+             Fp,
              "Specific class of IBMQ's U2 Gate, which is a rotation about X+Z-axis, "
              "represented as "
              "$\\frac{1}{\\sqrt{2}} \\begin{bmatrix}1 & -e^{-i\\lambda}\\\\\n"
              "e^{i\\phi} & e^{i(\\phi+\\lambda)}\n\\end{bmatrix}$.")
         .def(
-            "phi", [](const U2Gate<double>& gate) { return gate->phi(); }, "Get `phi` property.")
+            "phi", [](const U2Gate<Fp>& gate) { return gate->phi(); }, "Get `phi` property.")
         .def(
             "lambda_",
-            [](const U2Gate<double>& gate) { return gate->lambda(); },
+            [](const U2Gate<Fp>& gate) { return gate->lambda(); },
             "Get `lambda` property.");
     DEF_GATE(U3Gate,
-             double,
+             Fp,
              "Specific class of IBMQ's U3 Gate, which is a rotation abount 3 axis, "
              "represented as "
              "$\\begin{bmatrix}\n\\cos \\frac{\\theta}{2} & "
@@ -560,16 +561,14 @@ void bind_gate_gate_standard_hpp(nb::module_& m) {
              "e^{i\\phi}\\sin\\frac{\\theta}{2} & "
              "e^{i(\\phi+\\lambda)}\\cos\\frac{\\theta}{2}\n\\end{bmatrix}$.")
         .def(
-            "theta",
-            [](const U3Gate<double>& gate) { return gate->theta(); },
-            "Get `theta` property.")
+            "theta", [](const U3Gate<Fp>& gate) { return gate->theta(); }, "Get `theta` property.")
         .def(
-            "phi", [](const U3Gate<double>& gate) { return gate->phi(); }, "Get `phi` property.")
+            "phi", [](const U3Gate<Fp>& gate) { return gate->phi(); }, "Get `phi` property.")
         .def(
             "lambda_",
-            [](const U3Gate<double>& gate) { return gate->lambda(); },
+            [](const U3Gate<Fp>& gate) { return gate->lambda(); },
             "Get `lambda` property.");
-    DEF_GATE(SwapGate, double, "Specific class of two-qubit swap gate.");
+    DEF_GATE(SwapGate, Fp, "Specific class of two-qubit swap gate.");
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/gate/param_gate.hpp
+++ b/include/scaluq/gate/param_gate.hpp
@@ -218,12 +218,12 @@ namespace internal {
             },                                                                                    \
             "Get matrix representation of the gate with holding the parameter.")
 
-nb::class_<ParamGate<double>> param_gate_base_def_double;
-nb::class_<ParamGate<float>> param_gate_base_def_float;
+template <std::floating_point Fp>
+nb::class_<ParamGate<Fp>> param_gate_base_def;
 
 #define DEF_PARAM_GATE(PARAM_GATE_TYPE, FLOAT, DESCRIPTION)                                     \
-    ::scaluq::internal::param_gate_base_def_##FLOAT.def(nb::init<PARAM_GATE_TYPE<FLOAT>>(),     \
-                                                        "Upcast from `" #PARAM_GATE_TYPE "`."); \
+    ::scaluq::internal::param_gate_base_def<Fp>.def(nb::init<PARAM_GATE_TYPE<FLOAT>>(),         \
+                                                    "Upcast from `" #PARAM_GATE_TYPE "`.");     \
     DEF_PARAM_GATE_BASE(                                                                        \
         PARAM_GATE_TYPE,                                                                        \
         FLOAT,                                                                                  \
@@ -231,33 +231,23 @@ nb::class_<ParamGate<float>> param_gate_base_def_float;
         "\n\n.. note:: Upcast is required to use gate-general functions (ex: add to Circuit).") \
         .def(nb::init<ParamGate<FLOAT>>())
 
-template <std::floating_point Fp>
-void bind_gate_param_gate_hpp(nb::module_& m) {
+void bind_gate_param_gate_hpp_without_precision(nb::module_& m) {
     nb::enum_<ParamGateType>(m, "ParamGateType", "Enum of ParamGate Type.")
         .value("ParamRX", ParamGateType::ParamRX)
         .value("ParamRY", ParamGateType::ParamRY)
         .value("ParamRZ", ParamGateType::ParamRZ)
         .value("ParamPauliRotation", ParamGateType::ParamPauliRotation);
+}
 
-    if constexpr (std::is_same_v<Fp, double>) {
-        param_gate_base_def_double =
-            DEF_PARAM_GATE_BASE(
-                ParamGate,
-                double,
-                "General class of parametric quantum gate.\n\n.. note:: Downcast to requred to use "
-                "gate-specific functions.")
-                .def(nb::init<ParamGate<double>>(), "Just copy shallowly.");
-    } else if constexpr (std::is_same_v<Fp, float>) {
-        param_gate_base_def_float =
-            DEF_PARAM_GATE_BASE(
-                ParamGate,
-                float,
-                "General class of parametric quantum gate.\n\n.. note:: Downcast to requred to use "
-                "gate-specific functions.")
-                .def(nb::init<ParamGate<float>>(), "Just copy shallowly.");
-    } else {
-        static_asert(internal::lazy_false_v<void>);
-    }
+template <std::floating_point Fp>
+void bind_gate_param_gate_hpp(nb::module_& m) {
+    param_gate_base_def<Fp> =
+        DEF_PARAM_GATE_BASE(
+            ParamGate,
+            Fp,
+            "General class of parametric quantum gate.\n\n.. note:: Downcast to requred to use "
+            "gate-specific functions.")
+            .def(nb::init<ParamGate<Fp>>(), "Just copy shallowly.");
 }
 
 }  // namespace internal

--- a/include/scaluq/gate/param_gate_factory.hpp
+++ b/include/scaluq/gate/param_gate_factory.hpp
@@ -54,47 +54,48 @@ inline ParamGate<Fp> ParamProbablistic(
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_gate_param_gate_factory(nb::module_& mgate) {
     mgate.def("ParamRX",
-              &gate::ParamRX<double>,
+              &gate::ParamRX<Fp>,
               "Generate general ParamGate class instance of ParamRX.",
               "target"_a,
               "coef"_a = 1.,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("ParamRY",
-              &gate::ParamRY<double>,
+              &gate::ParamRY<Fp>,
               "Generate general ParamGate class instance of ParamRY.",
               "target"_a,
               "coef"_a = 1.,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("ParamRZ",
-              &gate::ParamRZ<double>,
+              &gate::ParamRZ<Fp>,
               "Generate general ParamGate class instance of ParamRZ.",
               "target"_a,
               "coef"_a = 1.,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("ParamPauliRotation",
-              &gate::ParamPauliRotation<double>,
+              &gate::ParamPauliRotation<Fp>,
               "Generate general ParamGate class instance of ParamPauliRotation.",
               "pauli"_a,
               "coef"_a = 1.,
               "controls"_a = std::vector<std::uint64_t>{});
     mgate.def("ParamProbablistic",
-              &gate::ParamProbablistic<double>,
+              &gate::ParamProbablistic<Fp>,
               "Generate general ParamGate class instance of ParamProbablistic.");
     mgate.def(
         "ParamProbablistic",
-        [](const std::vector<std::pair<double, std::variant<Gate<double>, ParamGate<double>>>>&
+        [](const std::vector<std::pair<Fp, std::variant<Gate<Fp>, ParamGate<Fp>>>>&
                prob_gate_list) {
-            std::vector<double> distribution;
-            std::vector<std::variant<Gate<double>, ParamGate<double>>> gate_list;
+            std::vector<Fp> distribution;
+            std::vector<std::variant<Gate<Fp>, ParamGate<Fp>>> gate_list;
             distribution.reserve(prob_gate_list.size());
             gate_list.reserve(prob_gate_list.size());
             for (const auto& [prob, gate] : prob_gate_list) {
                 distribution.push_back(prob);
                 gate_list.push_back(gate);
             }
-            return gate::ParamProbablistic<double>(distribution, gate_list);
+            return gate::ParamProbablistic<Fp>(distribution, gate_list);
         },
         "Generate general ParamGate class instance of ParamProbablistic.");
 }

--- a/include/scaluq/gate/param_gate_pauli.hpp
+++ b/include/scaluq/gate/param_gate_pauli.hpp
@@ -38,10 +38,11 @@ using ParamPauliRotationGate = internal::ParamGatePtr<internal::ParamPauliRotati
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_gate_param_gate_pauli_hpp(nb::module_& m) {
     DEF_PARAM_GATE(
         ParamPauliRotationGate,
-        double,
+        Fp,
         "Specific class of parametric multi-qubit pauli-rotation gate, represented as "
         "$e^{-i\\frac{\\mathrm{angle}}{2}P}$. `angle` is given as `param * param_coef`.");
 }

--- a/include/scaluq/gate/param_gate_probablistic.hpp
+++ b/include/scaluq/gate/param_gate_probablistic.hpp
@@ -70,20 +70,21 @@ using ParamProbablisticGate = internal::ParamGatePtr<internal::ParamProbablistic
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_gate_param_gate_probablistic_hpp(nb::module_& m) {
     DEF_PARAM_GATE(
         ParamProbablisticGate,
-        double,
+        Fp,
         "Specific class of parametric probablistic gate. The gate to apply is picked from a "
         "cirtain "
         "distribution.")
         .def(
             "gate_list",
-            [](const ParamProbablisticGate<double>& gate) { return gate->gate_list(); },
+            [](const ParamProbablisticGate<Fp>& gate) { return gate->gate_list(); },
             nb::rv_policy::reference)
         .def(
             "distribution",
-            [](const ParamProbablisticGate<double>& gate) { return gate->distribution(); },
+            [](const ParamProbablisticGate<Fp>& gate) { return gate->distribution(); },
             nb::rv_policy::reference);
 }
 }  // namespace internal

--- a/include/scaluq/gate/param_gate_standard.hpp
+++ b/include/scaluq/gate/param_gate_standard.hpp
@@ -66,20 +66,21 @@ using ParamRZGate = internal::ParamGatePtr<internal::ParamRZGateImpl<Fp>>;
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_gate_param_gate_standard_hpp(nb::module_& m) {
     DEF_PARAM_GATE(
         ParamRXGate,
-        double,
+        Fp,
         "Specific class of parametric X rotation gate, represented as "
         "$e^{-i\\frac{\\mathrm{angle}}{2}X}$. `angle` is given as `param * param_coef`.");
     DEF_PARAM_GATE(
         ParamRYGate,
-        double,
+        Fp,
         "Specific class of parametric Y rotation gate, represented as "
         "$e^{-i\\frac{\\mathrm{angle}}{2}Y}$. `angle` is given as `param * param_coef`.");
     DEF_PARAM_GATE(
         ParamRZGate,
-        double,
+        Fp,
         "Specific class of parametric Z rotation gate, represented as "
         "$e^{-i\\frac{\\mathrm{angle}}{2}Z}$. `angle` is given as `param * param_coef`.");
 }

--- a/include/scaluq/kokkos.hpp
+++ b/include/scaluq/kokkos.hpp
@@ -5,4 +5,20 @@ void initialize();
 void finalize();
 bool is_initialized();
 bool is_finalized();
+
+#ifdef SCALUQ_USE_NANOBIND
+namespace internal {
+void bind_kokkos_hpp(nb::module_& m) {
+    m.def("finalize",
+          &finalize,
+          "Terminate the Kokkos execution environment. Release the resources.\n\n.. note:: "
+          "Finalization fails if there exists `StateVector` allocated. You must use "
+          "`StateVector` only inside inner scopes than the usage of `finalize` or delete all of "
+          "existing `StateVector`.\n\n.. note:: This is "
+          "automatically called when the program exits. If you call this manually, you cannot use "
+          "most of scaluq's functions until the program exits.");
+    m.def("is_finalized", &is_initialized, "Return true if `finalize()` is already called.");
+}
+}  // namespace internal
+#endif
 }  // namespace scaluq

--- a/include/scaluq/operator/operator.hpp
+++ b/include/scaluq/operator/operator.hpp
@@ -71,28 +71,23 @@ private:
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_operator_operator_hpp(nb::module_& m) {
-    nb::class_<Operator<double>>(m, "Operator", "General quantum operator class.")
+    nb::class_<Operator<Fp>>(m, "Operator", "General quantum operator class.")
         .def(nb::init<std::uint64_t>(),
              "qubit_count"_a,
              "Initialize operator with specified number of qubits.")
-        .def("is_hermitian", &Operator<double>::is_hermitian, "Check if the operator is Hermitian.")
-        .def("n_qubits",
-             &Operator<double>::n_qubits,
-             "Get the number of qubits the operator acts on.")
-        .def("terms",
-             &Operator<double>::terms,
-             "Get the list of Pauli terms that make up the operator.")
+        .def("is_hermitian", &Operator<Fp>::is_hermitian, "Check if the operator is Hermitian.")
+        .def("n_qubits", &Operator<Fp>::n_qubits, "Get the number of qubits the operator acts on.")
         .def(
-            "to_string", &Operator<double>::to_string, "Get string representation of the operator.")
+            "terms", &Operator<Fp>::terms, "Get the list of Pauli terms that make up the operator.")
+        .def("to_string", &Operator<Fp>::to_string, "Get string representation of the operator.")
         .def("add_operator",
-             nb::overload_cast<const PauliOperator<double>&>(&Operator<double>::add_operator),
+             nb::overload_cast<const PauliOperator<Fp>&>(&Operator<Fp>::add_operator),
              "Add a Pauli operator to this operator.")
         .def(
             "add_random_operator",
-            [](Operator<double>& op,
-               std::uint64_t operator_count,
-               std::optional<std::uint64_t> seed) {
+            [](Operator<Fp>& op, std::uint64_t operator_count, std::optional<std::uint64_t> seed) {
                 return op.add_random_operator(operator_count,
                                               seed.value_or(std::random_device{}()));
             },
@@ -101,23 +96,21 @@ void bind_operator_operator_hpp(nb::module_& m) {
             "Add a specified number of random Pauli operators to this operator. An optional "
             "seed "
             "can be provided for reproducibility.")
-        .def("optimize",
-             &Operator<double>::optimize,
-             "Optimize the operator by combining like terms.")
+        .def("optimize", &Operator<Fp>::optimize, "Optimize the operator by combining like terms.")
         .def("get_dagger",
-             &Operator<double>::get_dagger,
+             &Operator<Fp>::get_dagger,
              "Get the adjoint (Hermitian conjugate) of the operator.")
         .def("apply_to_state",
-             &Operator<double>::apply_to_state,
+             &Operator<Fp>::apply_to_state,
              "Apply the operator to a state vector.")
         .def("get_expectation_value",
-             &Operator<double>::get_expectation_value,
+             &Operator<Fp>::get_expectation_value,
              "Get the expectation value of the operator with respect to a state vector.")
         .def("get_transition_amplitude",
-             &Operator<double>::get_transition_amplitude,
+             &Operator<Fp>::get_transition_amplitude,
              "Get the transition amplitude of the operator between two state vectors.")
-        .def(nb::self *= Complex<double>())
-        .def(nb::self * Complex<double>())
+        .def(nb::self *= Complex<Fp>())
+        .def(nb::self * Complex<Fp>())
         .def(+nb::self)
         .def(-nb::self)
         .def(nb::self += nb::self)
@@ -126,12 +119,12 @@ void bind_operator_operator_hpp(nb::module_& m) {
         .def(nb::self - nb::self)
         .def(nb::self * nb::self)
         .def(nb::self *= nb::self)
-        .def(nb::self += PauliOperator<double>())
-        .def(nb::self + PauliOperator<double>())
-        .def(nb::self -= PauliOperator<double>())
-        .def(nb::self - PauliOperator<double>())
-        .def(nb::self *= PauliOperator<double>())
-        .def(nb::self * PauliOperator<double>());
+        .def(nb::self += PauliOperator<Fp>())
+        .def(nb::self + PauliOperator<Fp>())
+        .def(nb::self -= PauliOperator<Fp>())
+        .def(nb::self - PauliOperator<Fp>())
+        .def(nb::self *= PauliOperator<Fp>())
+        .def(nb::self * PauliOperator<Fp>());
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/operator/pauli_operator.hpp
+++ b/include/scaluq/operator/pauli_operator.hpp
@@ -100,89 +100,86 @@ public:
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_operator_pauli_operator_hpp(nb::module_& m) {
-    nb::enum_<PauliOperator<double>::PauliID>(m, "PauliID")
-        .value("I", PauliOperator<double>::I)
-        .value("X", PauliOperator<double>::X)
-        .value("Y", PauliOperator<double>::Y)
-        .value("Z", PauliOperator<double>::Z)
+    nb::enum_<typename PauliOperator<Fp>::PauliID>(m, "PauliID")
+        .value("I", PauliOperator<Fp>::I)
+        .value("X", PauliOperator<Fp>::X)
+        .value("Y", PauliOperator<Fp>::Y)
+        .value("Z", PauliOperator<Fp>::Z)
         .export_values();
 
-    nb::class_<PauliOperator<double>::Data>(
+    nb::class_<typename PauliOperator<Fp>::Data>(
         m, "PauliOperatorData", "Internal data structure for PauliOperator.")
-        .def(nb::init<Complex<double>>(), "coef"_a = 1., "Initialize data with coefficient.")
-        .def(nb::init<std::string_view, Complex<double>>(),
+        .def(nb::init<Complex<Fp>>(), "coef"_a = 1., "Initialize data with coefficient.")
+        .def(nb::init<std::string_view, Complex<Fp>>(),
              "pauli_string"_a,
              "coef"_a = 1.,
              "Initialize data with pauli string.")
         .def(nb::init<const std::vector<std::uint64_t>&,
                       const std::vector<std::uint64_t>&,
-                      Complex<double>>(),
+                      Complex<Fp>>(),
              "target_qubit_list"_a,
              "pauli_id_list"_a,
              "coef"_a = 1.,
              "Initialize data with target qubits and pauli ids.")
-        .def(nb::init<const std::vector<std::uint64_t>&, Complex<double>>(),
+        .def(nb::init<const std::vector<std::uint64_t>&, Complex<Fp>>(),
              "pauli_id_par_qubit"_a,
              "coef"_a = 1.,
              "Initialize data with pauli ids per qubit.")
-        .def(nb::init<std::uint64_t, std::uint64_t, Complex<double>>(),
+        .def(nb::init<std::uint64_t, std::uint64_t, Complex<Fp>>(),
              "bit_flip_mask"_a,
              "phase_flip_mask"_a,
              "coef"_a = 1.,
              "Initialize data with bit flip and phase flip masks.")
-        .def(nb::init<const PauliOperator<double>::Data&>(),
+        .def(nb::init<const typename PauliOperator<Fp>::Data&>(),
              "data"_a,
              "Initialize pauli operator from Data object.")
         .def("add_single_pauli",
-             &PauliOperator<double>::Data::add_single_pauli,
+             &PauliOperator<Fp>::Data::add_single_pauli,
              "target_qubit"_a,
              "pauli_id"_a,
              "Add a single pauli operation to the data.")
-        .def("coef",
-             &PauliOperator<double>::Data::coef,
-             "Get the coefficient of the Pauli operator.")
+        .def("coef", &PauliOperator<Fp>::Data::coef, "Get the coefficient of the Pauli operator.")
         .def("set_coef",
-             &PauliOperator<double>::Data::set_coef,
+             &PauliOperator<Fp>::Data::set_coef,
              "c"_a,
              "Set the coefficient of the Pauli operator.")
         .def("target_qubit_list",
-             &PauliOperator<double>::Data::target_qubit_list,
+             &PauliOperator<Fp>::Data::target_qubit_list,
              "Get the list of target qubits.")
-        .def("pauli_id_list",
-             &PauliOperator<double>::Data::pauli_id_list,
-             "Get the list of Pauli IDs.")
+        .def("pauli_id_list", &PauliOperator<Fp>::Data::pauli_id_list, "Get the list of Pauli IDs.")
         .def("get_XZ_mask_representation",
-             &PauliOperator<double>::Data::get_XZ_mask_representation,
+             &PauliOperator<Fp>::Data::get_XZ_mask_representation,
              "Get the X and Z mask representation as a tuple of vectors.");
 
-    nb::class_<PauliOperator<double>>(
+    nb::class_<PauliOperator<Fp>>(
         m,
         "PauliOperator",
         "Pauli operator as coef and tensor product of single pauli for each qubit.")
-        .def(nb::init<Complex<double>>(),
+        .def(nb::init<Complex<Fp>>(),
              "coef"_a = 1.,
              "Initialize operator which just multiplying coef.")
         .def(nb::init<const std::vector<std::uint64_t>&,
                       const std::vector<std::uint64_t>&,
-                      Complex<double>>(),
+                      Complex<Fp>>(),
              "target_qubit_list"_a,
              "pauli_id_list"_a,
              "coef"_a = 1.,
              "Initialize pauli operator. For each `i`, single pauli correspond to "
              "`pauli_id_list[i]` is applied to `target_qubit_list`-th qubit.")
-        .def(nb::init<std::string_view, Complex<double>>(),
+        .def(nb::init<std::string_view, Complex<Fp>>(),
              "pauli_string"_a,
              "coef"_a = 1.,
              "Initialize pauli operator. If `pauli_string` is `\"X0Y2\"`, Pauli-X is applied to "
              "0-th qubit and Pauli-Y is applied to 2-th qubit. In `pauli_string`, spaces are "
              "ignored.")
-        .def(nb::init<const std::vector<std::uint64_t>&, Complex<double>>(),
+        .def(nb::init<const std::vector<std::uint64_t>&, Complex<Fp>>(),
              "pauli_id_par_qubit"_a,
              "coef"_a = 1.,
              "Initialize pauli operator. For each `i`, single pauli correspond to "
              "`paul_id_per_qubit` is applied to `i`-th qubit.")
-        .def(nb::init<std::uint64_t, std::uint64_t, Complex<double>>(),
+        .def(nb::init<std::uint64_t, std::uint64_t, Complex<Fp>>(),
              "bit_flip_mask"_a,
              "phase_flip_mask"_a,
              "coef"_a = 1.,
@@ -192,39 +189,37 @@ void bind_operator_pauli_operator_hpp(nb::module_& m) {
              "csv-table::\n\n    \"bit_flip\",\"phase_flip\",\"pauli\"\n    "
              "\"0\",\"0\",\"I\"\n    "
              "\"0\",\"1\",\"Z\"\n    \"1\",\"0\",\"X\"\n    \"1\",\"1\",\"Y\"")
-        .def("coef", &PauliOperator<double>::coef, "Get property `coef`.")
+        .def("coef", &PauliOperator<Fp>::coef, "Get property `coef`.")
         .def("target_qubit_list",
-             &PauliOperator<double>::target_qubit_list,
+             &PauliOperator<Fp>::target_qubit_list,
              "Get qubits to be applied pauli.")
         .def("pauli_id_list",
-             &PauliOperator<double>::pauli_id_list,
+             &PauliOperator<Fp>::pauli_id_list,
              "Get pauli id to be applied. The order is correspond to the result of "
              "`target_qubit_list`")
         .def("get_XZ_mask_representation",
-             &PauliOperator<double>::get_XZ_mask_representation,
+             &PauliOperator<Fp>::get_XZ_mask_representation,
              "Get single-pauli property as binary integer representation. See description of "
              "`__init__(bit_flip_mask_py: int, phase_flip_mask_py: int, coef: float=1.)` for "
              "details.")
         .def("get_pauli_string",
-             &PauliOperator<double>::get_pauli_string,
+             &PauliOperator<Fp>::get_pauli_string,
              "Get single-pauli property as string representation. See description of "
              "`__init__(pauli_string: str, coef: float=1.)` for details.")
-        .def("get_dagger", &PauliOperator<double>::get_dagger, "Get adjoint operator.")
+        .def("get_dagger", &PauliOperator<Fp>::get_dagger, "Get adjoint operator.")
         .def("get_qubit_count",
-             &PauliOperator<double>::get_qubit_count,
+             &PauliOperator<Fp>::get_qubit_count,
              "Get num of qubits to applied with, when count from 0-th qubit. Subset of $[0, "
              "\\mathrm{qubit_count})$ is the target.")
-        .def("apply_to_state",
-             &PauliOperator<double>::apply_to_state,
-             "Apply pauli to state vector.")
+        .def("apply_to_state", &PauliOperator<Fp>::apply_to_state, "Apply pauli to state vector.")
         .def("get_expectation_value",
-             &PauliOperator<double>::get_expectation_value,
+             &PauliOperator<Fp>::get_expectation_value,
              "Get expectation value of measuring state vector. $\\bra{\\psi}P\\ket{\\psi}$.")
         .def("get_transition_amplitude",
-             &PauliOperator<double>::get_transition_amplitude,
+             &PauliOperator<Fp>::get_transition_amplitude,
              "Get transition amplitude of measuring state vector. $\\bra{\\chi}P\\ket{\\psi}$.")
         .def(nb::self * nb::self)
-        .def(nb::self * Complex<double>());
+        .def(nb::self * Complex<Fp>());
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/state/state_vector.hpp
+++ b/include/scaluq/state/state_vector.hpp
@@ -88,8 +88,9 @@ public:
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_state_state_vector_hpp(nb::module_& m) {
-    nb::class_<StateVector<double>>(
+    nb::class_<StateVector<Fp>>(
         m,
         "StateVector",
         "Vector representation of quantum state.\n\n.. note:: Qubit index is "
@@ -98,13 +99,13 @@ void bind_state_state_vector_hpp(nb::module_& m) {
         .def(nb::init<std::uint64_t>(),
              "Construct state vector with specified qubits, initialized with computational "
              "basis $\\ket{0\\dots0}$.")
-        .def(nb::init<const StateVector<double>&>(),
+        .def(nb::init<const StateVector<Fp>&>(),
              "Constructing state vector by copying other state.")
         .def_static(
             "Haar_random_state",
             [](std::uint64_t n_qubits, std::optional<std::uint64_t> seed) {
-                return StateVector<double>::Haar_random_state(
-                    n_qubits, seed.value_or(std::random_device{}()));
+                return StateVector<Fp>::Haar_random_state(n_qubits,
+                                                          seed.value_or(std::random_device{}()));
             },
             "n_qubits"_a,
             "seed"_a = std::nullopt,
@@ -143,57 +144,57 @@ void bind_state_state_vector_hpp(nb::module_& m) {
                 .build_as_google_style()
                 .c_str())
         .def("set_amplitude_at",
-             &StateVector<double>::set_amplitude_at,
+             &StateVector<Fp>::set_amplitude_at,
              "Manually set amplitude at one index.")
         .def("get_amplitude_at",
-             &StateVector<double>::get_amplitude_at,
+             &StateVector<Fp>::get_amplitude_at,
              "Get amplitude at one index.\n\n.. note:: If you want to get all amplitudes, you "
              "should "
              "use `StateVector::get_amplitudes()`.")
         .def("set_zero_state",
-             &StateVector<double>::set_zero_state,
+             &StateVector<Fp>::set_zero_state,
              "Initialize with computational basis $\\ket{00\\dots0}$.")
         .def("set_zero_norm_state",
-             &StateVector<double>::set_zero_norm_state,
+             &StateVector<Fp>::set_zero_norm_state,
              "Initialize with 0 (null vector).")
         .def("set_computational_basis",
-             &StateVector<double>::set_computational_basis,
+             &StateVector<Fp>::set_computational_basis,
              "Initialize with computational basis \\ket{\\mathrm{basis}}.")
         .def("get_amplitudes",
-             &StateVector<double>::get_amplitudes,
+             &StateVector<Fp>::get_amplitudes,
              "Get all amplitudes with as `list[complex]`.")
-        .def("n_qubits", &StateVector<double>::n_qubits, "Get num of qubits.")
+        .def("n_qubits", &StateVector<Fp>::n_qubits, "Get num of qubits.")
         .def("dim",
-             &StateVector<double>::dim,
+             &StateVector<Fp>::dim,
              "Get dimension of the vector ($=2^\\mathrm{n\\_qubits}$).")
         .def("get_squared_norm",
-             &StateVector<double>::get_squared_norm,
+             &StateVector<Fp>::get_squared_norm,
              "Get squared norm of the state. $\\braket{\\psi|\\psi}$.")
         .def("normalize",
-             &StateVector<double>::normalize,
+             &StateVector<Fp>::normalize,
              "Normalize state (let $\\braket{\\psi|\\psi} = 1$ by multiplying coef).")
         .def("get_zero_probability",
-             &StateVector<double>::get_zero_probability,
+             &StateVector<Fp>::get_zero_probability,
              "Get the probability to observe $\\ket{0}$ at specified index.")
         .def("get_marginal_probability",
-             &StateVector<double>::get_marginal_probability,
+             &StateVector<Fp>::get_marginal_probability,
              "Get the marginal probability to observe as specified. Specify the result as n-length "
              "list. `0` and `1` represent the qubit is observed and get the value. `2` represents "
              "the qubit is not observed.")
-        .def("get_entropy", &StateVector<double>::get_entropy, "Get the entropy of the vector.")
+        .def("get_entropy", &StateVector<Fp>::get_entropy, "Get the entropy of the vector.")
         .def("add_state_vector_with_coef",
-             &StateVector<double>::add_state_vector_with_coef,
+             &StateVector<Fp>::add_state_vector_with_coef,
              "add other state vector with multiplying the coef and make superposition. "
              "$\\ket{\\mathrm{this}}\\leftarrow\\ket{\\mathrm{this}}+\\mathrm{coef}"
              "\\ket{\\mathrm{"
              "state}}$.")
         .def("multiply_coef",
-             &StateVector<double>::multiply_coef,
+             &StateVector<Fp>::multiply_coef,
              "Multiply coef. "
              "$\\ket{\\mathrm{this}}\\leftarrow\\mathrm{coef}\\ket{\\mathrm{this}}$.")
         .def(
             "sampling",
-            [](const StateVector<double>& state,
+            [](const StateVector<Fp>& state,
                std::uint64_t sampling_count,
                std::optional<std::uint64_t> seed) {
                 return state.sampling(sampling_count, seed.value_or(std::random_device{}()));
@@ -201,12 +202,11 @@ void bind_state_state_vector_hpp(nb::module_& m) {
             "sampling_count"_a,
             "seed"_a = std::nullopt,
             "Sampling specified times. Result is `list[int]` with the `sampling_count` length.")
-        .def("to_string", &StateVector<double>::to_string, "Information as `str`.")
-        .def(
-            "load", &StateVector<double>::load, "Load amplitudes of `list[int]` with `dim` length.")
-        .def("__str__", &StateVector<double>::to_string, "Information as `str`.")
+        .def("to_string", &StateVector<Fp>::to_string, "Information as `str`.")
+        .def("load", &StateVector<Fp>::load, "Load amplitudes of `list[int]` with `dim` length.")
+        .def("__str__", &StateVector<Fp>::to_string, "Information as `str`.")
         .def_ro_static("UNMEASURED",
-                       &StateVector<double>::UNMEASURED,
+                       &StateVector<Fp>::UNMEASURED,
                        "Constant used for `StateVector::get_marginal_probability` to express the "
                        "the qubit is not measured.");
 }

--- a/include/scaluq/state/state_vector.hpp
+++ b/include/scaluq/state/state_vector.hpp
@@ -90,17 +90,47 @@ public:
 namespace internal {
 template <std::floating_point Fp>
 void bind_state_state_vector_hpp(nb::module_& m) {
-    nb::class_<StateVector<Fp>>(
-        m,
-        "StateVector",
-        "Vector representation of quantum state.\n\n.. note:: Qubit index is "
-        "start from 0. If the amplitudes of $\\ket{b_{n-1}\\dots b_0}$ is "
-        "$b_i$, the state is $\\sum_i b_i 2^i$.")
+    nb::class_<StateVector<Fp>>(m,
+                                "StateVector",
+                                DocString()
+                                    .desc("Vector representation of quantum state.")
+                                    .desc("Qubit index is "
+                                          "start from 0. If the i-th value of the vector is "
+                                          "$a_i$, the state is $\\sum_i a_i \\ket{i}$.")
+                                    .desc("Given `n_qubits: int`, construct with bases "
+                                          "$\\ket{0\\dots 0}$ holding `n_qubits` number of qubits.")
+                                    .ex(DocString::Code({">>> state1 = StateVector(2)",
+                                                         ">>> print(state1)",
+                                                         " *** Quantum State ***",
+                                                         " * Qubit Count : 2",
+                                                         " * Dimension   : 4",
+                                                         " * State vector : ",
+                                                         "00: (1,0)",
+                                                         "01: (0,0)",
+                                                         "10: (0,0)",
+                                                         "11: (0,0)",
+                                                         ""}))
+                                    .build_as_google_style()
+                                    .c_str())
         .def(nb::init<std::uint64_t>(),
-             "Construct state vector with specified qubits, initialized with computational "
-             "basis $\\ket{0\\dots0}$.")
-        .def(nb::init<const StateVector<Fp>&>(),
-             "Constructing state vector by copying other state.")
+             "n_qubits"_a,
+             DocString()
+                 .desc("Construct with specified number of qubits.")
+                 .desc("Vector is initialized with computational "
+                       "basis $\\ket{0\\dots0}$.")
+                 .arg("n_qubits", "int", "number of qubits")
+                 .ex(DocString::Code({">>> state1 = StateVector(2)",
+                                      ">>> print(state1)",
+                                      " *** Quantum State ***",
+                                      " * Qubit Count : 2",
+                                      " * Dimension   : 4",
+                                      " * State vector : ",
+                                      "00: (1,0)",
+                                      "01: (0,0)",
+                                      "10: (0,0)",
+                                      "11: (0,0)"}))
+                 .build_as_google_style()
+                 .c_str())
         .def_static(
             "Haar_random_state",
             [](std::uint64_t n_qubits, std::optional<std::uint64_t> seed) {
@@ -145,53 +175,260 @@ void bind_state_state_vector_hpp(nb::module_& m) {
                 .c_str())
         .def("set_amplitude_at",
              &StateVector<Fp>::set_amplitude_at,
-             "Manually set amplitude at one index.")
+             "index"_a,
+             "value"_a,
+             DocString()
+                 .desc("Manually set amplitude at one index.")
+                 .arg("index",
+                      "int",
+                      "index of state vector",
+                      "This is read as binary.k-th bit of index represents k-th qubit.")
+                 .arg("value", "complex", "amplitude value to set at index")
+                 .ex(DocString::Code({">>> state = StateVector(2)",
+                                      ">>> state.get_amplitudes()",
+                                      "[(1+0j), 0j, 0j, 0j]",
+                                      ">>> state.set_amplitude_at(2, 3+1j)",
+                                      ">>> state.get_amplitudes()",
+                                      "[(1+0j), 0j, (3+1j), 0j]"}))
+                 .note("If you want to get amplitudes at all indices, you should use "
+                       ":meth:`.load`.")
+                 .build_as_google_style()
+                 .c_str())
         .def("get_amplitude_at",
              &StateVector<Fp>::get_amplitude_at,
-             "Get amplitude at one index.\n\n.. note:: If you want to get all amplitudes, you "
-             "should "
-             "use `StateVector::get_amplitudes()`.")
+             "index"_a,
+             DocString()
+                 .desc("Get amplitude at one index.")
+                 .arg("index",
+                      "int",
+                      "index of state vector",
+                      "This is read as binary. k-th bit of index represents k-th qubit.")
+                 .ret("complex", "Amplitude at specified index")
+                 .ex(DocString::Code{">>> state = StateVector(2)",
+                                     ">>> state.load([1+2j, 3+4j, 5+6j, 7+8j])",
+                                     ">>> state.get_amplitude_at(0)",
+                                     "(1+2j)",
+                                     ">>> state.get_amplitude_at(1)",
+                                     "(3+4j)",
+                                     ">>> state.get_amplitude_at(2)",
+                                     "(5+6j)",
+                                     ">>> state.get_amplitude_at(3)",
+                                     "(7+8j)"})
+                 .note("If you want to get amplitudes at all indices, you should use "
+                       ":meth:`.get_amplitudes`.")
+                 .build_as_google_style()
+                 .c_str())
         .def("set_zero_state",
              &StateVector<Fp>::set_zero_state,
-             "Initialize with computational basis $\\ket{00\\dots0}$.")
+             DocString()
+                 .desc("Initialize with computational basis $\\ket{00\\dots0}$.")
+                 .ex(DocString::Code{">>> state = StateVector.Haar_random_state(2)",
+                                     ">>> state.get_amplitudes()",
+                                     "[(-0.05726462181150916+0.3525270165415515j), "
+                                     "(0.1133709060491142+0.3074930854078303j), "
+                                     "(0.03542174692996924+0.18488950377672345j), "
+                                     "(0.8530024105558827+0.04459332470844164j)]",
+                                     ">>> state.set_zero_state()",
+                                     ">>> state.get_amplitudes()",
+                                     "[(1+0j), 0j, 0j, 0j]"})
+                 .build_as_google_style()
+                 .c_str())
         .def("set_zero_norm_state",
              &StateVector<Fp>::set_zero_norm_state,
-             "Initialize with 0 (null vector).")
+             DocString()
+                 .desc("Initialize with 0 (null vector).")
+                 .ex(DocString::Code{">>> state = StateVector(2)",
+                                     ">>> state.get_amplitudes()",
+                                     "[(1+0j), 0j, 0j, 0j]",
+                                     ">>> state.set_zero_norm_state()",
+                                     ">>> state.get_amplitudes()",
+                                     "[0j, 0j, 0j, 0j]"})
+                 .build_as_google_style()
+                 .c_str())
         .def("set_computational_basis",
              &StateVector<Fp>::set_computational_basis,
-             "Initialize with computational basis \\ket{\\mathrm{basis}}.")
+             "basis"_a,
+             DocString()
+                 .desc("Initialize with computational basis \\ket{\\mathrm{basis}}.")
+                 .arg("basis",
+                      "int",
+                      "basis as integer format ($0 \\leq \\mathrm{basis} \\leq "
+                      "2^{\\mathrm{n\\_qubits}}-1$)")
+                 .ex(DocString::Code{">>> state = StateVector(2)",
+                                     ">>> state.set_computational_basis(0) # |00>",
+                                     ">>> state.get_amplitudes()",
+                                     "[(1+0j), 0j, 0j, 0j]",
+                                     ">>> state.set_computational_basis(1) # |01>",
+                                     ">>> state.get_amplitudes()",
+                                     "[0j, (1+0j), 0j, 0j]",
+                                     ">>> state.set_computational_basis(2) # |10>",
+                                     ">>> state.get_amplitudes()",
+                                     "[0j, 0j, (1+0j), 0j]",
+                                     ">>> state.set_computational_basis(3) # |11>",
+                                     ">>> state.get_amplitudes()",
+                                     "[0j, 0j, 0j, (1+0j)]"})
+                 .build_as_google_style()
+                 .c_str())
         .def("get_amplitudes",
              &StateVector<Fp>::get_amplitudes,
-             "Get all amplitudes with as `list[complex]`.")
-        .def("n_qubits", &StateVector<Fp>::n_qubits, "Get num of qubits.")
+             DocString()
+                 .desc("Get all amplitudes as `list[complex]`.")
+                 .ret("list[complex]", "amplitudes of list with len $2^{\\mathrm{n\\_qubits}}$")
+                 .ex(DocString::Code{">>> state = StateVector(2)",
+                                     ">>> state.get_amplitudes()",
+                                     "[(1+0j), 0j, 0j, 0j]"})
+                 .build_as_google_style()
+                 .c_str())
+        .def("n_qubits",
+             &StateVector<Fp>::n_qubits,
+             DocString()
+                 .desc("Get num of qubits.")
+                 .ret("int", "num of qubits")
+                 .ex(DocString::Code{">>> state = StateVector(2)", ">>> state.n_qubits()", "2"})
+                 .build_as_google_style()
+                 .c_str())
         .def("dim",
              &StateVector<Fp>::dim,
-             "Get dimension of the vector ($=2^\\mathrm{n\\_qubits}$).")
+             DocString()
+                 .desc("Get dimension of the vector ($=2^\\mathrm{n\\_qubits}$).")
+                 .ret("int", "dimension of the vector")
+                 .ex(DocString::Code{">>> state = StateVector(2)", ">>> state.dim()", "4"})
+                 .build_as_google_style()
+                 .c_str())
         .def("get_squared_norm",
              &StateVector<Fp>::get_squared_norm,
-             "Get squared norm of the state. $\\braket{\\psi|\\psi}$.")
+             DocString()
+                 .desc("Get squared norm of the state. $\\braket{\\psi|\\psi}$.")
+                 .ret("float", "squared norm of the state")
+                 .ex(DocString::Code{">>> v = [1+2j, 3+4j, 5+6j, 7+8j]",
+                                     ">>> state = StateVector(2)",
+                                     ">>> state.load(v)",
+                                     ">>> state.get_squared_norm()",
+                                     "204.0"
+                                     ">>> sum([abs(a)**2 for a in v])",
+                                     "204.0"})
+                 .build_as_google_style()
+                 .c_str())
         .def("normalize",
              &StateVector<Fp>::normalize,
-             "Normalize state (let $\\braket{\\psi|\\psi} = 1$ by multiplying coef).")
-        .def("get_zero_probability",
-             &StateVector<Fp>::get_zero_probability,
-             "Get the probability to observe $\\ket{0}$ at specified index.")
+             DocString()
+                 .desc("Normalize state.")
+                 .desc("Let $\\braket{\\psi|\\psi} = 1$ by multiplying constant.")
+                 .ex(DocString::Code{">>> v = [1+2j, 3+4j, 5+6j, 7+8j]",
+                                     ">>> state = StateVector(2)",
+                                     ">>> state.load(v)",
+                                     ">>> state.normalize()",
+                                     ">>> state.get_amplitudes()",
+                                     "[(0.07001400420140048+0.14002800840280097j), "
+                                     "(0.21004201260420147+0.28005601680560194j), "
+                                     "(0.3500700210070024+0.42008402520840293j), "
+                                     "(0.4900980294098034+0.5601120336112039j)]",
+                                     ">>> norm = state.get_squared_norm()**.5",
+                                     ">>> [a / norm for a in v]"
+                                     "[(0.07001400420140048+0.14002800840280097j), "
+                                     "(0.21004201260420147+0.28005601680560194j), "
+                                     "(0.3500700210070024+0.42008402520840293j), "
+                                     "(0.4900980294098034+0.5601120336112039j)]"})
+                 .build_as_google_style()
+                 .c_str())
+        .def(
+            "get_zero_probability",
+            &StateVector<Fp>::get_zero_probability,
+            "index"_a,
+            DocString()
+                .desc("Get the probability to observe $\\ket{0}$ at specified index.")
+                .desc("**State must be normalized.**")
+                .arg("index", "int", "qubit index to be observed")
+                .ret("float", "probability to observe $\\ket{0}$")
+                .ex(DocString::Code{">>> v = [1 / 6**.5, 2j / 6**.5 * 1j, -1 / 6**.5, -2j / 6**.5]",
+                                    ">>> state = StateVector(2)",
+                                    ">>> state.load(v)",
+                                    ">>> state.get_zero_probability(0)",
+                                    "0.3333333333333334",
+                                    ">>> state.get_zero_probability(1)",
+                                    "0.8333333333333336",
+                                    ">>> abs(v[0])**2+abs(v[2])**2",
+                                    "0.3333333333333334",
+                                    ">>> abs(v[0])**2+abs(v[1])**2",
+                                    "0.8333333333333336"})
+                .build_as_google_style()
+                .c_str())
         .def("get_marginal_probability",
              &StateVector<Fp>::get_marginal_probability,
-             "Get the marginal probability to observe as specified. Specify the result as n-length "
-             "list. `0` and `1` represent the qubit is observed and get the value. `2` represents "
-             "the qubit is not observed.")
-        .def("get_entropy", &StateVector<Fp>::get_entropy, "Get the entropy of the vector.")
+             "measured_values"_a,
+             DocString()
+                 .desc("Get the marginal probability to observe as given.")
+                 .desc("**State must be normalized.**")
+                 .arg("measured_values",
+                      "list[int]",
+                      "list with len n_qubits.",
+                      "`0`, `1` or :attr:`.UNMEASURED` is allowed for each elements. `0` or `1` "
+                      "shows the qubit is observed and the value is got. :attr:`.UNMEASURED` "
+                      "shows the the qubit is not observed.")
+                 .ret("float", "probability to observe as given")
+                 .ex(DocString::Code{
+                     ">>> v = [1/4, 1/2, 0, 1/4, 1/4, 1/2, 1/4, 1/2]",
+                     "state = StateVector(3)",
+                     ">>> state.load(v)",
+                     ">>> state.get_marginal_probability([0, 1, StateVector.UNMEASURED])",
+                     "0.0625",
+                     ">>> abs(v[2])**2 + abs(v[6])**2",
+                     "0.0625"})
+                 .build_as_google_style()
+                 .c_str())
+        .def("get_entropy",
+             &StateVector<Fp>::get_entropy,
+             DocString()
+                 .desc("Get the entropy of the vector.")
+                 .desc("**State must be normalized.**")
+                 .ret("float", "entropy")
+                 .ex(DocString::Code{
+                     ">>> v = [1/4, 1/2, 0, 1/4, 1/4, 1/2, 1/4, 1/2]",
+                     ">>> state = StateVector(3)",
+                     ">>> state.load(v)",
+                     ">>> state.get_entropy()",
+                     "2.5000000000000497",
+                     ">>> sum(-abs(a)**2 * math.log2(abs(a)**2) for a in v if a != 0)",
+                     "2.5"})
+                 .note("The result of this function differs from qulacs. This is because scaluq "
+                       "adopted 2 for the base of log in the difinition of entropy $\\sum_i -p_i "
+                       "\\log p_i$ "
+                       "however qulacs adopted e.")
+                 .build_as_google_style()
+                 .c_str())
         .def("add_state_vector_with_coef",
              &StateVector<Fp>::add_state_vector_with_coef,
-             "add other state vector with multiplying the coef and make superposition. "
-             "$\\ket{\\mathrm{this}}\\leftarrow\\ket{\\mathrm{this}}+\\mathrm{coef}"
-             "\\ket{\\mathrm{"
-             "state}}$.")
+             "coef"_a,
+             "state"_a,
+             DocString()
+                 .desc("Add other state vector with multiplying the coef and make superposition.")
+                 .desc("$\\ket{\\mathrm{this}}\\leftarrow\\ket{\\mathrm{this}}+\\mathrm{coef} "
+                       "\\ket{\\mathrm{state}}$.")
+                 .arg("coef", "complex", "coefficient to multiply to `state`")
+                 .arg("state", ":class:`StateVector`", "state to be added")
+                 .ex(DocString::Code{">>> state1 = StateVector(1)",
+                                     ">>> state1.load([1, 2])",
+                                     ">>> state2 = StateVector(1)",
+                                     ">>> state2.load([3, 4])",
+                                     ">>> state1.add_state_vector_with_coef(2j, state2)",
+                                     ">>> state1.get_amplitudes()",
+                                     "[(1+6j), (2+8j)]"})
+                 .build_as_google_style()
+                 .c_str())
         .def("multiply_coef",
              &StateVector<Fp>::multiply_coef,
-             "Multiply coef. "
-             "$\\ket{\\mathrm{this}}\\leftarrow\\mathrm{coef}\\ket{\\mathrm{this}}$.")
+             "coef"_a,
+             DocString()
+                 .desc("Multiply coef.")
+                 .desc("$\\ket{\\mathrm{this}}\\leftarrow\\mathrm{coef}\\ket{\\mathrm{this}}$.")
+                 .arg("coef", "complex", "coefficient to multiply")
+                 .ex(DocString::Code{">>> state = StateVector(1)",
+                                     ">>> state.load([1, 2])",
+                                     ">>> state.multiply_coef(2j)",
+                                     ">>> state.get_amplitudes()",
+                                     "[2j, 4j]"})
+                 .build_as_google_style()
+                 .c_str())
         .def(
             "sampling",
             [](const StateVector<Fp>& state,
@@ -201,14 +438,61 @@ void bind_state_state_vector_hpp(nb::module_& m) {
             },
             "sampling_count"_a,
             "seed"_a = std::nullopt,
-            "Sampling specified times. Result is `list[int]` with the `sampling_count` length.")
-        .def("to_string", &StateVector<Fp>::to_string, "Information as `str`.")
-        .def("load", &StateVector<Fp>::load, "Load amplitudes of `list[int]` with `dim` length.")
-        .def("__str__", &StateVector<Fp>::to_string, "Information as `str`.")
-        .def_ro_static("UNMEASURED",
-                       &StateVector<Fp>::UNMEASURED,
-                       "Constant used for `StateVector::get_marginal_probability` to express the "
-                       "the qubit is not measured.");
+            DocString()
+                .desc("Sampling state vector independently and get list of computational basis")
+                .arg("sampling_count", "int", "how many times to apply sampling")
+                .arg("seed",
+                     "int | None",
+                     true,
+                     "random seed",
+                     "If not specified, the value from random device is used.")
+                .ret("list[int]",
+                     "result of sampling",
+                     "list of `sampling_count` length. Each element is in "
+                     "$[0,2^{\\mathrm{n\\_qubits}})$")
+                .ex(DocString::Code{" >>> state = StateVector(2)",
+                                    ">>> state.load([1/2, 0, -3**.5/2, 0])",
+                                    ">>> state.sampling(8) ",
+                                    "[0, 2, 2, 2, 2, 0, 0, 2]"})
+                .build_as_google_style()
+                .c_str())
+        .def(
+            "to_string",
+            &StateVector<Fp>::to_string,
+            DocString()
+                .desc("Information as `str`.")
+                .ret("str", "information as str")
+                .ex(DocString::Code{
+                    ">>> state = StateVector(1)",
+                    ">>> state.to_string()",
+                    R"(' *** Quantum State ***\n * Qubit Count : 1\n * Dimension   : 2\n * State vector : \n0: (1,0)\n1: (0,0)\n')"})
+                .build_as_google_style()
+                .c_str())
+        .def("load",
+             &StateVector<Fp>::load,
+             "other"_a,
+             DocString()
+                 .desc("Load amplitudes of `Sequence`")
+                 .arg("other",
+                      "collections.abc.Sequence[complex]",
+                      "list of complex amplitudes with len $2^{\\mathrm{n_qubits}}$")
+                 .build_as_google_style()
+                 .c_str())
+        .def("__str__",
+             &StateVector<Fp>::to_string,
+             DocString()
+                 .desc("Information as `str`.")
+                 .desc("Same as :meth:`.to_string()`")
+                 .build_as_google_style()
+                 .c_str())
+        .def_ro_static(
+            "UNMEASURED",
+            &StateVector<Fp>::UNMEASURED,
+            DocString()
+                .desc("Constant used for `StateVector::get_marginal_probability` to express the "
+                      "the qubit is not measured.")
+                .build_as_google_style()
+                .c_str());
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/state/state_vector_batched.hpp
+++ b/include/scaluq/state/state_vector_batched.hpp
@@ -86,8 +86,9 @@ public:
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <std::floating_point Fp>
 void bind_state_state_vector_batched_hpp(nb::module_& m) {
-    nb::class_<StateVectorBatched<double>>(
+    nb::class_<StateVectorBatched<Fp>>(
         m,
         "StateVectorBatched",
         "Batched vector representation of quantum state.\n\n.. note:: Qubit index is start from 0. "
@@ -95,36 +96,35 @@ void bind_state_state_vector_batched_hpp(nb::module_& m) {
         "2^i$.")
         .def(nb::init<std::uint64_t, std::uint64_t>(),
              "Construct batched state vector with specified batch size and qubits.")
-        .def(nb::init<const StateVectorBatched<double>&>(),
+        .def(nb::init<const StateVectorBatched<Fp>&>(),
              "Constructing batched state vector by copying other batched state.")
-        .def("n_qubits", &StateVectorBatched<double>::n_qubits, "Get num of qubits.")
+        .def("n_qubits", &StateVectorBatched<Fp>::n_qubits, "Get num of qubits.")
         .def("dim",
-             &StateVectorBatched<double>::dim,
+             &StateVectorBatched<Fp>::dim,
              "Get dimension of the vector ($=2^\\mathrm{n\\_qubits}$).")
-        .def("batch_size", &StateVectorBatched<double>::batch_size, "Get batch size.")
+        .def("batch_size", &StateVectorBatched<Fp>::batch_size, "Get batch size.")
         .def("set_state_vector",
-             nb::overload_cast<const StateVector<double>&>(
-                 &StateVectorBatched<double>::set_state_vector),
+             nb::overload_cast<const StateVector<Fp>&>(&StateVectorBatched<Fp>::set_state_vector),
              "Set the state vector for all batches.")
         .def("set_state_vector_at",
-             nb::overload_cast<std::uint64_t, const StateVector<double>&>(
-                 &StateVectorBatched<double>::set_state_vector_at),
+             nb::overload_cast<std::uint64_t, const StateVector<Fp>&>(
+                 &StateVectorBatched<Fp>::set_state_vector_at),
              "Set the state vector for a specific batch.")
         .def("get_state_vector_at",
-             &StateVectorBatched<double>::get_state_vector_at,
+             &StateVectorBatched<Fp>::get_state_vector_at,
              "Get the state vector for a specific batch.")
         .def("set_zero_state",
-             &StateVectorBatched<double>::set_zero_state,
+             &StateVectorBatched<Fp>::set_zero_state,
              "Initialize all batches with computational basis $\\ket{00\\dots0}$.")
         .def("set_zero_norm_state",
-             &StateVectorBatched<double>::set_zero_norm_state,
+             &StateVectorBatched<Fp>::set_zero_norm_state,
              "Initialize with 0 (null vector).")
         .def("set_computational_basis",
-             &StateVectorBatched<double>::set_computational_basis,
+             &StateVectorBatched<Fp>::set_computational_basis,
              "Initialize with computational basis \\ket{\\mathrm{basis}}.")
         .def(
             "sampling",
-            [](const StateVectorBatched<double>& states,
+            [](const StateVectorBatched<Fp>& states,
                std::uint64_t sampling_count,
                std::optional<std::uint64_t> seed) {
                 return states.sampling(sampling_count, seed.value_or(std::random_device{}()));
@@ -139,7 +139,7 @@ void bind_state_state_vector_batched_hpp(nb::module_& m) {
                std::uint64_t n_qubits,
                bool set_same_state,
                std::optional<std::uint64_t> seed) {
-                return StateVectorBatched<double>::Haar_random_state(
+                return StateVectorBatched<Fp>::Haar_random_state(
                     batch_size, n_qubits, set_same_state, seed.value_or(std::random_device{}()));
             },
             "batch_size"_a,
@@ -149,39 +149,38 @@ void bind_state_state_vector_batched_hpp(nb::module_& m) {
             "Construct batched state vectors with Haar random states. If seed is not "
             "specified, the value from random device is used.")
         .def("get_amplitudes",
-             &StateVectorBatched<double>::get_amplitudes,
+             &StateVectorBatched<Fp>::get_amplitudes,
              "Get all amplitudes with as `list[list[complex]]`.")
         .def("get_squared_norm",
-             &StateVectorBatched<double>::get_squared_norm,
+             &StateVectorBatched<Fp>::get_squared_norm,
              "Get squared norm of each state in the batch. $\\braket{\\psi|\\psi}$.")
         .def("normalize",
-             &StateVectorBatched<double>::normalize,
+             &StateVectorBatched<Fp>::normalize,
              "Normalize each state in the batch (let $\\braket{\\psi|\\psi} = 1$ by "
              "multiplying coef).")
         .def("get_zero_probability",
-             &StateVectorBatched<double>::get_zero_probability,
+             &StateVectorBatched<Fp>::get_zero_probability,
              "Get the probability to observe $\\ket{0}$ at specified index for each state in "
              "the batch.")
         .def("get_marginal_probability",
-             &StateVectorBatched<double>::get_marginal_probability,
+             &StateVectorBatched<Fp>::get_marginal_probability,
              "Get the marginal probability to observe as specified for each state in the batch. "
              "Specify the result as n-length list. `0` and `1` represent the qubit is observed "
              "and get the value. `2` represents the qubit is not observed.")
         .def("get_entropy",
-             &StateVectorBatched<double>::get_entropy,
+             &StateVectorBatched<Fp>::get_entropy,
              "Get the entropy of each state in the batch.")
         .def("add_state_vector_with_coef",
-             &StateVectorBatched<double>::add_state_vector_with_coef,
+             &StateVectorBatched<Fp>::add_state_vector_with_coef,
              "Add other batched state vectors with multiplying the coef and make superposition. "
              "$\\ket{\\mathrm{this}}\\leftarrow\\ket{\\mathrm{this}}+\\mathrm{coef}"
              "\\ket{\\mathrm{states}}$.")
         .def("load",
-             &StateVectorBatched<double>::load,
+             &StateVectorBatched<Fp>::load,
              "Load batched amplitudes from `list[list[complex]]`.")
-        .def(
-            "copy", &StateVectorBatched<double>::copy, "Create a copy of the batched state vector.")
-        .def("to_string", &StateVectorBatched<double>::to_string, "Information as `str`.")
-        .def("__str__", &StateVectorBatched<double>::to_string, "Information as `str`.");
+        .def("copy", &StateVectorBatched<Fp>::copy, "Create a copy of the batched state vector.")
+        .def("to_string", &StateVectorBatched<Fp>::to_string, "Information as `str`.")
+        .def("__str__", &StateVectorBatched<Fp>::to_string, "Information as `str`.");
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/types.hpp
+++ b/include/scaluq/types.hpp
@@ -48,21 +48,4 @@ public:
     SparseMatrix(const SparseComplexMatrix<Fp>& sp);
 };
 }  // namespace internal
-
-#ifdef SCALUQ_USE_NANOBIND
-namespace internal {
-void bind_types_hpp(nb::module_& m) {
-    m.def("finalize",
-          &finalize,
-          "Terminate the Kokkos execution environment. Release the resources.\n\n.. note:: "
-          "Finalization fails if there exists `StateVector` allocated. You must use "
-          "`StateVector` only inside inner scopes than the usage of `finalize` or delete all of "
-          "existing `StateVector`.\n\n.. note:: This is "
-          "automatically called when the program exits. If you call this manually, you cannot use "
-          "most of scaluq's functions until the program exits.");
-    m.def("is_finalized", &is_initialized, "Return true if `finalize()` is already called.");
-}
-}  // namespace internal
-#endif
-
 }  // namespace scaluq

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -21,12 +21,23 @@ nanobind_add_stub(
     MARKER_FILE scaluq/py.typed
     VERBOSE
 )
-nanobind_add_stub(
-    scaluq_stub
-    INSTALL_TIME
-    MODULE scaluq.scaluq_core.gate
-    OUTPUT scaluq/gate.pyi
-    PYTHON_PATH $<TARGET_FILE_DIR:scaluq>
-    MARKER_FILE scaluq/py.typed
-    VERBOSE
-)
+foreach(FLOAT IN ITEMS f64 f32)
+    nanobind_add_stub(
+        scaluq_stub
+        INSTALL_TIME
+        MODULE scaluq.scaluq_core.${FLOAT}
+        OUTPUT scaluq/${FLOAT}/__init__.pyi
+        PYTHON_PATH $<TARGET_FILE_DIR:scaluq>
+        MARKER_FILE scaluq/py.typed
+        VERBOSE
+    )
+    nanobind_add_stub(
+        scaluq_stub
+        INSTALL_TIME
+        MODULE scaluq.scaluq_core.${FLOAT}.gate
+        OUTPUT scaluq/${FLOAT}/gate/__init__.pyi
+        PYTHON_PATH $<TARGET_FILE_DIR:scaluq>
+        MARKER_FILE scaluq/py.typed
+        VERBOSE
+    )
+endforeach()

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -80,30 +80,41 @@ void cleanup() {
     if (!is_finalized()) finalize();
 }
 
+template <std::floating_point Fp>
+void bind_on_precision(nb::module_& m, const char* submodule_name) {
+    auto mp = m.def_submodule(
+        submodule_name,
+        (std::ostringstream("module for ") << submodule_name << "precision").str().c_str());
+
+    internal::bind_state_state_vector_hpp<Fp>(mp);
+    internal::bind_state_state_vector_batched_hpp<Fp>(mp);
+
+    auto mgate = mp.def_submodule("gate", "Define gates.");
+
+    internal::bind_gate_gate_hpp<Fp>(mp);
+    internal::bind_gate_gate_standard_hpp<Fp>(mp);
+    internal::bind_gate_gate_matrix_hpp<Fp>(mp);
+    internal::bind_gate_gate_pauli_hpp<Fp>(mp);
+    internal::bind_gate_gate_factory_hpp<Fp>(mgate);
+    internal::bind_gate_param_gate_hpp<Fp>(mp);
+    internal::bind_gate_param_gate_standard_hpp<Fp>(mp);
+    internal::bind_gate_param_gate_pauli_hpp<Fp>(mp);
+    internal::bind_gate_param_gate_probablistic_hpp<Fp>(mp);
+    internal::bind_gate_param_gate_factory<Fp>(mgate);
+    // internal::bind_gate_merge_gate_hpp<Fp>(mp);
+
+    internal::bind_circuit_circuit_hpp<Fp>(mp);
+
+    internal::bind_operator_pauli_operator_hpp<Fp>(mp);
+    internal::bind_operator_operator_hpp<Fp>(mp);
+}
+
 NB_MODULE(scaluq_core, m) {
-    internal::bind_types_hpp(m);
+    internal::bind_kokkos_hpp(m);
+    internal::bind_gate_gate_hpp_without_precision(m);
 
-    internal::bind_state_state_vector_hpp(m);
-    internal::bind_state_state_vector_batched_hpp(m);
-
-    auto mgate = m.def_submodule("gate", "Define gates.");
-
-    internal::bind_gate_gate_hpp(m);
-    internal::bind_gate_gate_standard_hpp(m);
-    internal::bind_gate_gate_matrix_hpp(m);
-    internal::bind_gate_gate_pauli_hpp(m);
-    internal::bind_gate_gate_factory_hpp(mgate);
-    internal::bind_gate_param_gate_hpp(m);
-    internal::bind_gate_param_gate_standard_hpp(m);
-    internal::bind_gate_param_gate_pauli_hpp(m);
-    internal::bind_gate_param_gate_probablistic_hpp(m);
-    internal::bind_gate_param_gate_factory(mgate);
-    // internal::bind_gate_merge_gate_hpp(m);
-
-    internal::bind_circuit_circuit_hpp(m);
-
-    internal::bind_operator_pauli_operator_hpp(m);
-    internal::bind_operator_operator_hpp(m);
+    bind_on_precision<double>(m, "f64");
+    bind_on_precision<float>(m, "f32");
 
     initialize();
     std::atexit(&cleanup);

--- a/python/scaluq/__init__.py
+++ b/python/scaluq/__init__.py
@@ -1,1 +1,3 @@
 from .scaluq_core import *
+from . import f64
+from . import f32

--- a/python/scaluq/f32/__init__.py
+++ b/python/scaluq/f32/__init__.py
@@ -1,0 +1,2 @@
+from ..scaluq_core.f32 import *
+from . import gate

--- a/python/scaluq/f32/gate/__init__.py
+++ b/python/scaluq/f32/gate/__init__.py
@@ -1,0 +1,1 @@
+from ...scaluq_core.f32.gate import *

--- a/python/scaluq/f64/__init__.py
+++ b/python/scaluq/f64/__init__.py
@@ -1,0 +1,2 @@
+from ..scaluq_core.f64 import *
+from . import gate

--- a/python/scaluq/f64/gate/__init__.py
+++ b/python/scaluq/f64/gate/__init__.py
@@ -1,0 +1,1 @@
+from ...scaluq_core.f64.gate import *

--- a/python/scaluq/gate.py
+++ b/python/scaluq/gate.py
@@ -1,1 +1,0 @@
-from .scaluq_core.gate import *


### PR DESCRIPTION
Pythonでも好きな精度を選べるようにしました。
現状どうせf64とf32の両方でライブラリがコンパイルされていて、バイナリサイズが大きくなることもなさそうだと思ったので標準で両方サポートしていいと思っています。
今後f16,f32,f128などをサポートするならライブラリのコンパイル時点でオプションで選べるようにすべきそうですが…

```python
from scaluq.f64 import StateVector
from scaluq.f64.gate import X
```
のように精度でサブモジュールを切って使えるようにしていますが、
```python
from scaluq import StateVector
from scaluq.gate import X
```
のように1つ上の階層からもデフォルトとしてf64のものを使えるようにするか迷っているので意見がほしいです。
従来通り精度を選ばなくても使えるのがいいところですが、メンテナにとってもユーザーにとっても階層構造がわかりにくくなる懸念があります。