### PR TITLE
add circuit batch update

### DIFF
--- a/exe/main.cpp
+++ b/exe/main.cpp
@@ -32,6 +32,12 @@ int main() {
         std::uint64_t n_qubits = 2, batch_size = 2;
         scaluq::StateVectorBatched<double> states(batch_size, n_qubits);
         states.set_Haar_random_state(batch_size, n_qubits, false);
+
+        Circuit<double> cirq(n_qubits);
+        cirq.add_param_gate(gate::ParamRX<double>(1, {2}), "RX");
+        std::map<std::string, std::vector<double>> params = {{"RX", {0.5, 1.5}}};
+        cirq.update_quantum_state(states, params);
+
         Json j = states;
         std::cout << j << std::endl;
         states = j;
@@ -155,5 +161,5 @@ int main() {
         std::cout << Json(c) << std::endl;
     }
 
-    Kokkos::finalize();
+    scaluq::finalize();
 }

--- a/exe/main.py
+++ b/exe/main.py
@@ -18,9 +18,17 @@ def main():
 
     print(operator.to_json())
 
-    states = StateVectorBatched(3, 3)
+    states = StateVectorBatched.Haar_random_state(2, 3)
+    prx = gate.ParamRX(0, 2.0, [1])
+    pry = gate.ParamRY(1, 2.0, [2])
+    params = {
+        "rx": [0.0, 0.1, 0.2],
+        "ry": [0.3, 0.4, 0.5]
+    }
+    circuit.add_param_gate(prx, "rx")
+    circuit.add_param_gate(pry, "ry")
+    circuit.update_quantum_state(states, params)
     print(states.to_json())
-
 
 if __name__ == "__main__":
     main()

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -60,6 +60,8 @@ public:
 
     void update_quantum_state(StateVector<Fp>& state,
                               const std::map<std::string, Fp>& parameters = {}) const;
+    void update_quantum_state(StateVectorBatched<Fp>& states,
+                              const std::map<std::string, std::vector<Fp>>& parameters = {}) const;
 
     Circuit copy() const;
 
@@ -147,6 +149,28 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
         .def("update_quantum_state",
              [](const Circuit<Fp>& circuit, StateVector<Fp>& state) {
                  circuit.update_quantum_state(state);
+             })
+        .def(
+            "update_quantum_state",
+            &Circuit<Fp>::update_quantum_state,
+            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
+            "If the circuit contains parametric gate, you have to give real value of parameter as "
+            "dict[str, list[float]] in 2nd arg.")
+        .def(
+            "update_quantum_state",
+            [&](const Circuit<Fp>& circuit, StateVectorBatched<Fp>& states, nb::kwargs kwargs) {
+                std::map<std::string, std::vector<Fp>> parameters;
+                for (auto&& [key, param] : kwargs) {
+                    parameters[nb::cast<std::string>(key)] = nb::cast<std::vector<Fp>>(param);
+                }
+                circuit.update_quantum_state(states, parameters);
+            },
+            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
+            "If the circuit contains parametric gate, you have to give real value of parameter as "
+            "\"name=[value1, value2, ...]\" format in kwargs.")
+        .def("update_quantum_state",
+             [](const Circuit<Fp>& circuit, StateVectorBatched<Fp>& states) {
+                 circuit.update_quantum_state(states);
              })
         .def("copy", &Circuit<Fp>::copy, "Copy circuit. All the gates inside is copied.")
         .def("get_inverse",

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -130,7 +130,8 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
              nb::overload_cast<const Circuit<Fp>&>(&Circuit<Fp>::add_circuit),
              "Add all gates in specified circuit. Given gates are copied.")
         .def("update_quantum_state",
-             &Circuit<Fp>::update_quantum_state,
+             static_cast<void (Circuit<Fp>::*)(StateVector<Fp>&, const std::map<std::string, Fp>&)
+                             const>(&Circuit<Fp>::update_quantum_state),
              "Apply gate to the StateVector. StateVector in args is directly updated. If the "
              "circuit contains parametric gate, you have to give real value of parameter as "
              "dict[str, float] in 2nd arg.")
@@ -146,13 +147,11 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
             "Apply gate to the StateVector. StateVector in args is directly updated. If the "
             "circuit contains parametric gate, you have to give real value of parameter as "
             "\"name=value\" format in kwargs.")
