### PR TITLE
upgrade os version in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,6 @@
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 


### PR DESCRIPTION
Read the DocsビルドがC++23で導入されたstdfloatに未対応で失敗していたため、コンテナのバージョンを上げました