### PR TITLE
solve_ground_state_*** methodのドキュメントのRetyrn Typeの修正

### DIFF
--- a/include/scaluq/operator/operator.hpp
+++ b/include/scaluq/operator/operator.hpp
@@ -226,6 +226,8 @@ void bind_operator_operator_hpp(nb::module_& m) {
                      true,
                      "Shift value to accelerate convergence. The value must be larger than largest "
                      "eigenvalue. If not provided, a default value is calculated internally.")
+                .ret(":class:`Operator.GroundState`",
+                     "The ground state information including eigenvalue and ground state vector.")
                 .ex(DocString::Code(
                     {">>> terms = [PauliOperator(\"\", -3.8505), PauliOperator(\"X 1\", -0.2288), "
                      "PauliOperator(\"Z 1\", -1.0466), PauliOperator(\"X 0\", -0.2288), "
@@ -267,6 +269,8 @@ void bind_operator_operator_hpp(nb::module_& m) {
                      true,
                      "Shift value to accelerate convergence. The value must be larger than largest "
                      "eigenvalue. If not provided, a default value is calculated internally.")
+                .ret(":class:`Operator.GroundState`",
+                     "The ground state information including eigenvalue and ground state vector.")
                 .ex(DocString::Code(
                     {">>> terms = [PauliOperator(\"\", -3.8505), PauliOperator(\"X 1\", -0.2288), "
                      "PauliOperator(\"Z 1\", -1.0466), PauliOperator(\"X 0\", -0.2288), "


### PR DESCRIPTION
<img width="583" height="718" alt="image" src="https://github.com/user-attachments/assets/41be3309-a4f2-4802-8c85-c5205136961f" />
stubの型注釈は

```py
    def solve_ground_state_by_power_method(self, initial_state: StateVector, iter_count: int, mu: complex | None = None) -> Operator.GroundState:
        """
        Solve for the ground state using the power method.

        Args:
            initial_state (:class:`StateVector`):
                Initial state vector for the iteration. Passing Haar_random_state is often nice.

            iter_count (int):
                Number of iterations to perform.

            mu (complex, optional):
                Shift value to accelerate convergence. The value must be larger than largest eigenvalue. If not provided, a default value is calculated internally.

        Examples:
            >>> terms = [PauliOperator("", -3.8505), PauliOperator("X 1", -0.2288), PauliOperator("Z 1", -1.0466), PauliOperator("X 0", -0.2288), PauliOperator("X 0 X 1", 0.2613), PauliOperator("X 0 Z 1", 0.2288), PauliOperator("Z 0", -1.0466), PauliOperator("Z 0 X 1", 0.2288), PauliOperator("Z 0 Z 1", 0.2356)]
            >>> op = Operator(terms)
            >>> op *= .5
            >>> ground_state = op.solve_ground_state_by_power_method(StateVector.Haar_random_state(2, seed=0), 200)
            >>> ground_state.eigenvalue.real # doctest: +ELLIPSIS
            -2.862620764...
            >>> print(ground_state.state.get_amplitudes()) # doctest: +SKIP
            [(0.593378420...-0.801949191...j), (-0.00937288681...+0.0126674290...j), (-0.00937288706...+0.0126674292...j), (-0.0389261878...+0.0526086285...j)]
        """
```
で問題ないのですが、sphinx-autoapiのバグなのか、内部クラスのreturn typeがうまくパースされずOperatorになってしまっていました(スクショ参照)。

DocStringにGoogleStyleのReturnsセクションを設けることでうまくパースされました
<img width="583" height="780" alt="image" src="https://github.com/user-attachments/assets/6f5712e1-7b85-452c-9389-e6421d725008" />