-        .def("update_quantum_state",
-             [](const Circuit<Fp>& circuit, StateVector<Fp>& state) {
-                 circuit.update_quantum_state(state);
-             })
         .def(
             "update_quantum_state",
-            &Circuit<Fp>::update_quantum_state,
+            static_cast<void (Circuit<Fp>::*)(StateVectorBatched<Fp>&,
+                                              const std::map<std::string, std::vector<Fp>>&) const>(
+                &Circuit<Fp>::update_quantum_state),
             "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
             "If the circuit contains parametric gate, you have to give real value of parameter as "
             "dict[str, list[float]] in 2nd arg.")
@@ -168,10 +167,6 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
             "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
             "If the circuit contains parametric gate, you have to give real value of parameter as "
             "\"name=[value1, value2, ...]\" format in kwargs.")
-        .def("update_quantum_state",
-             [](const Circuit<Fp>& circuit, StateVectorBatched<Fp>& states) {
-                 circuit.update_quantum_state(states);
-             })
         .def("copy", &Circuit<Fp>::copy, "Copy circuit. All the gates inside is copied.")
         .def("get_inverse",
              &Circuit<Fp>::get_inverse,

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -130,8 +130,8 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
              nb::overload_cast<const Circuit<Fp>&>(&Circuit<Fp>::add_circuit),
              "Add all gates in specified circuit. Given gates are copied.")
         .def("update_quantum_state",
-             static_cast<void (Circuit<Fp>::*)(StateVector<Fp>&, const std::map<std::string, Fp>&)
-                             const>(&Circuit<Fp>::update_quantum_state),
+             nb::overload_cast<StateVector<Fp>&, const std::map<std::string, Fp>&>(
+                 &Circuit<Fp>::update_quantum_state, nb::const_),
              "Apply gate to the StateVector. StateVector in args is directly updated. If the "
              "circuit contains parametric gate, you have to give real value of parameter as "
              "dict[str, float] in 2nd arg.")
@@ -149,9 +149,9 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
             "\"name=value\" format in kwargs.")
         .def(
             "update_quantum_state",
-            static_cast<void (Circuit<Fp>::*)(StateVectorBatched<Fp>&,
-                                              const std::map<std::string, std::vector<Fp>>&) const>(
-                &Circuit<Fp>::update_quantum_state),
+            nb::overload_cast<StateVectorBatched<Fp>&,
+                              const std::map<std::string, std::vector<Fp>>&>(
+                &Circuit<Fp>::update_quantum_state, nb::const_),
             "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
             "If the circuit contains parametric gate, you have to give real value of parameter as "
             "dict[str, list[float]] in 2nd arg.")

--- a/src/circuit/circuit.cpp
+++ b/src/circuit/circuit.cpp
@@ -92,6 +92,30 @@ void Circuit<Fp>::update_quantum_state(StateVector<Fp>& state,
 }
 
 FLOAT(Fp)
+void Circuit<Fp>::update_quantum_state(
+    StateVectorBatched<Fp>& states,
+    const std::map<std::string, std::vector<Fp>>& parameters) const {
+    for (auto&& gate : _gate_list) {
+        if (gate.index() == 0) continue;
+        const auto& key = std::get<1>(gate).second;
+        if (!parameters.contains(key)) {
+            using namespace std::string_literals;
+            throw std::runtime_error(
+                "Circuit::update_quantum_state(StateVector&, const std::map<std::string_view, double>&) const: parameter named "s +
+                std::string(key) + "is not given.");
+        }
+    }
+    for (auto&& gate : _gate_list) {
+        if (gate.index() == 0) {
+            std::get<0>(gate)->update_quantum_state(states);
+        } else {
+            const auto& [param_gate, key] = std::get<1>(gate);
+            param_gate->update_quantum_state(states, parameters.at(key));
+        }
+    }
+}
+
+FLOAT(Fp)
 Circuit<Fp> Circuit<Fp>::copy() const {
     Circuit ccircuit(_n_qubits);
     ccircuit._gate_list.reserve(_gate_list.size());


### PR DESCRIPTION
ゲートの更新でparameters[固定のキー][batch_id]を使うため、回路に渡すパラメータの型はmap<std::string, std::vector<Fp>>にしています。