### PR TITLE
force CMake >= 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,7 @@ endif(SCALUQ_USE_CUDA)
 FetchContent_Declare(
     kokkos
     GIT_REPOSITORY https://github.com/kokkos/kokkos
-    # GIT_HASH b9d70e4653b87a06dbb48d63291bf248058c7c7db4bd91979676ad5609bb1a3a
-    GIT_TAG 1b1383c6001f3bfe9fe309ca923c2d786600cc79
-    # GIT_TAG 4.6.01
+    GIT_TAG 1b1383c6001f3bfe9fe309ca923c2d786600cc79 # 4.6.01
 )
 FetchContent_MakeAvailable(kokkos)
 set_property(TARGET kokkoscore PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.24)
 
 project(scaluq)
 
@@ -71,7 +71,8 @@ endif(SCALUQ_USE_CUDA)
 FetchContent_Declare(
     kokkos
     GIT_REPOSITORY https://github.com/kokkos/kokkos
-    GIT_HASH b9d70e4653b87a06dbb48d63291bf248058c7c7db4bd91979676ad5609bb1a3a
+    # GIT_HASH b9d70e4653b87a06dbb48d63291bf248058c7c7db4bd91979676ad5609bb1a3a
+    GIT_TAG 1b1383c6001f3bfe9fe309ca923c2d786600cc79
     # GIT_TAG 4.6.01
 )
 FetchContent_MakeAvailable(kokkos)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Compared to [Qulacs](https://github.com/qulacs/qulacs), the following improvemen
 
 - Ninja ≥ 1.10
 - GCC ≥ 11 (≥ 13 if not using CUDA)
-- CMake ≥ 3.21
+- CMake ≥ 3.24
 - CUDA ≥ 12.6 (only when using CUDA)
 - Python ≥ 3.9 (only when using Python)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -16,7 +16,7 @@ Scaluq は、量子回路シミュレータ [Qulacs](https://github.com/qulacs/q
 
 - Ninja 1.10 以上
 - GCC 11 以上 (CUDAを利用しない場合13以上)
-- CMake 3.21 以上
+- CMake 3.24 以上
 - CUDA 12.6 以上（CUDA利用時のみ）
 - Python 3.9 以上 (Python利用時のみ)
 

--- a/example_project/CMakeLists.txt
+++ b/example_project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.24)
 
 project(example)
 

--- a/exe/CMakeLists.txt
+++ b/exe/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.24)
 
 function(exe name)
     add_executable(${name} ${name}.cpp)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.24)
 
 message(STATUS "Building library for python...")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.24)
 
 foreach(LIBRARY IN LISTS SCALUQ_LIBRARIES)
     target_link_libraries(${LIBRARY} PUBLIC 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.24)
 
 include(GoogleTest)
 


### PR DESCRIPTION
- kokkosのFetchContent_Declareで、`GIT_HASH` が使われているが、ドキュメント中で見つからず、CMake 3.21では少なくとも使えなさそうだったため`GIT_TAG`にコミットハッシュを指定しました
- jsonのFetchContent_Declareで、`DOWNLOAD_EXTRACT_TIMESTAMP` は CMake 3.24以上のサポートだったため、最低バージョンを3.24に上げました ( https://cmake.org/cmake/help/latest/module/ExternalProject.html#url )