### PR TITLE
Circuit::optimize (control_value対応版)

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -29,7 +29,7 @@
 				"python.terminal.activateEnvironment": false,
 				// CAVEAT: you need to restart after building scaluq to take effect.
 				"C_Cpp.default.includePath": [
-					"scaluq",
+					"include",
 					"/usr/local/include/kokkos",
 					"build/_deps/eigen-src",
 					"build/_deps/googletest-src/googletest/include",

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -61,6 +61,8 @@ public:
 
     Circuit get_inverse() const;
 
+    void optimize(std::uint64_t block_size=3);
+
     friend void to_json(Json& j, const Circuit& circuit) {
         j = Json{{"n_qubits", circuit.n_qubits()}, {"gate_list", Json::array()}};
         for (auto&& gate : circuit.gate_list()) {

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -210,6 +210,11 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
         .def("get_inverse",
              &Circuit<Prec, Space>::get_inverse,
              "Get inverse of circuit. All the gates are newly created.")
+        .def("optimize",
+             &Circuit<Prec, Space>::optimize,
+             "max_block_size"_a = 3,
+             "Optimize circuit. Create qubit dependency tree and merge neighboring gates if the "
+             "new gate has less than or equal to `max_block_size` or the new gate is Pauli.")
         .def("simulate_noise",
              &Circuit<Prec, Space>::simulate_noise,
              "Simulate noise circuit. Return all the possible states and their counts.")

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -61,7 +61,7 @@ public:
 
     Circuit get_inverse() const;
 
-    void optimize(std::uint64_t block_size=3);
+    void optimize(std::uint64_t max_block_size = 3);
 
     friend void to_json(Json& j, const Circuit& circuit) {
         j = Json{{"n_qubits", circuit.n_qubits()}, {"gate_list", Json::array()}};

--- a/include/scaluq/gate/gate_probablistic.hpp
+++ b/include/scaluq/gate/gate_probablistic.hpp
@@ -34,9 +34,7 @@ public:
             "ProbablisticGateImpl.");
     }
     std::vector<std::uint64_t> operand_qubit_list() const override {
-        throw std::runtime_error(
-            "ProbablisticGateImpl::operand_qubit_list(): This function must not be used in "
-            "ProbablisticGateImpl.");
+        return mask_to_vector(operand_qubit_mask());
     }
     std::uint64_t target_qubit_mask() const override {
         throw std::runtime_error(
@@ -54,9 +52,9 @@ public:
             "ProbablisticGateImpl.");
     }
     std::uint64_t operand_qubit_mask() const override {
-        throw std::runtime_error(
-            "ProbablisticGateImpl::operand_qubit_mask(): This function must not be used in "
-            "ProbablisticGateImpl.");
+        std::uint64_t ret = 0ULL;
+        for (const Gate<Prec, Space>& gate : _gate_list) ret |= gate->operand_qubit_mask();
+        return ret;
     }
 
     std::shared_ptr<const GateBase<Prec, Space>> get_inverse() const override;

--- a/include/scaluq/gate/param_gate_probablistic.hpp
+++ b/include/scaluq/gate/param_gate_probablistic.hpp
@@ -39,9 +39,7 @@ public:
             "ParamProbablisticGateImpl.");
     }
     std::vector<std::uint64_t> operand_qubit_list() const override {
-        throw std::runtime_error(
-            "ParamProbablisticGateImpl::operand_qubit_list(): This function must not be used in "
-            "ParamProbablisticGateImpl.");
+        return mask_to_vector(operand_qubit_mask());
     }
     std::uint64_t target_qubit_mask() const override {
         throw std::runtime_error(
@@ -59,9 +57,10 @@ public:
             "ParamProbablisticGateImpl.");
     }
     std::uint64_t operand_qubit_mask() const override {
-        throw std::runtime_error(
-            "ParamProbablisticGateImpl::operand_qubit_mask(): This function must not be used in "
-            "ParamProbablisticGateImpl.");
+        std::uint64_t ret = 0ULL;
+        for (const EitherGate& gate : _gate_list)
+            ret |= std::visit([&](const auto& gate) { return gate->operand_qubit_mask(); }, gate);
+        return ret;
     }
 
     std::shared_ptr<const ParamGateBase<Prec, Space>> get_inverse() const override;

