### PR TITLE
Ctest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,4 +94,4 @@ jobs:
           else
             NPROC=$(nproc)
           fi
-          OMP_PROC_BIND=false ctest --test-dir -j ${NPROC}
+          OMP_PROC_BIND=false ctest --test-dir build/ -j ${NPROC}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install scaluq for Ubuntu
         run: ./script/build_gcc.sh
 
-      - name: Test in Ubuntu
+      - name: Test
         if: ${{ matrix.device == 'cpu' }} # currently GPU runner is not supported
         run: |
           if [ "$(uname)" == 'Darwin' ]; then
@@ -94,4 +94,4 @@ jobs:
           else
             NPROC=$(nproc)
           fi
-          OMP_PROC_BIND=false ninja test -C build -j ${NPROC}
+          OMP_PROC_BIND=false ctest --test-dir -j ${NPROC}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ if(SKBUILD)
     add_subdirectory(python)
 endif(SKBUILD)
 if(SCALUQ_USE_TEST)
+    enable_testing()
     add_subdirectory(tests)
 endif(SCALUQ_USE_TEST)
 if(SCALUQ_USE_EXE)
@@ -238,15 +239,6 @@ if(SKBUILD)
         DEPENDS scaluq_core
     )
 endif(SKBUILD)
-
-# test
-if(SCALUQ_USE_TEST)
-    add_custom_target(
-        test
-        DEPENDS scaluq_test
-        COMMAND scaluq_test
-    )
-endif(SCALUQ_USE_TEST)
 
 # format
 find_program(CLANG_FORMAT "clang-format")

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ scaluq は、量子回路シミュレータ [Qulacs](https://github.com/qulacs/q
 |`SCALUQ_USE_OMP`|`ON`|CPUでの並列処理にOpenMPを利用するか|
 |`SCALUQ_USE_CUDA`|`OFF`|GPU (CUDA)での並列処理を行うか|
 |`SCALUQ_CUDA_ARCH`|(自動識別)|`CMAKE_USE_CUDA=ON`の場合、ターゲットとなるNvidia GPU アーキテクチャ (名前は[Kokkos CMake Keywords](https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html)を参照、例: `SCALUQ_CUDA_ARCH=AMPERE80`)|
-|`SCALUQ_USE_TEST`|ON|`test/`をビルドターゲットに含める。`ninja -C build test`でテストのビルド/実行ができる|
+|`SCALUQ_USE_TEST`|ON|`test/`をビルドターゲットに含める。`ctest --test-dir build/`でテストのビルド/実行ができる|
 |`SCALUQ_USE_EXE`|ON|`exe/`をビルドターゲットに含める。インストールせずに実行を試すことができ、`ninja -C build`でのビルド後、`exe/main.cpp`の内容を`build/exe/main`で実行できる。|
 |`SCALUQ_FLOAT16`|OFF|`f16`精度を有効にする|
 |`SCALUQ_FLOAT32`|ON|`f32`精度を有効にする|

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.21)
 
-enable_testing()
+include(GoogleTest)
 
-add_executable(scaluq_test EXCLUDE_FROM_ALL
+add_executable(scaluq_test
     circuit/circuit_test.cpp
     circuit/param_circuit_test.cpp
     gate/gate_test.cpp
@@ -24,3 +24,5 @@ target_link_libraries(scaluq_test PUBLIC
 )
 target_include_directories(scaluq_test PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
 target_include_directories(scaluq_test PRIVATE ${eigen_SOURCE_DIR})
+
+gtest_discover_tests(scaluq_test)


### PR DESCRIPTION
ctestを導入しました。
今までのテスト実行では終了後に結果がまとめて表示されていましたが、ctestを使うと随時表示されてくれます。テスト内でのデバッグ出力は結果と同じ場所に表示されなくなりますが、`build/Testing/Temporary/LastTest.log`に従来のテストログが書き込まれます。

変更後は`SCALUQ_USE_TEST=ON`でconfigureしたあと`ninja -C build`を実行するとその段階でテストもビルドされるようになっており、`ctest --test-dir build/`で実行できます。
一部のテストだけ実行したい場合は今後はctestの`-R`オプションでフィルターできます。