### PR TITLE
Wheel Buildeで使用するmanylinuxのバージョンを上げた

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -50,6 +50,8 @@ jobs:
             python-version: "3.13"
     runs-on: ${{ matrix.runs-on }}
     env:
+      CMAKE_C_COMPILER: 'gcc-14' # only passed to macOS
+      CMAKE_CXX_COMPILER: 'g++-14' # only passed to macOS
       CIBW_BUILD: ${{ matrix.cibw-python }}-${{ matrix.cibw-os-arch }}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
       CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -50,9 +50,9 @@ jobs:
             python-version: "3.13"
     runs-on: ${{ matrix.runs-on }}
     env:
-      CMAKE_C_COMPILER: ${{ matrix.os == 'macos' && 'gcc-14' || 'gcc' }}
-      CMAKE_CXX_COMPILER: ${{ matrix.os == 'macos' && 'g++-14' || 'g++' }}
       CIBW_BUILD: ${{ matrix.cibw-python }}-${{ matrix.cibw-os-arch }}
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+      CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
       PYTHON: ${{ matrix.python-version }}
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.runs-on == 'macos-14' && '14.0' || '13.0' }}
     steps:


### PR DESCRIPTION
C++23を要求してからしばらくWheel Buildが落ちていた( https://github.com/qulacs/scaluq/actions/runs/14256490159 )ので修正しました

runnerのImageをUbuntu24.04にしたので問題ないと思っていたのですが、cibuildwheelはLinuxの場合別のコンテナを作ってビルドしているようで、そこで使用するイメージをGCC 14が導入されているものに変更しました。