### PR TITLE
fix version of astroid and use pre_build jobs in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,8 +3,9 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
-  commands:
-    - python doc/source/copy_stub.py
+  jobs:
+    pre_build:
+      - python doc/source/copy_stub.py
 
 sphinx:
   configuration: doc/source/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ doc = [
     "isort == 5.13.2",
     "myst_parser == 4.0.1",
     "nanobind == 2.0.0",
+    "astroid == 3.3.11",
     "sphinx == 7.3.7",
     "sphinx-autoapi == 3.1.1",
     "sphinxcontrib-napoleon == 0.7",


### PR DESCRIPTION
sphinxのautoapi拡張が使用しているastroidモジュールがRTDコンテナ上では4.0.0bであり、autoapiのバージョンが非対応だった。そのため、ビルドの成功が確認できたバージョンである3.3.11をインストールするように変更した。
また、.readthedocs.yaml内のジョブの指定方法が間違っていたため修正した。pre_buildを使うことでpip install .[doc]の実行後にcopy_stubが走るように変更した。