### PR TITLE
Tutorial with markdown

### DIFF
--- a/.devcontainer/cpu/Dockerfile
+++ b/.devcontainer/cpu/Dockerfile
@@ -64,3 +64,5 @@ RUN groupadd --gid $USER_GID $GROUPNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
 USER vscode
+
+ENV PATH="/home/vscode/.local/bin:${PATH}"

--- a/.devcontainer/cpu/Dockerfile
+++ b/.devcontainer/cpu/Dockerfile
@@ -52,6 +52,8 @@ RUN git clone --recursive https://github.com/kokkos/kokkos.git /tmp/kokkos --dep
 
 RUN pip install nanobind==2.0.0
 
+RUN locale-gen en_US.UTF-8
+
 ARG USERNAME=vscode
 ARG GROUPNAME=vscode
 ARG USER_UID=1000

--- a/.devcontainer/cpu/Dockerfile
+++ b/.devcontainer/cpu/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && \
     gdb \
     libboost-dev \
     libpython3-dev \
+    locales \
     ninja-build \
     python3 \
     python3-pip \

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,6 +33,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx_math_dollar',
     'autoapi.extension',
+    'myst_parser'
 ]
 
 autoapi_type = "python"
@@ -52,6 +53,11 @@ autoapi_options = [
 ]
 
 autodoc_typehints = 'description'
+
+myst_enable_extensions = [
+    "amsmath",
+    "dollarmath",
+]
 
 html_theme = "sphinx_rtd_theme"
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,30 +1,30 @@
-import sys
 import subprocess
 from pathlib import Path
+import importlib.util
+import os
+import shutil
 
 stub_dir = Path('./stub/scaluq/')
 stub_dir.mkdir(parents=True, exist_ok=True)
 
 files = []
 
-subprocess.run([sys.executable, '-m', 'nanobind.stubgen',
-    '-m', 'scaluq.scaluq_core',
-    '-o', './stub/scaluq/__init__.py'])
-files.append('./stub/scaluq/__init__.py')
+scaluq_path = os.path.dirname(importlib.util.find_spec('scaluq').origin)
+
+def copy_stub_file(target):
+    if not os.path.isfile(f'{scaluq_path}/{target}/__init__.pyi'):
+        print(f'No stub file found for {target}')
+        return
+    os.makedirs(f'stub/scaluq/{target}', exist_ok=True)
+    shutil.copyfile(f'{scaluq_path}/{target}/__init__.pyi', f'stub/scaluq/{target}/__init__.pyi')
+    files.append(f'./stub/scaluq/{target}/__init__.pyi')
+
+copy_stub_file('')
 for space in ['default', 'host']:
-    subprocess.run([sys.executable, '-m', 'nanobind.stubgen',
-        '-m', f'scaluq.scaluq_core.{space}',
-        '-o', f'./stub/scaluq/{space}/__init__.py'])
-    files.append(f'./stub/scaluq/{space}/__init__.py')
+    copy_stub_file(space)
     for precision in ['f16', 'f32', 'f64', 'bf16']:
-        subprocess.run([sys.executable, '-m', 'nanobind.stubgen',
-            '-m', f'scaluq.scaluq_core.{space}.{precision}',
-            '-o', f'./stub/scaluq/{space}/{precision}/__init__.py'])
-        files.append(f'./stub/scaluq/{space}/{precision}/__init__.py')
-        subprocess.run([sys.executable, '-m', 'nanobind.stubgen',
-            '-m', f'scaluq.scaluq_core.{space}.{precision}.gate',
-            '-o', f'./stub/scaluq/{space}/{precision}/gate.py'])
-        files.append(f'./stub/scaluq/{space}/{precision}/gate.py')
+        copy_stub_file(f'{space}/{precision}')
+        copy_stub_file(f'{space}/{precision}/gate')
 
 subprocess.run(["sed", "-i", "/@overload/d"] + files, check=True)
 
