### PR TITLE
Erase debug comment

### DIFF
--- a/src/circuit/circuit.cpp
+++ b/src/circuit/circuit.cpp
@@ -165,9 +165,7 @@ std::vector<std::pair<StateVector<Prec, Space>, std::int64_t>> Circuit<Prec, Spa
     // 今／次の深さにおける各状態のサンプリング回数
     std::vector<std::uint64_t> scounts{sampling_count}, new_scounts;
 
-    int a = 0;
     for (auto& g : _gate_list) {
-        std::cout << "Depth: " << ++a << std::endl;
         std::vector<double> probs;
         std::vector<GateWithKey> gates;
         if (g.index() == 0) {
@@ -205,26 +203,29 @@ std::vector<std::pair<StateVector<Prec, Space>, std::int64_t>> Circuit<Prec, Spa
         // gate_used_count[i][j] := states[i] が gates[j] によって変換される回数
         std::vector<std::vector<std::uint64_t>> gate_used_count(
             states.batch_size(), std::vector<std::uint64_t>(probs.size(), 0));
+        std::uint64_t new_size = 0;
         for (std::uint64_t i = 0; i < states.batch_size(); ++i) {
             for (std::uint64_t _ = 0; _ < scounts[i]; ++_) {
-                ++gate_used_count[i][dist(mt)];
+                std::uint64_t j = dist(mt);
+                if (j >= probs.size()) {
+                    throw std::runtime_error(
+                        "Circuit::simulate_noise: discrete_distribution returned out of range "
+                        "index.");
+                }
+                if (gate_used_count[i][j] == 0) {
+                    ++new_size;
+                }
+                ++gate_used_count[i][j];
             }
         }
 
-        std::uint64_t new_size = 0;
-        for (std::uint64_t i = 0; i < gate_used_count.size(); ++i) {
-            for (std::uint64_t j = 0; j < gate_used_count[i].size(); ++j) {
-                if (gate_used_count[i][j] == 0) continue;
-                ++new_size;
-            }
-        }
-
-        new_states = StateVectorBatched<Prec, Space>(new_size, initial_state.n_qubits());
+        new_states = StateVectorBatched<Prec, Space>::uninitialized_state(new_size,
+                                                                          initial_state.n_qubits());
         new_scounts.assign(new_size, 0);
 
         std::int64_t insert_idx = 0;
         for (std::uint64_t i = 0; i < probs.size(); ++i) {
-            StateVectorBatched<Prec, Space> tmp_states = states.copy();
+            StateVectorBatched<Prec, Space> tmp_states(states.copy());
             if (gates[i].index() == 0) {
                 std::get<0>(gates[i])->update_quantum_state(tmp_states);
             } else {

--- a/src/operator/operator.cpp
+++ b/src/operator/operator.cpp
@@ -104,7 +104,8 @@ ComplexMatrix Operator<internal::Prec, internal::Space>::get_matrix() const {
 template <>
 void Operator<internal::Prec, internal::Space>::apply_to_state(
     StateVector<internal::Prec, internal::Space>& state_vector) const {
-    StateVector<internal::Prec, internal::Space> res(state_vector.n_qubits());
+    auto res =
+        StateVector<internal::Prec, internal::Space>::uninitialized_state(state_vector.n_qubits());
     res.set_zero_norm_state();
     for (const auto& term : _terms) {
         StateVector<internal::Prec, internal::Space> tmp = state_vector.copy();

--- a/src/state/state_vector_batched.cpp
+++ b/src/state/state_vector_batched.cpp
@@ -49,7 +49,7 @@ void StateVectorBatched<Prec, Space>::set_state_vector_at(std::uint64_t batch_id
 template <Precision Prec, ExecutionSpace Space>
 StateVector<Prec, Space> StateVectorBatched<Prec, Space>::get_state_vector_at(
     std::uint64_t batch_id) const {
-    StateVector<Prec, Space> ret(_n_qubits);
+    auto ret = StateVector<Prec, Space>::uninitialized_state(_n_qubits);
     Kokkos::parallel_for(
         "get_state_vector_at",
         Kokkos::RangePolicy<internal::SpaceType<Space>>(0, _dim),
@@ -447,7 +447,7 @@ void StateVectorBatched<Prec, Space>::load(const std::vector<std::vector<StdComp
 
 template <Precision Prec, ExecutionSpace Space>
 StateVectorBatched<Prec, Space> StateVectorBatched<Prec, Space>::copy() const {
-    StateVectorBatched<Prec, Space> cp(_batch_size, _n_qubits);
+    auto cp = StateVectorBatched<Prec, Space>::uninitialized_state(_batch_size, _n_qubits);
     Kokkos::deep_copy(cp._raw, _raw);
     return cp;
 }


### PR DESCRIPTION
Circuit::simulate_noise のデバッグ用出力が残っていたので消しました（すみません）
また，状態ベクトルのバッファを確保する際に値の初期化を行わないようにすることで，1.2x くらい高速化しました．