### PR TITLE
use local method for CUDA install

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -65,7 +65,9 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.19
         with:
           cuda: "12.6.1"
-          method: "network"
+          method: "local"
+          linux-local-args: '["--toolkit"]'
+          log-file-suffix: '${{ github.job }}-${{ matrix.os }}-${{ matrix.architecture }}'
       
       - name: Show installed Compiler version
         run: |
@@ -141,7 +143,9 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.19
         with:
           cuda: "12.6.1"
-          method: "network"
+          method: "local"
+          linux-local-args: '["--toolkit"]'
+          log-file-suffix: '${{ github.job }}-${{ matrix.os }}-${{ matrix.architecture }}'
       
       - name: Show installed Compiler version
         run: |

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -70,7 +70,9 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.19
         with:
           cuda: "12.6.1"
-          method: "network"
+          method: "local"
+          linux-local-args: '["--toolkit"]'
+          log-file-suffix: '${{ github.job }}-${{ matrix.os }}-${{ matrix.architecture }}'
       
       - name: Show installed Compiler version
         run: |

--- a/.github/workflows/test_changed.yml
+++ b/.github/workflows/test_changed.yml
@@ -95,7 +95,9 @@ jobs:
         uses: Jimver/cuda-toolkit@v0.2.19
         with:
           cuda: "12.6.1"
-          method: "network"
+          method: "local"
+          linux-local-args: '["--toolkit"]'
+          log-file-suffix: '${{ github.job }}-${{ matrix.os }}-${{ matrix.architecture }}'
       
       - name: Show installed Compiler version
         if: ${{ steps.check-build-files.outputs.any_changed == 'true' || steps.check-source-files.outputs.any_changed == 'true' }}


### PR DESCRIPTION
CIのJimver/cuda-tookitがdriverのapt install時のconflictで落ちています (例: https://github.com/qulacs/scaluq/actions/runs/21978657477/job/63499026063)
これ自体の原因は、aptリポジトリのパッケージの一時的な不整合なのか、選ばれたrunnerのハードウェアの違いの問題なのかよくわかっていないですが、少なくともCUDA toolkitが必要なだけでdriverをインストールする必要はないはずです。

network methodではなくlocal methodを使えば、インストーラのダウンロードサイズは増えますが、aptに依存せずにCUDA公式のインストーラを使えるのでエラー率は落ちるはずです。また、オプションでインストールするものを選べるのでドライバのインストールを回避できます。あまりに遅いようでしたらnetworkに戻します。