@@ -39,7 +39,7 @@ extensions = [
 autoapi_type = "python"
 autoapi_keep_files = True
 
-autoapi_file_patterns = ["*.py"]
+autoapi_file_patterns = ["*.py", "*.pyi"]
 autoapi_dirs = ["./stub/scaluq"]
 autoapi_add_toctree_entry = True
 autoapi_python_class_content = 'class'

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,6 +10,7 @@ Welcome to Scaluq's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   tutorials/index
 
 
 Indices and tables

--- a/doc/source/tutorials/index.md
+++ b/doc/source/tutorials/index.md
@@ -8,3 +8,4 @@ To get more information, see {doc}`../autoapi/index`.
 :maxdepth: 2
 
 python/index
+```

--- a/doc/source/tutorials/index.md
+++ b/doc/source/tutorials/index.md
@@ -1,0 +1,10 @@
+# Tutorials
+
+Here are tutorials of Scaluq for beginners.
+
+To get more information, see {doc}`../autoapi/index`.
+
+```{toctree}
+:maxdepth: 2
+
+python/index

--- a/doc/source/tutorials/python/index.md
+++ b/doc/source/tutorials/python/index.md
@@ -4,4 +4,5 @@
 :maxdepth: 2
 
 install.md
+state_vector.md
 ```

--- a/doc/source/tutorials/python/index.md
+++ b/doc/source/tutorials/python/index.md
@@ -1,0 +1,4 @@
+# Python Tutorials
+
+{func}`set_computational_basis <scaluq.default.f64.StateVector.set_computational_basis>`
+

--- a/doc/source/tutorials/python/index.md
+++ b/doc/source/tutorials/python/index.md
@@ -1,4 +1,7 @@
 # Python Tutorials
 
-{func}`set_computational_basis <scaluq.default.f64.StateVector.set_computational_basis>`
+```{toctree}
+:maxdepth: 2
 
+install.md
+```

--- a/doc/source/tutorials/python/install.md
+++ b/doc/source/tutorials/python/install.md
@@ -1,0 +1,58 @@
+# Install Scaluq Python package
+
+## Install from PyPI
+The most simple way to install Scaluq is running below.
+
+```python
+pip install scaluq
+```
+
+The configuration of distributed package is below.
+
+- Use OpenMP for parallel processing.
+- All of the simulation is run on CPU.
+    - Do not use GPU.
+    - Execution Space `default` and `host` is same.
+- Precision `f32` and `f64` is enabled.
+
+## Build from source
+If you want to install on the specific commit or with non-default option, you can install Scaluq from source.
+
+The build requirements are below.
+
+- Ninja ≥ 1.10
+- GCC ≥ 11 (≥ 13 if not using CUDA)
+- CMake ≥ 3.21
+- CUDA ≥ 12.6 (only when using CUDA)
+- Python ≥ 3.9 (only when using Python)
+
+The build options are below.
+
+| Variable Name           | Default     | Description |
+|------------------------|-------------|-------------|
+| `CMAKE_C_COMPILER`     | -           | See [CMake Documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) |
+| `CMAKE_CXX_COMPILER`   | -           | See [CMake Documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER.html) |
+| `CMAKE_BUILD_TYPE`     | -           | See [CMake Documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html) |
+| `CMAKE_INSTALL_PREFIX` | -           | See [CMake Documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html) |
+| `SCALUQ_USE_OMP`       | `ON`        | Use OpenMP for parallel computation on CPU |
+| `SCALUQ_USE_CUDA`      | `OFF`       | Enable parallel computation using GPU (CUDA) |
+| `SCALUQ_CUDA_ARCH`     | (auto)      | Target Nvidia GPU architecture (see [Kokkos CMake Keywords](https://kokkos.org/kokkos-core-wiki/get-started/configuration-guide.html), e.g., `SCALUQ_CUDA_ARCH=AMPERE80`) |
+| `SCALUQ_USE_TEST`      | `ON`        | Include `test/` in build targets. You can build and run tests with `ctest --test-dir build/` |
+| `SCALUQ_USE_EXE`       | `ON`        | Include `exe/` in build targets. You can try running without installing by building with `ninja -C build` and running `build/exe/main` |
+| `SCALUQ_FLOAT16`       | `OFF`       | Enable `f16` precision |
+| `SCALUQ_FLOAT32`       | `ON`        | Enable `f32` precision |
+| `SCALUQ_FLOAT64`       | `ON`        | Enable `f64` precision |
+| `SCALUQ_BFLOAT16`      | `OFF`       | Enable `bf16` precision |
+
+To install Scaluq, clone the git repository first and enter.
+
+```
+git clone https://github.com/qulacs/scaluq
+cd scaluq
+```
+
+Then, install qulacs with passing configuration by environment variable.
+
+```
+SCALUQ_USE_CUDA=ON SCALUQ_FLOAT32=OFF pip install .
+```

--- a/doc/source/tutorials/python/state_vector.md
+++ b/doc/source/tutorials/python/state_vector.md
@@ -12,8 +12,93 @@ For example, $\ket{110}$ means that qubit $0$ is $\ket{0}$, qubit $1$ is $\ket{1
 The state is initialized to $\ket{0\dots 0}$.
 
 ```py
+from scaluq.default.f64 import StateVector
 state = StateVector(2)
 print(state)
 ```
 ```
+Qubit Count : 2
+Dimension : 4
+State vector : 
+  00 : (1,0)
+  01 : (0,0)
+  10 : (0,0)
+  11 : (0,0)
 ```
+
+## Getting property of StateVector
+
+{func}`n_qubits <scaluq.default.f64.StateVector>` returns the number of qubits $n$.
+
+{func}`dim <scaluq.default.f64.StateVector>` returns the dimension of the vector $2^n$.
+
+{func}`get_amplitudes <scaluq.default.f64.StateVector>` returns the content of StateVector as type `list[complex]`.
+
+{func}`get_squared_norm()` returns the squared norm of the state $\braket{\phi, \phi}$ which must be equal to $1$ with normalized states.
+
+## Initializing StateVector
+
+In addition to the constructor, you can initialize state with some static functions.
+
+{func}`Haar_random_state <scaluq.default.f64.StateVector>` initialize state with Haar random state. You pass seed as an optional argument. Without passing seed, the random device of system is used.
+
+{func}`uninitialized_state <scaluq.default.f64.StateVector>` only allocate memory on the execution space without initializing. The content of the vector is undefined. It is not guaranteed to be normalized. Since allocating the vector by this function is faster than other initializing functions, you should use this if you will load other vector immediately after.
+
+```py
+from scaluq.default.f64 import StateVector
+state = StateVector.Haar_random_state(2)
+print("Haar random (without seed): ", state.get_amplitudes())
+state = StateVector.Haar_random_state(2)
+print("Haar random (without seed): ", state.get_amplitudes())
+state = StateVector.Haar_random_state(2, 0)
+print("Haar random (seed = 0): ", state.get_amplitudes())
+state = StateVector.Haar_random_state(2, 0)
+print("Haar random (seed = 0): ", state.get_amplitudes())
+state = StateVector.uninitialized_state(2) # the content is undefined
+```
+```
+Haar random (without seed):  [(-0.12377148096652951+0.027715511836463032j), (0.23343008413304153-0.6125930779810899j), (0.348536530607012+0.16314293047597564j), (-0.6344277255462337-0.059671766025997705j)]
+Haar random (without seed):  [(0.20861863181020227+0.36023007097415805j), (-0.7038208261050227+0.15424679536389918j), (0.032557696049571434+0.4498796978221459j), (0.3196074684536188+0.04422729148920198j)]
+Haar random (seed = 0):  [(0.24602695668676106-0.3593147366777609j), (-0.2016366688947537+0.10904346570777179j), (-0.7078115548871466+0.3479734076173536j), (0.09795534521513291-0.3551589695281517j)]
+Haar random (seed = 0):  [(0.24602695668676106-0.3593147366777609j), (-0.2016366688947537+0.10904346570777179j), (-0.7078115548871466+0.3479734076173536j), (0.09795534521513291-0.3551589695281517j)]
+```
+
+## Loading StateVector
+
+You can load the content of {class}`StateVector <scaluq.default.f64.StateVector>` by various functions.
+
+{func}`set_zero_state <scaluq.default.f64.StateVector.set_zero_state>` is used for setting the vector to $\ket{00\dots0}=[1,0,\dots,0]$.
+
+{func}`set_zero_norm_state <scaluq.default.f64.StateVector.set_zero_norm_state>` is used for setting the vector to $0=[0,0,\dots,0]$.
+
+{func}`set_computational_basis <scaluq.default.f64.StateVector.set_computational_basis>` is used for setting the vector to $\ket{b}$ with input args $0\leq b \leq 2^{n}-1$.
+
+{func}`load <scaluq.default.f64.StateVector.load>` is used for loading the other vector (with $2^n$ length) directly as amplitudes.
+
+```py
+from scaluq.default.f64 import StateVector
+state = StateVector(2)
+state.set_zero_state()
+print("zero state:", state.get_amplitudes())
+state.set_zero_norm_state()
+print("zero norm state:", state.get_amplitudes())
+state.load([0.5, 0.5, -0.5, 0.5])
+print("loaded state:", state.get_amplitudes())
+import numpy as np
+state.load(np.array([1, 0, 0, 1]) / np.sqrt(2)) # You can also load numpy arrays
+print("loaded numpy state:", state.get_amplitudes())
+```
+```
+zero state: [(1+0j), 0j, 0j, 0j]
+zero norm state: [0j, 0j, 0j, 0j]
+loaded state: [(0.5+0j), (0.5+0j), (-0.5+0j), (0.5+0j)]
+loaded numpy state: [(0.7071067811865475+0j), 0j, 0j, (0.7071067811865475+0j)]
+```
+
+## Operation to StateVector
+`add_state_vector_with_coef`, `multiply_coef`
+
+## Get probabilistic measures of StateVector
+`get_zero_property`, `get_marginal_property`, `get_entropy`, `sampling`
+
+JSONは別でチュートリアルを作ると良さそうなのでここに書かなくてもOK。

--- a/doc/source/tutorials/python/state_vector.md
+++ b/doc/source/tutorials/python/state_vector.md
@@ -96,9 +96,65 @@ loaded numpy state: [(0.7071067811865475+0j), 0j, 0j, (0.7071067811865475+0j)]
 ```
 
 ## Operation to StateVector
-`add_state_vector_with_coef`, `multiply_coef`
+
+You can perform some operations to {class}`StateVector <scaluq.default.f64.StateVector>`.
+
+{func}`add_state_vector_with_coef <scaluq.default.f64.add_state_vector_with_coef>` is used to update the vector by adding $c\ket{\psi}$, where `c` is a complex number and $\ket{\psi}$ is another state vector with same dimension.
+
+{func}`multiply_coef <scaluq.default.f64.multiply_coef>` is used to update the vector by multiplying a complex number.
+
+```py
+import math
+from scaluq.default.f64 import StateVector
+phi = StateVector(2)
+print("phi:", phi.get_amplitudes())
+psi = StateVector.uninitialized_state(2)
+psi.set_computational_basis(3)
+print("psi:", psi.get_amplitudes())
+phi.add_state_vector_with_coef(1j, psi)
+print("phi after added psi:", phi.get_amplitudes())
+phi.multiply_coef(1 / math.sqrt(2))
+print("phi after multiplied coef:", phi.get_amplitudes())
+```
+```
+phi: [(1+0j), 0j, 0j, 0j]
+psi: [0j, 0j, 0j, (1+0j)]
+phi after added psi: [(1+0j), 0j, 0j, 1j]
+phi after multiplied coef: [(0.7071067811865475+0j), 0j, 0j, 0.7071067811865475j]
+```
 
 ## Get probabilistic measures of StateVector
-`get_zero_property`, `get_marginal_property`, `get_entropy`, `sampling`
 
-JSONは別でチュートリアルを作ると良さそうなのでここに書かなくてもOK。
+You can get probabilistic measures of {class}`StateVector <scaluq.default.f64.StateVector>`.
+
+{func}`get_zero_probability <scaluq.default.f64.StateVector.get_zero_probability>` is used to get the probability of getting $0$ when the specified qubit is measured by Z-basis.
+
+{func}`get_marginal_probability <scaluq.default.f64.StateVector.get_marginal_probability>` is used to get the marginal probability of getting specified result when some of qubits are measured simultaneously by Z-basis.
+The result is specified by a list of integer with length `n`. $i$-th value of elements means as follows:
+- `0`: $i$-th qubit is measured and the result is $0$.
+- `1`: $i$-th qubit is measured and the result is $1$.
+- {func}`StateVector.UNMEASURED <scaluq.default.f64.StateVector.UNMEASURED>`: $i$-th qubit is not measured.
+
+{func}`get_entropy <scaluq.default.f64.StateVector.get_entropy>` is used to get the entropy of the vector, which is calculated by $\sum_i -p_i \log_2 p_i$ ($p_i$ ($0\leq i<2^n$) is $|v_i|^2$ with $v_i$ is the $i$-th amplitude of the vector).
+
+{func}`sampling <scaluq.default.f64.StateVector.sampling>` is used to perform sampling on the vector.
+With passing the number of sampling as `sampling_count`, a list of integers with length `sampling_count` is returned.
+
+```py
+import math
+from scaluq.default.f64 import StateVector
+state = StateVector.uninitialized_state(2)
+vec = [1/2, 0, 0, math.sqrt(3)/2 * 1j]
+state.load(vec)
+print("zero probability of 0:", state.get_zero_probability(0))
+assert abs(state.get_zero_probability(0) - (abs(vec[0])**2 + abs(vec[2])**2)) < 1e-9
+print("zero probability of 1:", state.get_zero_probability(1))
+assert abs(state.get_zero_probability(1) - (abs(vec[0])**2 + abs(vec[1])**2)) < 1e-9
+print("marginal probability of [1, UNMEASURED]:", state.get_marginal_probability([1, StateVector.UNMEASURED]))
+assert abs(state.get_marginal_probability([1, StateVector.UNMEASURED]) - (abs(vec[1])**2 + abs(vec[3])**2)) < 1e-9
+```
+```
+zero probability of 0: 0.25
+zero probability of 1: 0.25
+marginal probability of [1, UNMEASURED]: 0.7499999999999999
+```

--- a/doc/source/tutorials/python/state_vector.md
+++ b/doc/source/tutorials/python/state_vector.md
@@ -1,0 +1,19 @@
+# StateVector
+
+State vector of a quantum state is expressed as {class}`StateVector <scaluq.default.f64.StateVector>`.
+This holds $2^n$ complex numbers where $n$ is the number of qubits.
+
+Indices of the qubit is numbered as $0,1,\dots,n-1$.
+The state is represented by computational basis. For example `[a, b, c, d]` means $a\ket{00}+b\ket{01}+c\ket{10}+d\ket{11}$.
+$i$-th bit from lower (counted from $0$) of the basis is a qubit $i$.
+For example, $\ket{110}$ means that qubit $0$ is $\ket{0}$, qubit $1$ is $\ket{1}$, and qubit $2$ is $\ket{2}$.
+
+{class}`StateVector <scaluq.default.f64.StateVector>` is constructed with single integer value `n_qubits`, which is the number of qubits.
+The state is initialized to $\ket{0\dots 0}$.
+
+```py
+state = StateVector(2)
+print(state)
+```
+```
+```

--- a/include/scaluq/state/state_vector.hpp
+++ b/include/scaluq/state/state_vector.hpp
@@ -254,7 +254,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
         .def("set_zero_norm_state",
              &StateVector<Prec, Space>::set_zero_norm_state,
              DocString()
-                 .desc("Initialize with 0 (null vector).")
+                 .desc("Initialize with $0$ (null vector).")
                  .ex(DocString::Code{">>> state = StateVector(2)",
                                      ">>> state.get_amplitudes()",
                                      "[(1+0j), 0j, 0j, 0j]",
@@ -267,7 +267,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
              &StateVector<Prec, Space>::set_computational_basis,
              "basis"_a,
              DocString()
-                 .desc("Initialize with computational basis \\ket{\\mathrm{basis}}.")
+                 .desc("Initialize with computational basis $\\ket{\\mathrm{basis}}$.")
                  .arg("basis",
                       "int",
                       "basis as integer format ($0 \\leq \\mathrm{basis} \\leq "
@@ -493,7 +493,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
                  .desc("Load amplitudes of `Sequence`")
                  .arg("other",
                       "collections.abc.Sequence[complex]",
-                      "list of complex amplitudes with len $2^{\\mathrm{n_qubits}}$")
+                      "list of complex amplitudes with len $2^{\\mathrm{n\\_qubits}}$")
                  .build_as_google_style()
                  .c_str())
         .def("__str__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ homepage = "http://www.scaluq.org"
 doc = [
     "black == 24.4.2",
     "isort == 5.13.2",
+    "myst_parser == 4.0.1",
     "nanobind == 2.0.0",
     "sphinx == 7.3.7",
     "sphinx-autoapi == 3.1.1",


### PR DESCRIPTION
#129 
Markdownによるチュートリアルを整備します。
このPRはPython版のインストール方法とStateVectorの使い方のみですが、今後他の機能に関しても追加していきたいです。