### PR TITLE
run related-test-files after installing compilers

### DIFF
--- a/.github/workflows/test_changed.yml
+++ b/.github/workflows/test_changed.yml
@@ -108,7 +108,7 @@ jobs:
           ninja --version
 
       - name: List related test files
-        if: ${{ steps.check-build-files.outputs.any_changed == 'false' }}
+        if: ${{ steps.check-build-files.outputs.any_changed == 'false' && steps.check-source-files.outputs.any_changed == 'true' }}
         run: |
           RELATED_TEST_FILES=$(./script/related-test-files ${{ steps.check-source-files.outputs.changed_files }})
           if [ -z "$RELATED_TEST_FILES" ]; then


### PR DESCRIPTION
#295 の変更にミスがあったので修正します。
`script/related-test-files` は内部でCMake configureしているので、コンパイラをインストールしてから実行する必要がありました。