### PR TITLE
suppress another warnng

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,8 @@ if(SCALUQ_USE_CUDA)
         --expt-relaxed-constexpr
         -Werror=cross-execution-space-call # prevent call of non __device__ function in device call
         -DEIGEN_NO_CUDA
-        -Xcudafe --diag_suppress=1675 # for suppressing warning of Eigen
+        "SHELL:-Xcudafe --diag_suppress=1675" # for suppressing warning of Eigen
+        "SHELL:-Xcudafe --diag_suppress=186"
     ) 
 endif()
 


### PR DESCRIPTION
Eigen由来の警告がもう一つありました．
-Xcudafe を2回並べる必要がありましたが，同じオプションとしてCMakeがまとめてしまうので，SHELL:で明示的に並べます．