### PR TITLE
Define macro for omission of template

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,12 +7,6 @@ on:
       - ".vscode/**"
       - "doc/**"
       - "*.md"
-  pull_request:
-    paths-ignore:
-      - ".devcontainer/**"
-      - ".vscode/**"
-      - "doc/**"
-      - "*.md"
 
 jobs:
   check-format:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -7,12 +7,6 @@ on:
       - ".vscode/**"
       - "doc/**"
       - "*.md"
-  pull_request:
-    paths-ignore:
-      - ".devcontainer/**"
-      - ".vscode/**"
-      - "doc/**"
-      - "*.md"
 
 jobs:
   library:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,4 +88,4 @@ jobs:
           else
             NPROC=$(nproc)
           fi
-          OMP_PROC_BIND=false ctest --test-dir -j ${NPROC}
+          OMP_PROC_BIND=false ctest --test-dir build/ -j ${NPROC}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install scaluq for Ubuntu
         run: ./script/build_gcc.sh
 
-      - name: Test in Ubuntu
+      - name: Test
         if: ${{ matrix.device == 'cpu' }} # currently GPU runner is not supported
         run: |
           if [ "$(uname)" == 'Darwin' ]; then
@@ -88,4 +88,4 @@ jobs:
           else
             NPROC=$(nproc)
           fi
-          OMP_PROC_BIND=false ninja test -C build -j ${NPROC}
+          OMP_PROC_BIND=false ctest --test-dir -j ${NPROC}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,6 @@ on:
       - ".vscode/**"
       - "doc/**"
       - "*.md"
-  pull_request:
-    paths-ignore:
-      - ".devcontainer/**"
-      - ".vscode/**"
-      - "doc/**"
-      - "*.md"
 
 jobs:
   test:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,7 @@ if(SKBUILD)
     add_subdirectory(python)
 endif(SKBUILD)
 if(SCALUQ_USE_TEST)
+    enable_testing()
     add_subdirectory(tests)
 endif(SCALUQ_USE_TEST)
 if(SCALUQ_USE_EXE)
@@ -253,15 +254,6 @@ if(SKBUILD)
         DEPENDS scaluq_core
     )
 endif(SKBUILD)
