### PR TITLE
update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Qulacs-Osaka
+Copyright (c) 2023-2025 Qulacs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
ライセンの発行年を2023-2025にしました。発行者もQulacsにしました。