### PR TITLE
コンテナ内の `nanobind` のインストール方法を変更

### DIFF
--- a/.devcontainer/cpu/Dockerfile
+++ b/.devcontainer/cpu/Dockerfile
@@ -50,6 +50,8 @@ RUN git clone --recursive https://github.com/kokkos/kokkos.git /tmp/kokkos --dep
     cp -r /tmp/kokkos-build/include /usr/local/include/kokkos && \
     rm -rf /tmp/kokkos /tmp/kokkos-build
 
+RUN pip install nanobind==2.0.0
+
 ARG USERNAME=vscode
 ARG GROUPNAME=vscode
 ARG USER_UID=1000

--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -34,7 +34,7 @@
 					"build/_deps/eigen-src",
 					"build/_deps/googletest-src/googletest/include",
 					"build/_deps/json-src/include",
-					"~/.local/lib/python3.10/site-packages/nanobind/include",
+					"/usr/local/lib/python3.10/dist-packages/nanobind/include/",
 					"/usr/include/python3.10"
 				],
 				"C_Cpp.default.cppStandard": "c++23",

--- a/.devcontainer/gpu/Dockerfile
+++ b/.devcontainer/gpu/Dockerfile
@@ -49,4 +49,6 @@ RUN git clone --recursive https://github.com/kokkos/kokkos.git /tmp/kokkos --dep
     cp -r /tmp/kokkos-build/include /usr/local/include/kokkos && \
     rm -rf /tmp/kokkos /tmp/kokkos-build
 
+RUN pip install nanobind==2.0.0
+
 USER vscode

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -35,7 +35,7 @@
 					"build/_deps/eigen-src",
 					"build/_deps/googletest-src/googletest/include",
 					"build/_deps/json-src/include",
-					"~/.local/lib/python3.10/site-packages/nanobind/include",
+					"/usr/local/lib/python3.10/dist-packages/nanobind/include/",
 					"/usr/include/python3.10"
 				],
 				"C_Cpp.default.cppStandard": "c++23",

--- a/include/scaluq/types.hpp
+++ b/include/scaluq/types.hpp
@@ -66,3 +66,10 @@ struct adl_serializer<::scaluq::StdComplex> {
     }
 };
 }  // namespace nlohmann
+
+#ifdef SCALUQ_USE_NANOBIND
+#include <nanobind/nanobind.h>
+namespace scaluq {
+namespace nb = nanobind;
+}
+#endif

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ homepage = "http://www.scaluq.org"
 doc = [
     "black == 24.4.2",
     "isort == 5.13.2",
-    "nanobind == 2.0.0",
     "sphinx == 7.3.7",
     "sphinx-autoapi == 3.1.1",
     "sphinxcontrib-napoleon == 0.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ homepage = "http://www.scaluq.org"
 doc = [
     "black == 24.4.2",
     "isort == 5.13.2",
+    "nanobind == 2.0.0",
     "sphinx == 7.3.7",
     "sphinx-autoapi == 3.1.1",
     "sphinxcontrib-napoleon == 0.7",


### PR DESCRIPTION
ソースコード内にも nanobind のメソッドが使われており，エディタ上でエラーが出てよくない．
先んじて nanobind をインストールするようにする．