--- a/src/circuit/circuit.cpp
+++ b/src/circuit/circuit.cpp
@@ -1,5 +1,7 @@
 #include <scaluq/circuit/circuit.hpp>
+#include <scaluq/gate/gate_factory.hpp>
 #include <scaluq/gate/gate_probablistic.hpp>
+#include <scaluq/gate/merge_gate.hpp>
 #include <scaluq/gate/param_gate_probablistic.hpp>
 
 #include "../util/template.hpp"
@@ -148,85 +150,152 @@ Circuit<Prec, Space> Circuit<Prec, Space>::get_inverse() const {
 }
 
 template <Precision Prec, ExecutionSpace Space>
-void Circuit<Prec, Space>::optimize(std::uint64_t block_size) {
-    std::vector<GateWithKey> new_gate_list;
+void Circuit<Prec, Space>::optimize(std::uint64_t max_block_size) {
+    std::vector<GateWithKey> new_gate_list;  // result
     double global_phase = 0.;
-    std::vector<Gate> gate_pool;  // waitlist for merge or push
+    std::vector<Gate<Prec, Space>> gate_pool;  // waitlist for merge or push
     constexpr std::uint64_t NO_GATES = std::numeric_limits<std::uint64_t>::max();
-    std::vector<std::uint64_t> latest_gate_idx(
+    std::vector<std::uint64_t> waiting_gate_idx_at_qubit(
         _n_qubits,
         NO_GATES);  // which gate is waiting in the qubit (by index of gate_pool)
+    auto get_operand_list = [&](const GateWithKey& gate_with_key) {
+        if (gate_with_key.index() == 0)
+            return std::get<0>(gate_with_key)->operand_qubit_list();
+        else
+            return std::get<1>(gate_with_key).first->operand_qubit_list();
+    };
+    auto push = [&](const GateWithKey& gate_with_key) {
+        // clear waitlist and push gate to result
+        for (std::uint64_t operand : get_operand_list(gate_with_key)) {
+            waiting_gate_idx_at_qubit[operand] = NO_GATES;
+        }
+        new_gate_list.push_back(gate_with_key);
+    };
+    auto wait = [&](const Gate<Prec, Space>& gate) {
+        // wait for merge or push
+        std::uint64_t new_idx = gate_pool.size();
+        for (std::uint64_t operand : gate->operand_qubit_list()) {
+            waiting_gate_idx_at_qubit[operand] = new_idx;
+        }
+        gate_pool.push_back(gate);
+    };
+    auto get_waiting_gate_indices = [&](const GateWithKey& gate_with_key) {
+        std::vector<std::uint64_t> waiting_gate_indices;
+        for (std::uint64_t operand : get_operand_list(gate_with_key)) {
+            if (waiting_gate_idx_at_qubit[operand] != NO_GATES)
+                waiting_gate_indices.push_back(waiting_gate_idx_at_qubit[operand]);
+        }
+        std::ranges::sort(waiting_gate_indices);
+        waiting_gate_indices.erase(std::ranges::unique(waiting_gate_indices).begin(),
+                                   waiting_gate_indices.end());
+        return waiting_gate_indices;
+    };
+    auto push_waiting_gates = [&](const GateWithKey& gate_with_key) {
+        for (std::uint64_t idx : get_waiting_gate_indices(gate_with_key)) {
+            push(gate_pool[idx]);
+        }
+    };
+    auto get_newly_applied_qubits = [&](const GateWithKey& gate_with_key) {
+        std::vector<std::uint64_t> newly_applied_qubits;
+        for (std::uint64_t operand : get_operand_list(gate_with_key)) {
+            if (waiting_gate_idx_at_qubit[operand] == NO_GATES)
+                newly_applied_qubits.push_back(operand);
+        }
+        return newly_applied_qubits;
+    };
+
     for (const GateWithKey& gate_with_key : _gate_list) {
-        if (gate_with_key.index() == 1) {
-            // ParamGate is not optimized
-            const ParamGate& pgate = std::get<1>(gate_with_key).first;
-            for (std::uint64_t target : pgate->get_target_qubit_list()) {
-                latest_gate_idx[target] = NO_GATES;
-            }
-            for (std::uint64_t control : pgate->get_control_qubit_list()) {
-                latest_gate_idx[control] = NO_GATES;
-            }
-            new_gate_list.emplace_back(std::move(gate_with_key));
+        if (gate_with_key.index() == 1 ||
+            std::get<0>(gate_with_key).gate_type() == GateType::Probablistic) {
+            // ParamGate and Probablistic cannot be merged with others
+            push_waiting_gates(gate_with_key);
+            push(gate_with_key);
             continue;
         }
-        const Gate& gate = std::get<0>(gate_with_key);
-        auto operand_list = gate->operand_qubit_list();
+        const Gate<Prec, Space>& gate = std::get<0>(gate_with_key);
         if (gate.gate_type() == GateType::I) continue;  // IGate is ignored
         if (gate.gate_type() == GateType::GlobalPhase && gate->control_qubit_mask() == 0ULL) {
             // non-controlled GlobalPhase is ignored
-            global_phase += gate.global_phase();
+            global_phase += GlobalPhaseGate<Prec, Space>(gate)->phase();
             continue;
         }
-        std::vector<std::uint64_t>
-            previous_gate_indices;  // indices of gates in gate_pool which is waiting
-        std::vector<std::uint64_t>
-            newly_applied_qubits;  // qubits which is newly applied by this gate
-        for (std::uint64_t operand : operand_list) {
-            if (latest_gate_idx[operand] == NO_GATES) {
-                newly_applied_qubits.push_back(operand);
-            } else {
-                previous_gate_indices.push_back(latest_gate_idx[operand]);
-            }
-        }
-        std::ranges::sort(previous_gate_indices);
-        previous_gate_indices.erase(std::ranges::unique(previous_gate_indices).begin(),
-                                    previous_gate_indices.end());
-        std::uint64_t new_idx = gate_pool.size();
-        if (previous_gate_indices.empty()) {
-            // not merge, just wait
-            for (std::uint64_t operand : operand_list) {
-                latest_gate_idx[operand] = new_idx;
-            }
-            gate_pool.emplace_back(std::move(gate));
+        std::vector<std::uint64_t> waiting_gate_indices = get_waiting_gate_indices(gate_with_key);
+        if (waiting_gate_indices.empty()) {
+            // just wait
+            wait(gate);
             continue;
         }
+        std::vector<std::uint64_t> newly_applied_qubits = get_newly_applied_qubits(gate_with_key);
         std::uint64_t new_gate_size =
-            newly_applied_qubits.size() +
-            std::accumulate(previous_gate_indices.begin(),
-                            previous_gate_indices.end(),
-                            0ULL,
+            std::accumulate(waiting_gate_indices.begin(),
+                            waiting_gate_indices.end(),
+                            newly_applied_qubits.size(),
                             [&](std::uint64_t acc, std::uint64_t idx) {
-                                return acc + gate_pool[idx]->get_target_qubit_list().size();
+                                return acc + gate_pool[idx]->operand_qubit_list().size();
                             });
-        if (previous_gate_indices.size() == 1) {
-            // common control qubits are not counted as size
-            std::uint64_t control_qubit_mask1 = gate->control_qubit_mask();
-            std::uint64_t control_value_mask1 = gate->control_value_mask();
-            std::uint64_t control_qubit_mask2 = previous_gate_indices[0]->control_qubit_mask();
-            std::uint64_t control_value_mask2 = previous_gate_indices[0]->control_value_mask();
-            new_gate_size -= std::popcount(control_qubit_mask1 & control_qubit_mask2 &
-                                           ~(control_value_mask1 ^ control_value_mask2));
-        }
-        auto is_pauli = [&](Gate& gate) {
-            if (gate->control_qubit_mask() != 0ULL) return false;
+        auto is_pauli = [&](const Gate<Prec, Space>& gate) {
             return gate.gate_type() == GateType::X || gate.gate_type() == GateType::Y ||
                    gate.gate_type() == GateType::Z || gate.gate_type() == GateType::Pauli;
         };
-        bool all_pauli =
-            is_pauli(gate) && std::ranges::all_of(previous_gate_indices, [&](std::uint64_t idx) {
-                return is_pauli(gate_pool[idx]);
-            });
+        auto is_pure_pauli = [&](const Gate<Prec, Space>& gate) {
+            return gate->control_qubit_mask() == 0ULL && is_pauli(gate);
+        };
+        bool all_pauli = is_pure_pauli(gate) &&
+                         std::ranges::all_of(waiting_gate_indices, [&](std::uint64_t idx) {
+                             return is_pure_pauli(gate_pool[idx]);
+                         });
+        if (waiting_gate_indices.size() == 1) {
+            const Gate<Prec, Space>& previous_gate = gate_pool[waiting_gate_indices[0]];
+            // common control qubits are not counted as size
+            std::uint64_t control_qubit_mask1 = gate->control_qubit_mask();
+            std::uint64_t control_value_mask1 = gate->control_value_mask();
+            std::uint64_t control_qubit_mask2 = previous_gate->control_qubit_mask();
+            std::uint64_t control_value_mask2 = previous_gate->control_value_mask();
+            new_gate_size -= std::popcount(control_qubit_mask1 & control_qubit_mask2 &
+                                           ~(control_value_mask1 ^ control_value_mask2));
+
+            // check whether both gates are pauli with same control qubits
+            if (control_qubit_mask1 == control_qubit_mask2 &&
+                control_value_mask1 == control_value_mask2 && is_pauli(gate) &&
+                is_pauli(previous_gate)) {
+                all_pauli = true;
+            }
+        }
+        if (all_pauli || new_gate_size <= max_block_size) {
+            // merge with waiting gates
+            Gate<Prec, Space> merged_gate = gate;
+            for (std::uint64_t idx : waiting_gate_indices) {
+                const auto& [new_merged_gate, phase] = merge_gate(gate_pool[idx], merged_gate);
+                merged_gate = new_merged_gate;
+                global_phase += phase;
+            }
+
+            // wait
+            wait(merged_gate);
+        } else {
+            // not merge
+            // push waiting gates
+            for (std::uint64_t idx : waiting_gate_indices) {
+                push(gate_pool[idx]);
+            }
+
+            // wait
+            wait(gate);
+        }
     }
+    std::vector<std::uint64_t> finally_waiting_gate_indices;
+    for (std::uint64_t idx : waiting_gate_idx_at_qubit) {
+        if (idx != NO_GATES) finally_waiting_gate_indices.push_back(idx);
+    }
+    std::ranges::sort(finally_waiting_gate_indices);
+    finally_waiting_gate_indices.erase(std::ranges::unique(finally_waiting_gate_indices).begin(),
+                                       finally_waiting_gate_indices.end());
+    for (std::uint64_t idx : finally_waiting_gate_indices) {
+        new_gate_list.push_back(gate_pool[idx]);
+    }
+    if (std::abs(global_phase) > 1e-12)
+        new_gate_list.push_back(gate::GlobalPhase<Prec, Space>(global_phase));
+    _gate_list.swap(new_gate_list);
 }
 
 template <Precision Prec, ExecutionSpace Space>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ enable_testing()
 
 add_executable(scaluq_test EXCLUDE_FROM_ALL
     circuit/circuit_test.cpp
+    circuit/circuit_optimize_test.cpp
     circuit/param_circuit_test.cpp
     gate/gate_test.cpp
     gate/batched_gate_test.cpp

--- a/tests/circuit/circuit_optimize_test.cpp
+++ b/tests/circuit/circuit_optimize_test.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+
+#include <scaluq/circuit/circuit.hpp>
+#include <scaluq/gate/gate_factory.hpp>
+#include <scaluq/gate/param_gate_factory.hpp>
+
+#include "../test_environment.hpp"
+#include "../util/util.hpp"
+
+using namespace scaluq;
+
+template <typename T>
+class CircuitOptimizeTest : public FixtureBase<T> {};
+TYPED_TEST_SUITE(CircuitOptimizeTest, TestTypes, NameGenerator);
+
+TYPED_TEST(CircuitOptimizeTest, Basic) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    constexpr std::uint64_t N = 10;
+    constexpr std::uint64_t M = 100;
+    Random random;
+    Circuit<Prec, Space> circuit(N);
+    std::vector<std::function<void()>> adders;
+    std::vector<std::string> keys;
+    adders.push_back([&] { circuit.add_gate(gate::I<Prec, Space>()); });
+    adders.push_back([&] {
+        circuit.add_gate(
+            gate::GlobalPhase<Prec, Space>(random.uniform() * std::numbers::pi_v<double> * 2));
+    });
+    adders.push_back([&] {
+        circuit.add_gate(
+            gate::GlobalPhase<Prec, Space>(random.uniform() * std::numbers::pi_v<double> * 2,
+                                           {random.int64() % N},
+                                           {random.int32() & 1}));
+    });
+    auto gen_dense = [&](std::uint64_t num_targets, std::uint64_t num_controls) {
+        auto perm = random.permutation(N);
+        ComplexMatrix mat = ComplexMatrix::Identity(1, 1);
+        for ([[maybe_unused]] std::uint64_t _ : std::views::iota(std::uint64_t{0}, num_targets)) {
+            mat = internal::kronecker_product(mat, get_eigen_matrix_random_one_target_unitary());
+        }
+        std::vector<std::uint64_t> control_values(num_controls);
+        for (std::uint64_t& val : control_values) val = random.int32() & 1;
+        return gate::DenseMatrix<Prec, Space>(
+            std::vector<std::uint64_t>(perm.begin(), perm.begin() + num_targets),
+            mat,
+            std::vector<std::uint64_t>(perm.begin() + num_targets,
+                                       perm.begin() + num_targets + num_controls),
+            control_values);
+    };
+    adders.push_back([&] { circuit.add_gate(gen_dense(1, 0)); });
+    adders.push_back([&] { circuit.add_gate(gen_dense(1, 1)); });
+    adders.push_back([&] { circuit.add_gate(gen_dense(1, 2)); });
+    adders.push_back([&] { circuit.add_gate(gen_dense(2, 0)); });
+    adders.push_back([&] { circuit.add_gate(gen_dense(2, 1)); });
+    adders.push_back([&] { circuit.add_gate(gen_dense(2, 2)); });
+    adders.push_back(
+        [&] { circuit.add_gate(gate::Probablistic<Prec, Space>({1.}, {gate::I<Prec, Space>()})); });
+    adders.push_back([&] {
+        std::string new_key = std::to_string(keys.size());
+        circuit.add_param_gate(gate::ParamRX<Prec, Space>(0), new_key);
+        keys.push_back(new_key);
+    });
+    for ([[maybe_unused]] std::uint64_t _ : std::views::iota(std::uint64_t{0}, M)) {
+        adders[random.int32() % adders.size()]();
+    }
+    std::map<std::string, double> params;
+    for (const std::string& key : keys) {
+        params[key] = random.uniform() * std::numbers::pi_v<double> * 2;
+    }
+
+    StateVector<Prec, Space> state0 = StateVector<Prec, Space>::Haar_random_state(N);
+    StateVector<Prec, Space> state1 = state0.copy();
+    circuit.update_quantum_state(state0, params);
+    circuit.optimize();
+    circuit.update_quantum_state(state1, params);
+    assert(same_state(state0, state1));
+}


### PR DESCRIPTION
close #68 

#146 からかなり時間が立ち、現在のアーキテクチャに対応したCircuit::optimizeを書き直しました。 #215 のcontrol_valuesにまで対応しています。

少なくとも`merge_gate`がcontrol_valuesに対応していないのが原因でテストが落ちています。まずは #215 を優先して進めていただければと思います。