### PR TITLE
CI wheel-build 修正

### DIFF
--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -82,9 +82,9 @@ void cleanup() {
 
 template <std::floating_point Fp>
 void bind_on_precision(nb::module_& m, const char* submodule_name) {
-    auto mp = m.def_submodule(
-        submodule_name,
-        (std::ostringstream("module for ") << submodule_name << "precision").str().c_str());
+    std::ostringstream oss;
+    oss << "module for " << submodule_name << "precision";
+    auto mp = m.def_submodule(submodule_name, oss.str().c_str());
 
     internal::bind_state_state_vector_hpp<Fp>(mp);
     internal::bind_state_state_vector_batched_hpp<Fp>(mp);


### PR DESCRIPTION
ostreamの一時オブジェクトを作って解決します．
とりあえずローカルでビルドが成功することを確認しています．