### PR TITLE
capitalize Scaluq

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
           cmake --version
           ninja --version
 
-      - name: Install scaluq for Ubuntu
+      - name: Install Scaluq for Ubuntu
         run: ./script/build_gcc.sh
 
       - name: Test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# scaluq
+# Scaluq
 
-scaluq は、量子回路シミュレータ [Qulacs](https://github.com/qulacs/qulacs) をもとに再開発された、新しい Python/C++ ライブラリです。
+Scaluq は、量子回路シミュレータ [Qulacs](https://github.com/qulacs/qulacs) をもとに再開発された、新しい Python/C++ ライブラリです。
 大規模な量子回路、ノイズを伴う量子回路(未実装)、パラメトリック量子回路の高速シミュレーションを実行することができます。
 本ライブラリは、MITライセンスの下で公開されています。
 
@@ -46,7 +46,7 @@ scaluq は、量子回路シミュレータ [Qulacs](https://github.com/qulacs/q
 
 ## C++ ライブラリとしてインストール
 
-scaluq を静的ライブラリとしてインストールするには、以下の一連のコマンドを実行します。
+Scaluq を静的ライブラリとしてインストールするには、以下の一連のコマンドを実行します。
 
 ```txt
 git clone https://github.com/qulacs/scaluq
@@ -66,7 +66,7 @@ sudo -E env "PATH=$PATH" ninja -C build install
 rm build/CMakeCache.txt
 ```
 
-インストール済みのscaluqを利用したプロジェクトでのCMake設定例を[example_project/](example_project/CMakeLists.txt)に提示しています。
+インストール済みのScaluqを利用したプロジェクトでのCMake設定例を[example_project/](example_project/CMakeLists.txt)に提示しています。
 
 ## Python ライブラリとしてインストール
 Python のライブラリとしても使用することができます。
@@ -146,7 +146,7 @@ print(value)
 ```
 
 # 精度と実行スペースの指定について
-scaluqでは、計算に使用する浮動小数点数のサイズとして`f16` `f32` `f64` `bf16`が選択できます。ただしデフォルトのビルドオプションでは`f16` `bf16`は無効になっています。
+Scaluqでは、計算に使用する浮動小数点数のサイズとして`f16` `f32` `f64` `bf16`が選択できます。ただしデフォルトのビルドオプションでは`f16` `bf16`は無効になっています。
 通常は`f64`の使用が推奨されますが、量子機械学習での利用などあまり精度が必要でない場合は`f32`以下を使用すると最大2~4倍の高速化が見込めます。
 
 各精度の指定方法と内容は以下のとおりです。

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,9 +1,9 @@
-.. scaluq documentation master file, created by
+.. Scaluq documentation master file, created by
    sphinx-quickstart on Thu Mar 28 10:04:24 2024.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to scaluq's documentation!
+Welcome to Scaluq's documentation!
 ==================================
 
 .. toctree::


### PR DESCRIPTION
Qulacsに合わせて、Scaluqの名称を先頭大文字にしました。