### PR TITLE
Fix matrix_f64 type

### DIFF
--- a/src/util/utility.cpp
+++ b/src/util/utility.cpp
@@ -46,7 +46,8 @@ ComplexMatrix convert_internal_matrix_to_external_matrix<Prec, Space>(
     } else {
         Kokkos::View<StdComplex**, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
             host_view(reinterpret_cast<StdComplex*>(eigen_matrix.data()), rows, cols);
-        Matrix<Prec, Space> matrix_f64("internal_matrix", rows, cols);
+        Kokkos::View<StdComplex**, Kokkos::LayoutRight, SpaceType<Space>> matrix_f64(
+            "internal_matrix", rows, cols);
         Kokkos::parallel_for(
             Kokkos::MDRangePolicy<Kokkos::Rank<2>, SpaceType<Space>>({0, 0}, {rows, cols}),
             KOKKOS_LAMBDA(std::uint64_t r, std::uint64_t c) {


### PR DESCRIPTION
F32,GPUのMergeGateTestが `Error: Kokkos::deep_copy with no available copy mechanism: internal_matrix to ` で落ちていたので調査した結果、`convert_internal_matrix_to_external_matrix`のF64以外の実装に明らかなミスがあったため、修正しました。