### PR TITLE
handle binding scaluq_core.host when CPU

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -34,10 +34,14 @@ if(SCALUQ_BFLOAT16)
     list(APPEND PRECISIONS bf16)
 endif()
 foreach(SPACE default host)
+    set(PYTHON_MODULE_NAME scaluq.scaluq_core.${SPACE})
+    if(NOT(SCALUQ_USE_CUDA) AND SPACE STREQUAL host)
+        set(PYTHON_MODULE_NAME scaluq.scaluq_core.default)
+    endif()
     nanobind_add_stub(
         scaluq_stub
         INSTALL_TIME
-        MODULE scaluq.scaluq_core.${SPACE}
+        MODULE ${PYTHON_MODULE_NAME}
         OUTPUT scaluq/${SPACE}/__init__.pyi
         MARKER_FILE scaluq/py.typed
         VERBOSE
@@ -46,7 +50,7 @@ foreach(SPACE default host)
         nanobind_add_stub(
             scaluq_stub
             INSTALL_TIME
-            MODULE scaluq.scaluq_core.${SPACE}.${PRECISION}
+            MODULE ${PYTHON_MODULE_NAME}.${PRECISION}
             OUTPUT scaluq/${SPACE}/${PRECISION}/__init__.pyi
             MARKER_FILE scaluq/py.typed
             VERBOSE
@@ -54,7 +58,7 @@ foreach(SPACE default host)
         nanobind_add_stub(
             scaluq_stub
             INSTALL_TIME
-            MODULE scaluq.scaluq_core.${SPACE}.${PRECISION}.gate
+            MODULE ${PYTHON_MODULE_NAME}.${PRECISION}.gate
             OUTPUT scaluq/${SPACE}/${PRECISION}/gate/__init__.pyi
             MARKER_FILE scaluq/py.typed
             VERBOSE

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -86,6 +86,7 @@ NB_MODULE(scaluq_core, m) {
     bind_on_precision_and_space<Precision::BF16, ExecutionSpace::Default>(mdefault, "bf16");
 #endif
 
+#ifdef SCALUQ_USE_CUDA
     auto mhost = m.def_submodule("host", "module for host execution space");
 #ifdef SCALUQ_FLOAT16
     bind_on_precision_and_space<Precision::F16, ExecutionSpace::Host>(mhost, "f16");
@@ -99,6 +100,23 @@ NB_MODULE(scaluq_core, m) {
 #ifdef SCALUQ_BFLOAT16
     bind_on_precision_and_space<Precision::BF16, ExecutionSpace::Host>(mhost, "bf16");
 #endif
+#endif
+
+    m.def(
+        "get_default_execution_space",
+        []() -> std::string {
+#ifdef SCALUQ_USE_CUDA
+            return "cuda";
+#else
+            return "host";
+#endif
+        },
+        DocString()
+            .desc("Get the default execution space.")
+            .ret("str", "the default execution space, `cuda` or `host`")
+            .ex(DocString::Code{">>> get_default_execution_space()", "'cuda'"})
+            .build_as_google_style()
+            .c_str());
 
     m.def(
         "precision_available",

--- a/python/scaluq/host/__init__.py
+++ b/python/scaluq/host/__init__.py
@@ -1,5 +1,8 @@
-from ..scaluq_core.host import *
 import scaluq
+if scaluq.get_default_execution_space() == 'cuda':
+    from ..scaluq_core.host import *
+else:
+    from ..scaluq_core.default import *
 if scaluq.precision_available('f16'):
     from . import f16
 if scaluq.precision_available('f32'):

--- a/python/scaluq/host/bf16/__init__.py
+++ b/python/scaluq/host/bf16/__init__.py
@@ -1,2 +1,6 @@
-from ...scaluq_core.host.bf16 import *
+import scaluq
+if scaluq.get_default_execution_space() == 'cuda':
+    from ...scaluq_core.host.bf16 import *
+else:
+    from ...scaluq_core.default.bf16 import *
 from . import gate

--- a/python/scaluq/host/bf16/gate/__init__.py
+++ b/python/scaluq/host/bf16/gate/__init__.py
@@ -1,1 +1,5 @@
-from ....scaluq_core.host.bf16.gate import *
+import scaluq
+if scaluq.get_default_execution_space() == 'cuda':
+    from ....scaluq_core.host.bf16.gate import *
+else:
+    from ....scaluq_core.default.bf16.gate import *

--- a/python/scaluq/host/f16/__init__.py
+++ b/python/scaluq/host/f16/__init__.py
@@ -1,2 +1,6 @@
-from ...scaluq_core.host.f16 import *
+import scaluq
+if scaluq.get_default_execution_space() == 'cuda':
+    from ...scaluq_core.host.f16 import *
+else:
+    from ...scaluq_core.default.f16 import *
 from . import gate

--- a/python/scaluq/host/f16/gate/__init__.py
+++ b/python/scaluq/host/f16/gate/__init__.py
@@ -1,1 +1,5 @@
-from ....scaluq_core.host.f16.gate import *
+import scaluq
+if scaluq.get_default_execution_space() == 'cuda':
+    from ....scaluq_core.host.f16.gate import *
+else:
+    from ....scaluq_core.default.f16.gate import *

--- a/python/scaluq/host/f32/__init__.py
+++ b/python/scaluq/host/f32/__init__.py
@@ -1,2 +1,6 @@
-from ...scaluq_core.host.f32 import *
+import scaluq
+if scaluq.get_default_execution_space() == 'cuda':
+    from ...scaluq_core.host.f32 import *
+else:
+    from ...scaluq_core.default.f32 import *
 from . import gate

--- a/python/scaluq/host/f32/gate/__init__.py
+++ b/python/scaluq/host/f32/gate/__init__.py
@@ -1,1 +1,5 @@
-from ....scaluq_core.host.f32.gate import *
+import scaluq
+if scaluq.get_default_execution_space() == 'cuda':
+    from ....scaluq_core.host.f32.gate import *
+else:
+    from ....scaluq_core.default.f32.gate import *

--- a/python/scaluq/host/f64/__init__.py
+++ b/python/scaluq/host/f64/__init__.py
@@ -1,2 +1,6 @@
-from ...scaluq_core.host.f64 import *
+import scaluq
+if scaluq.get_default_execution_space() == 'cuda':
+    from ...scaluq_core.host.f64 import *
+else:
+    from ...scaluq_core.default.f64 import *
 from . import gate

--- a/python/scaluq/host/f64/gate/__init__.py
+++ b/python/scaluq/host/f64/gate/__init__.py
@@ -1,1 +1,5 @@
-from ....scaluq_core.host.f64.gate import *
+import scaluq
+if scaluq.get_default_execution_space() == 'cuda':
+    from ....scaluq_core.host.f64.gate import *
+else:
+    from ....scaluq_core.default.f64.gate import *


### PR DESCRIPTION
close #238 
#223 で、CPU環境では `StateVector<F64, Default>`と`StateVector<F64, Host>` が同じ型になりましたが、nanobindで同じ型を複数のクラスにバインドするとエラーになるようだったので、CPUの場合scaluq_coreはdefaultのみをbindするようにし、scaluqからimportするときに条件分岐することにしました。