-
-# test
-if(SCALUQ_USE_TEST)
-    add_custom_target(
-        test
-        DEPENDS scaluq_test
-        COMMAND scaluq_test
-    )
-endif(SCALUQ_USE_TEST)
 
 # format
 find_program(CLANG_FORMAT "clang-format")

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ https://scaluq.readthedocs.io/en/latest/index.html
 int main() {
     scaluq::initialize();  // must be called before using any scaluq methods
     {
-        constexpr Precision Prec = Precision::F64;
-        constexpr ExecutionSpace Space = ExecutionSpace::Default;
+        constexpr Precision Prec = scaluq::Precision::F64;
+        constexpr ExecutionSpace Space = scaluq::ExecutionSpace::Default;
         const std::uint64_t n_qubits = 3;
         scaluq::StateVector<Prec, Default> state = scaluq::StateVector<Prec, Default>::Haar_random_state(n_qubits, 0);
         std::cout << state << std::endl;
@@ -114,6 +114,45 @@ int main() {
         circuit.update_quantum_state(state);
 
         scaluq::Operator<Prec, Default> observable(n_qubits);
+        observable.add_random_operator(1, 0);
+        auto value = observable.get_expectation_value(state);
+        std::cout << value << std::endl;
+    }
+    scaluq::finalize();  // must be called last
+}
+```
+
+`scaluq/all.hpp` をincludeすれば、`SCALUQ_OMIT_TEMPLATE` を使うことでテンプレート引数を省略することもできます。
+
+```cpp
+#include <iostream>
+#include <cstdint>
+
+#include <scaluq/all.hpp>
+
+namespace my_scaluq {
+    SCALUQ_OMIT_TEMPLATE(scaluq::Precision::F64, scaluq::ExecutionSpace::Default)
+}
+
+using namespace my_scaluq;
+
+int main() {
+    scaluq::initialize();  // must be called before using any scaluq methods
+    {
+        constexpr Precision Prec = Precision::F64;
+        constexpr ExecutionSpace Space = ExecutionSpace::Default;
+        const std::uint64_t n_qubits = 3;
+        StateVector state = StateVector::Haar_random_state(n_qubits, 0);
+        std::cout << state << std::endl;
+
+        Circuit circuit(n_qubits);
+        circuit.add_gate(gate::X(0));
+        circuit.add_gate(gate::CNot(0, 1));
+        circuit.add_gate(gate::Y(1));
+        circuit.add_gate(gate::RX(1, std::numbers::pi / 2));
+        circuit.update_quantum_state(state);
+
+        Operator observable(n_qubits);
         observable.add_random_operator(1, 0);
         auto value = observable.get_expectation_value(state);
         std::cout << value << std::endl;

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ scaluq は、量子回路シミュレータ [Qulacs](https://github.com/qulacs/q
 |`SCALUQ_USE_OMP`|`ON`|CPUでの並列処理にOpenMPを利用するか|
 |`SCALUQ_USE_CUDA`|`OFF`|GPU (CUDA)での並列処理を行うか|
 |`SCALUQ_CUDA_ARCH`|(自動識別)|`CMAKE_USE_CUDA=ON`の場合、ターゲットとなるNvidia GPU アーキテクチャ (名前は[Kokkos CMake Keywords](https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html)を参照、例: `SCALUQ_CUDA_ARCH=AMPERE80`)|
-|`SCALUQ_USE_TEST`|ON|`test/`をビルドターゲットに含める。`ninja -C build test`でテストのビルド/実行ができる|
+|`SCALUQ_USE_TEST`|ON|`test/`をビルドターゲットに含める。`ctest --test-dir build/`でテストのビルド/実行ができる|
 |`SCALUQ_USE_EXE`|ON|`exe/`をビルドターゲットに含める。インストールせずに実行を試すことができ、`ninja -C build`でのビルド後、`exe/main.cpp`の内容を`build/exe/main`で実行できる。|
 |`SCALUQ_FLOAT16`|OFF|`f16`精度を有効にする|
 |`SCALUQ_FLOAT32`|ON|`f32`精度を有効にする|

--- a/include/scaluq/all.hpp
+++ b/include/scaluq/all.hpp
@@ -14,3 +14,235 @@
 #include "state/state_vector_batched.hpp"
 #include "types.hpp"
 #include "util/random.hpp"
+
+#define SCALUQ_OMIT_TEMPLATE(Prec, Space)                                                          \
+    using StateVector = ::scaluq::StateVector<Prec, Space>;                                        \
+    using StateVectorBatched = ::scaluq::StateVectorBatched<Prec, Space>;                          \
+    using PauliOperator = ::scaluq::PauliOperator<Prec, Space>;                                    \
+    using Operator = ::scaluq::Operator<Prec, Space>;                                              \
+    using Gate = ::scaluq::Gate<Prec, Space>;                                                      \
+    using IGate = ::scaluq::IGate<Prec, Space>;                                                    \
+    using GlobalPhaseGate = ::scaluq::GlobalPhaseGate<Prec, Space>;                                \
+    using XGate = ::scaluq::XGate<Prec, Space>;                                                    \
+    using YGate = ::scaluq::YGate<Prec, Space>;                                                    \
+    using ZGate = ::scaluq::ZGate<Prec, Space>;                                                    \
+    using HGate = ::scaluq::HGate<Prec, Space>;                                                    \
+    using SGate = ::scaluq::SGate<Prec, Space>;                                                    \
+    using SdagGate = ::scaluq::SdagGate<Prec, Space>;                                              \
+    using TGate = ::scaluq::TGate<Prec, Space>;                                                    \
+    using TdagGate = ::scaluq::TdagGate<Prec, Space>;                                              \
+    using SqrtXGate = ::scaluq::SqrtXGate<Prec, Space>;                                            \
+    using SqrtXdagGate = ::scaluq::SqrtXdagGate<Prec, Space>;                                      \
+    using SqrtYGate = ::scaluq::SqrtYGate<Prec, Space>;                                            \
+    using SqrtYdagGate = ::scaluq::SqrtYdagGate<Prec, Space>;                                      \
+    using P0Gate = ::scaluq::P0Gate<Prec, Space>;                                                  \
+    using P1Gate = ::scaluq::P1Gate<Prec, Space>;                                                  \
+    using RXGate = ::scaluq::RXGate<Prec, Space>;                                                  \
+    using RYGate = ::scaluq::RYGate<Prec, Space>;                                                  \
+    using RZGate = ::scaluq::RZGate<Prec, Space>;                                                  \
+    using U1Gate = ::scaluq::U1Gate<Prec, Space>;                                                  \
+    using U2Gate = ::scaluq::U2Gate<Prec, Space>;                                                  \
+    using U3Gate = ::scaluq::U3Gate<Prec, Space>;                                                  \
+    using SwapGate = ::scaluq::SwapGate<Prec, Space>;                                              \
+    using PauliGate = ::scaluq::PauliGate<Prec, Space>;                                            \
+    using PauliRotationGate = ::scaluq::PauliRotationGate<Prec, Space>;                            \
+    using SparseMatrixGate = ::scaluq::SparseMatrixGate<Prec, Space>;                              \
+    using DenseMatrixGate = ::scaluq::DenseMatrixGate<Prec, Space>;                                \
+    using ProbabilisticGate = ::scaluq::ProbabilisticGate<Prec, Space>;                            \
+    namespace gate {                                                                               \
+    inline auto& I = ::scaluq::gate::I<Prec, Space>;                                               \
+    inline Gate GlobalPhase(double phase,                                                          \
+                            const std::vector<std::uint64_t>& controls = {},                       \
+                            std::vector<std::uint64_t> control_values = {}) {                      \
+        return ::scaluq::gate::GlobalPhase<Prec, Space>(phase, controls, control_values);          \
+    }                                                                                              \
+    inline Gate X(std::uint64_t target,                                                            \
+                  const std::vector<std::uint64_t>& controls = {},                                 \
+                  std::vector<std::uint64_t> control_values = {}) {                                \
+        return ::scaluq::gate::X<Prec, Space>(target, controls, control_values);                   \
+    }                                                                                              \
+    inline Gate Y(std::uint64_t target,                                                            \
+                  const std::vector<std::uint64_t>& controls = {},                                 \
+                  std::vector<std::uint64_t> control_values = {}) {                                \
+        return ::scaluq::gate::Y<Prec, Space>(target, controls, control_values);                   \
+    }                                                                                              \
+    inline Gate Z(std::uint64_t target,                                                            \
+                  const std::vector<std::uint64_t>& controls = {},                                 \
+                  std::vector<std::uint64_t> control_values = {}) {                                \
+        return ::scaluq::gate::Z<Prec, Space>(target, controls, control_values);                   \
+    }                                                                                              \
+    inline Gate H(std::uint64_t target,                                                            \
+                  const std::vector<std::uint64_t>& controls = {},                                 \
+                  std::vector<std::uint64_t> control_values = {}) {                                \
+        return ::scaluq::gate::H<Prec, Space>(target, controls, control_values);                   \
+    }                                                                                              \
+    inline Gate S(std::uint64_t target,                                                            \
+                  const std::vector<std::uint64_t>& controls = {},                                 \
+                  std::vector<std::uint64_t> control_values = {}) {                                \
+        return ::scaluq::gate::S<Prec, Space>(target, controls, control_values);                   \
+    }                                                                                              \
+    inline Gate Sdag(std::uint64_t target,                                                         \
+                     const std::vector<std::uint64_t>& controls = {},                              \
+                     std::vector<std::uint64_t> control_values = {}) {                             \
+        return ::scaluq::gate::Sdag<Prec, Space>(target, controls, control_values);                \
+    }                                                                                              \
+    inline Gate T(std::uint64_t target,                                                            \
+                  const std::vector<std::uint64_t>& controls = {},                                 \
+                  std::vector<std::uint64_t> control_values = {}) {                                \
+        return ::scaluq::gate::T<Prec, Space>(target, controls, control_values);                   \
+    }                                                                                              \
+    inline Gate Tdag(std::uint64_t target,                                                         \
+                     const std::vector<std::uint64_t>& controls = {},                              \
+                     std::vector<std::uint64_t> control_values = {}) {                             \
+        return ::scaluq::gate::Tdag<Prec, Space>(target, controls, control_values);                \
+    }                                                                                              \
+    inline Gate SqrtX(std::uint64_t target,                                                        \
+                      const std::vector<std::uint64_t>& controls = {},                             \
+                      std::vector<std::uint64_t> control_values = {}) {                            \
+        return ::scaluq::gate::SqrtX<Prec, Space>(target, controls, control_values);               \
+    }                                                                                              \
+    inline Gate SqrtXdag(std::uint64_t target,                                                     \
+                         const std::vector<std::uint64_t>& controls = {},                          \
+                         std::vector<std::uint64_t> control_values = {}) {                         \
+        return ::scaluq::gate::SqrtXdag<Prec, Space>(target, controls, control_values);            \
+    }                                                                                              \
+    inline Gate SqrtY(std::uint64_t target,                                                        \
+                      const std::vector<std::uint64_t>& controls = {},                             \
+                      std::vector<std::uint64_t> control_values = {}) {                            \
+        return ::scaluq::gate::SqrtY<Prec, Space>(target, controls, control_values);               \
+    }                                                                                              \
+    inline Gate SqrtYdag(std::uint64_t target,                                                     \
+                         const std::vector<std::uint64_t>& controls = {},                          \
+                         std::vector<std::uint64_t> control_values = {}) {                         \
+        return ::scaluq::gate::SqrtYdag<Prec, Space>(target, controls, control_values);            \
+    }                                                                                              \
+    inline Gate P0(std::uint64_t target,                                                           \
+                   const std::vector<std::uint64_t>& controls = {},                                \
+                   std::vector<std::uint64_t> control_values = {}) {                               \
+        return ::scaluq::gate::P0<Prec, Space>(target, controls, control_values);                  \
+    }                                                                                              \
+    inline Gate P1(std::uint64_t target,                                                           \
+                   const std::vector<std::uint64_t>& controls = {},                                \
+                   std::vector<std::uint64_t> control_values = {}) {                               \
+        return ::scaluq::gate::P1<Prec, Space>(target, controls, control_values);                  \
+    }                                                                                              \
+    inline Gate RX(std::uint64_t target,                                                           \
+                   double angle,                                                                   \
+                   const std::vector<std::uint64_t>& controls = {},                                \
+                   std::vector<std::uint64_t> control_values = {}) {                               \
+        return ::scaluq::gate::RX<Prec, Space>(target, angle, controls, control_values);           \
+    }                                                                                              \
+    inline Gate RY(std::uint64_t target,                                                           \
+                   double angle,                                                                   \
+                   const std::vector<std::uint64_t>& controls = {},                                \
+                   std::vector<std::uint64_t> control_values = {}) {                               \
+        return ::scaluq::gate::RY<Prec, Space>(target, angle, controls, control_values);           \
+    }                                                                                              \
+    inline Gate RZ(std::uint64_t target,                                                           \
+                   double angle,                                                                   \
+                   const std::vector<std::uint64_t>& controls = {},                                \
+                   std::vector<std::uint64_t> control_values = {}) {                               \
+        return ::scaluq::gate::RZ<Prec, Space>(target, angle, controls, control_values);           \
+    }                                                                                              \
+    inline Gate U1(std::uint64_t target,                                                           \
+                   double lambda,                                                                  \
+                   const std::vector<std::uint64_t>& controls = {},                                \
+                   std::vector<std::uint64_t> control_values = {}) {                               \
+        return ::scaluq::gate::U1<Prec, Space>(target, lambda, controls, control_values);          \
+    }                                                                                              \
+    inline Gate U2(std::uint64_t target,                                                           \
+                   double phi,                                                                     \
+                   double lambda,                                                                  \
+                   const std::vector<std::uint64_t>& controls = {},                                \
+                   std::vector<std::uint64_t> control_values = {}) {                               \
+        return ::scaluq::gate::U2<Prec, Space>(target, phi, lambda, controls, control_values);     \
+    }                                                                                              \
+    inline Gate U3(std::uint64_t target,                                                           \
+                   double theta,                                                                   \
+                   double phi,                                                                     \
+                   double lambda,                                                                  \
+                   const std::vector<std::uint64_t>& controls = {},                                \
+                   std::vector<std::uint64_t> control_values = {}) {                               \
+        return ::scaluq::gate::U3<Prec, Space>(                                                    \
+            target, theta, phi, lambda, controls, control_values);                                 \
+    }                                                                                              \
+    inline auto& CX = ::scaluq::gate::CX<Prec, Space>;                                             \
+    inline auto& CNot = ::scaluq::gate::CNot<Prec, Space>;                                         \
+    inline auto& CZ = ::scaluq::gate::CZ<Prec, Space>;                                             \
+    inline auto& CCX = ::scaluq::gate::CCX<Prec, Space>;                                           \
+    inline auto& Toffoli = ::scaluq::gate::Toffoli<Prec, Space>;                                   \
+    inline auto& CCNot = ::scaluq::gate::CCNot<Prec, Space>;                                       \
+    inline Gate Swap(std::uint64_t target1,                                                        \
+                     std::uint64_t target2,                                                        \
+                     const std::vector<std::uint64_t>& controls = {},                              \
+                     std::vector<std::uint64_t> control_values = {}) {                             \
+        return ::scaluq::gate::Swap<Prec, Space>(target1, target2, controls, control_values);      \
+    }                                                                                              \
+    inline Gate Pauli(const PauliOperator& pauli,                                                  \
+                      const std::vector<std::uint64_t>& controls = {},                             \
+                      std::vector<std::uint64_t> control_values = {}) {                            \
+        return ::scaluq::gate::Pauli<Prec, Space>(pauli, controls, control_values);                \
+    }                                                                                              \
+    inline Gate PauliRotation(const PauliOperator& pauli,                                          \
+                              double angle,                                                        \
+                              const std::vector<std::uint64_t>& controls = {},                     \
+                              std::vector<std::uint64_t> control_values = {}) {                    \
+        return ::scaluq::gate::PauliRotation<Prec, Space>(pauli, angle, controls, control_values); \
+    }                                                                                              \
+    inline Gate DenseMatrix(const std::vector<std::uint64_t>& targets,                             \
+                            const ::scaluq::ComplexMatrix& matrix,                                 \
+                            const std::vector<std::uint64_t>& controls = {},                       \
+                            std::vector<std::uint64_t> control_values = {},                        \
+                            bool is_unitary = false) {                                             \
+        return ::scaluq::gate::DenseMatrix<Prec, Space>(                                           \
+            targets, matrix, controls, control_values, is_unitary);                                \
+    }                                                                                              \
+    inline Gate SparseMatrix(const std::vector<std::uint64_t>& targets,                            \
+                             const ::scaluq::SparseComplexMatrix& matrix,                          \
+                             const std::vector<std::uint64_t>& controls = {},                      \
+                             std::vector<std::uint64_t> control_values = {}) {                     \
+        return ::scaluq::gate::SparseMatrix<Prec, Space>(                                          \
+            targets, matrix, controls, control_values);                                            \
+    }                                                                                              \
+    inline auto& Probabilistic = ::scaluq::gate::Probabilistic<Prec, Space>;                       \
+    inline auto& BitFlipNoise = ::scaluq::gate::BitFlipNoise<Prec, Space>;                         \
+    inline auto& DephasingNoise = ::scaluq::gate::DephasingNoise<Prec, Space>;                     \
+    inline auto& BitFlipAndDephasingNoise = ::scaluq::gate::BitFlipAndDephasingNoise<Prec, Space>; \
+    inline auto& DepolarizingNoise = ::scaluq::gate::DepolarizingNoise<Prec, Space>;               \
+    }                                                                                              \
+    using ParamGate = ::scaluq::ParamGate<Prec, Space>;                                            \
+    using ParamRXGate = ::scaluq::ParamRXGate<Prec, Space>;                                        \
+    using ParamRYGate = ::scaluq::ParamRYGate<Prec, Space>;                                        \
+    using ParamRZGate = ::scaluq::ParamRZGate<Prec, Space>;                                        \
+    using ParamPauliRotationGate = ::scaluq::ParamPauliRotationGate<Prec, Space>;                  \
+    using ParamProbabilisticGate = ::scaluq::ParamProbabilisticGate<Prec, Space>;                  \
+    namespace gate {                                                                               \
+    inline ParamGate ParamRX(std::uint64_t target,                                                 \
+                             double param_coef = 1.,                                               \
+                             const std::vector<std::uint64_t>& controls = {},                      \
+                             std::vector<std::uint64_t> control_values = {}) {                     \
+        return ::scaluq::gate::ParamRX<Prec, Space>(target, param_coef, controls, control_values); \
+    }                                                                                              \
+    inline ParamGate ParamRY(std::uint64_t target,                                                 \
+                             double param_coef = 1.,                                               \
+                             const std::vector<std::uint64_t>& controls = {},                      \
+                             std::vector<std::uint64_t> control_values = {}) {                     \
+        return ::scaluq::gate::ParamRY<Prec, Space>(target, param_coef, controls, control_values); \
+    }                                                                                              \
+    inline ParamGate ParamRZ(std::uint64_t target,                                                 \
+                             double param_coef = 1.,                                               \
+                             const std::vector<std::uint64_t>& controls = {},                      \
+                             std::vector<std::uint64_t> control_values = {}) {                     \
+        return ::scaluq::gate::ParamRZ<Prec, Space>(target, param_coef, controls, control_values); \
+    }                                                                                              \
+    inline ParamGate ParamPauliRotation(const PauliOperator& pauli,                                \
+                                        double param_coef = 1.,                                    \
+                                        const std::vector<std::uint64_t>& controls = {},           \
+                                        std::vector<std::uint64_t> control_values = {}) {          \
+        return ::scaluq::gate::ParamPauliRotation<Prec, Space>(                                    \
+            pauli, param_coef, controls, control_values);                                          \
+    }                                                                                              \
+    const auto& ParamProbabilistic = ::scaluq::gate::ParamProbabilistic<Prec, Space>;              \
+    }                                                                                              \
+    inline auto& merge_gate = ::scaluq::merge_gate<Prec, Space>;                                   \
+    using Circuit = ::scaluq::Circuit<Prec, Space>;

--- a/include/scaluq/all.hpp
+++ b/include/scaluq/all.hpp
@@ -15,6 +15,10 @@
 #include "types.hpp"
 #include "util/random.hpp"
 
+/*
+ * Calling this macro from your original namespace will create aliases for all the types and
+ * functions without template arguments.
+ */
 #define SCALUQ_OMIT_TEMPLATE(Prec, Space)                                                          \
     using StateVector = ::scaluq::StateVector<Prec, Space>;                                        \
     using StateVectorBatched = ::scaluq::StateVectorBatched<Prec, Space>;                          \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.21)
 
-enable_testing()
+include(GoogleTest)
 
-add_executable(scaluq_test EXCLUDE_FROM_ALL
+add_executable(scaluq_test
     circuit/circuit_test.cpp
     circuit/param_circuit_test.cpp
     gate/gate_test.cpp
@@ -24,3 +24,5 @@ target_link_libraries(scaluq_test PUBLIC
 )
 target_include_directories(scaluq_test PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
 target_include_directories(scaluq_test PRIVATE ${eigen_SOURCE_DIR})
+
+gtest_discover_tests(scaluq_test)


### PR DESCRIPTION
テンプレート引数を省略するための，クラスや関数のエイリアスを定義するためのマクロを整備しました．

```cpp
#include <scaluq/all.hpp>
namespace myscaluq {
SCALUQ_OMIT_TEMPLATE(scaluq::Precision::F64, scaluq::ExecutionSpace::Default)
}

int main() {
    scaluq::initialize();
    {
        myscaluq::StateVector state(2);
        myscaluq::Gate x = myscaluq::gate::X(0);
        x->update_quantum_state(state);
        std::cout << state << std::endl;
    }
    scaluq::finalize();
}
```

のように，ユーザー独自の名前空間内で`SCALUQ_OMIT_TEMPLATE`を呼び出すことでその中にエイリアスを定義できます．