### PR TITLE
Changed README.md: Sample Code (Python) for can run the code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,9 @@ circuit.add_gate(gate.Y(1))
 circuit.add_gate(gate.RX(1, math.pi / 2))
 circuit.update_quantum_state(state)
 
-observable = Operator(n_qubits)
-observable.add_random_operator(1, 0)
+terms = []
+terms.append(PauliOperator(1, 0))
+observable = Operator(terms)
 value = observable.get_expectation_value(state)
 print(value)
 ```


### PR DESCRIPTION
環境構築の際に、READMEのpythonのサンプルコードが動作しないもの(.add_random_operator())だったので実行できるものに変更しました。