### PR TITLE
Add ecr gate

### DIFF
--- a/include/scaluq/all.hpp
+++ b/include/scaluq/all.hpp
@@ -49,6 +49,7 @@
     using U2Gate = ::scaluq::U2Gate<Prec>;                                                     \
     using U3Gate = ::scaluq::U3Gate<Prec>;                                                     \
     using SwapGate = ::scaluq::SwapGate<Prec>;                                                 \
+    using EcrGate = ::scaluq::EcrGate<Prec>;                                                   \
     using PauliGate = ::scaluq::PauliGate<Prec>;                                               \
     using PauliRotationGate = ::scaluq::PauliRotationGate<Prec>;                               \
     using SparseMatrixGate = ::scaluq::SparseMatrixGate<Prec, Space>;                          \
@@ -181,6 +182,12 @@
                      const std::vector<std::uint64_t>& controls = {},                          \
                      std::vector<std::uint64_t> control_values = {}) {                         \
         return ::scaluq::gate::Swap<Prec>(target1, target2, controls, control_values);         \
+    }                                                                                          \
+    inline Gate Ecr(std::uint64_t target1,                                                     \
+                    std::uint64_t target2,                                                     \
+                    const std::vector<std::uint64_t>& controls = {},                           \
+                    std::vector<std::uint64_t> control_values = {}) {                          \
+        return ::scaluq::gate::Ecr<Prec>(target1, target2, controls, control_values);          \
     }                                                                                          \
     inline Gate Pauli(const PauliOperator& pauli,                                              \
                       const std::vector<std::uint64_t>& controls = {},                         \

--- a/include/scaluq/all.hpp
+++ b/include/scaluq/all.hpp
@@ -183,8 +183,12 @@
                      std::vector<std::uint64_t> control_values = {}) {                         \
         return ::scaluq::gate::Swap<Prec>(target1, target2, controls, control_values);         \
     }                                                                                          \
-    inline Gate Ecr(std::uint64_t control, std::uint64_t target) {                             \
-        return ::scaluq::gate::Ecr<Prec>(control, target);                                     \
+    inline Gate Ecr(std::uint64_t physical_control,                                            \
+                    std::uint64_t physical_target,                                             \
+                    const std::vector<std::uint64_t>& controls = {},                           \
+                    std::vector<std::uint64_t> control_values = {}) {                          \
+        return ::scaluq::gate::Ecr<Prec>(                                                      \
+            physical_control, physical_target, controls, control_values);                      \
     }                                                                                          \
     inline Gate Pauli(const PauliOperator& pauli,                                              \
                       const std::vector<std::uint64_t>& controls = {},                         \

--- a/include/scaluq/all.hpp
+++ b/include/scaluq/all.hpp
@@ -184,7 +184,7 @@
         return ::scaluq::gate::Swap<Prec>(target1, target2, controls, control_values);         \
     }                                                                                          \
     inline Gate Ecr(std::uint64_t control, std::uint64_t target) {                             \
-        return ::scaluq::gate::Ecr<Prec>(target1, target2);                                    \
+        return ::scaluq::gate::Ecr<Prec>(control, target);                                     \
     }                                                                                          \
     inline Gate Pauli(const PauliOperator& pauli,                                              \
                       const std::vector<std::uint64_t>& controls = {},                         \

--- a/include/scaluq/all.hpp
+++ b/include/scaluq/all.hpp
@@ -183,11 +183,8 @@
                      std::vector<std::uint64_t> control_values = {}) {                         \
         return ::scaluq::gate::Swap<Prec>(target1, target2, controls, control_values);         \
     }                                                                                          \
-    inline Gate Ecr(std::uint64_t target1,                                                     \
-                    std::uint64_t target2,                                                     \
-                    const std::vector<std::uint64_t>& controls = {},                           \
-                    std::vector<std::uint64_t> control_values = {}) {                          \
-        return ::scaluq::gate::Ecr<Prec>(target1, target2, controls, control_values);          \
+    inline Gate Ecr(std::uint64_t control, std::uint64_t target) {                             \
+        return ::scaluq::gate::Ecr<Prec>(target1, target2);                                    \
     }                                                                                          \
     inline Gate Pauli(const PauliOperator& pauli,                                              \
                       const std::vector<std::uint64_t>& controls = {},                         \

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -59,6 +59,8 @@ class U3GateImpl;
 template <Precision Prec>
 class SwapGateImpl;
 template <Precision Prec>
+class EcrGateImpl;
+template <Precision Prec>
 class PauliGateImpl;
 template <Precision Prec>
 class PauliRotationGateImpl;
@@ -96,6 +98,7 @@ enum class GateType {
     U2,
     U3,
     Swap,
+    Ecr,
     Pauli,
     PauliRotation,
     SparseMatrix,
@@ -154,6 +157,8 @@ constexpr GateType get_gate_type() {
         return GateType::U3;
     else if constexpr (std::is_same_v<TWithoutConst, internal::SwapGateImpl<Prec>>)
         return GateType::Swap;
+    else if constexpr (std::is_same_v<TWithoutConst, internal::EcrGateImpl<Prec>>)
+        return GateType::Ecr;
     else if constexpr (std::is_same_v<TWithoutConst, internal::PauliGateImpl<Prec>>)
         return GateType::Pauli;
     else if constexpr (std::is_same_v<TWithoutConst, internal::PauliRotationGateImpl<Prec>>)
@@ -298,6 +303,7 @@ DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(U1GateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(U2GateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(U3GateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(SwapGateImpl)
+DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(EcrGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(PauliGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(PauliRotationGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(ProbabilisticGateImpl)
@@ -398,6 +404,7 @@ public:
         else if (type == "U2") gate = GetGateFromJson<U2GateImpl<Prec>>::get(j);
         else if (type == "U3") gate = GetGateFromJson<U3GateImpl<Prec>>::get(j);
         else if (type == "Swap") gate = GetGateFromJson<SwapGateImpl<Prec>>::get(j);
+        else if (type == "Ecr") gate = GetGateFromJson<EcrGateImpl<Prec>>::get(j);
         else if (type == "Pauli") gate = GetGateFromJson<PauliGateImpl<Prec>>::get(j);
         else if (type == "PauliRotation") gate = GetGateFromJson<PauliRotationGateImpl<Prec>>::get(j);
         else if (type == "Probabilistic") gate = GetGateFromJson<ProbabilisticGateImpl<Prec>>::get(j);
@@ -738,6 +745,7 @@ void bind_gate_gate_hpp_without_precision_and_space(nb::module_& m) {
         .value("U2", GateType::U2)
         .value("U3", GateType::U3)
         .value("Swap", GateType::Swap)
+        .value("Ecr", GateType::Ecr)
         .value("Pauli", GateType::Pauli)
         .value("PauliRotation", GateType::PauliRotation)
         .value("SparseMatrix", GateType::SparseMatrix)

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -568,7 +568,11 @@ void register_gate_common_methods(nb::class_<GateT>& c) {
             "get_matrix",
             [](const GateT& gate) { return gate->get_matrix(); },
             ([]() {
-                auto ds = DocString().desc("Get matrix representation of the gate.");
+                auto ds = DocString().desc(
+                    "Get matrix representation of the gate. "
+                    "Note: The matrix is constructed by reordering "
+                    "target qubits in ascending order of their indices. The qubit with the "
+                    "smaller index is treated as the first target, and the larger as the second.");
                 if constexpr (is_base_gate) {
                     ds.ex(
                         DocString::Code({">>> gate = H(0, controls=[1, 2], control_values=[1, 0])",

--- a/include/scaluq/gate/gate_factory.hpp
+++ b/include/scaluq/gate/gate_factory.hpp
@@ -920,7 +920,7 @@ void bind_gate_gate_factory_hpp(nb::module_& mgate) {
             .arg("control_values", "list[int]", true, "Control qubit values")
             .ret("Gate", "Ecr gate instance")
             .ex(DocString::Code({">>> gate = Ecr(0, 1)  # control : 0 and target : 1",
-                                 ">>> gate = Ecr(0, 2, [0])  #Controlled-ECR"}))
+                                 ">>> gate = Ecr(1, 2, [0])  #Controlled-ECR"}))
             .build_as_google_style()
             .c_str());
     mgate.def("CX",

--- a/include/scaluq/gate/gate_factory.hpp
+++ b/include/scaluq/gate/gate_factory.hpp
@@ -290,13 +290,17 @@ inline Gate<Prec> Swap(std::uint64_t target1,
         internal::vector_to_mask(controls, control_values));
 }
 template <Precision Prec>
-inline Gate<Prec> Ecr(std::uint64_t control, std::uint64_t target) {
+inline Gate<Prec> Ecr(std::uint64_t physical_control,
+                      std::uint64_t physical_target,
+                      const std::vector<std::uint64_t>& controls = {},
+                      std::vector<std::uint64_t> control_values = {}) {
+    internal::resize_and_check_control_values(controls, control_values);
     return internal::GateFactory::create_gate<internal::EcrGateImpl<Prec>>(
-        internal::vector_to_mask({target, control}),
-        internal::vector_to_mask({}),
-        internal::vector_to_mask({}),
-        internal::vector_to_mask({control}),
-        internal::vector_to_mask({target}));
+        internal::vector_to_mask({physical_target, physical_control}),
+        internal::vector_to_mask(controls),
+        internal::vector_to_mask(controls, control_values),
+        internal::vector_to_mask({physical_control}),
+        internal::vector_to_mask({physical_target}));
 }
 template <Precision Prec>
 inline Gate<Prec> Pauli(const PauliOperator<Prec>& pauli,
@@ -901,19 +905,22 @@ void bind_gate_gate_factory_hpp(nb::module_& mgate) {
     mgate.def(
         "Ecr",
         &gate::Ecr<Prec>,
-        "control"_a,
-        "target"_a,
+        "physical_control"_a,
+        "physical_target"_a,
+        "controls"_a = std::vector<std::uint64_t>{},
+        "control_values"_a = std::vector<std::uint64_t>{},
         DocString()
             .desc("Generate ECR gate. Echoed cross-resonance gate.")
             .note(
                 "If you need to use functions specific to the :class:`~scaluq.f64.EcrGate` class, "
-                "please downcast it."
-                "These control and target mean physical layer")
-            .arg("control", "int", "Control qubit index")
-            .arg("target", "int", "Target qubit index")
+                "please downcast it.")
+            .arg("physical_control", "int", "Physical control qubit index")
+            .arg("physical_target", "int", "Physical target qubit index")
+            .arg("controls", "list[int]", true, "Control qubit indices")
+            .arg("control_values", "list[int]", true, "Control qubit values")
             .ret("Gate", "Ecr gate instance")
             .ex(DocString::Code({">>> gate = Ecr(0, 1)  # control : 0 and target : 1",
-                                 ">>> gate = Ecr(0, 2)  # control : 0 and target : 2"}))
+                                 ">>> gate = Ecr(0, 2, [0])  #Controlled-ECR"}))
             .build_as_google_style()
             .c_str());
     mgate.def("CX",

--- a/include/scaluq/gate/gate_factory.hpp
+++ b/include/scaluq/gate/gate_factory.hpp
@@ -910,7 +910,7 @@ void bind_gate_gate_factory_hpp(nb::module_& mgate) {
             .arg("target", "int", "Target qubit index")
             .ret("Gate", "Ecr gate instance")
             .ex(DocString::Code({">>> gate = Ecr(0, 1)  # control : 0 and target : 1",
-                                 ">>> gate = Ecr(0, 2)  # control : 1 and target : 2"}))
+                                 ">>> gate = Ecr(0, 2)  # control : 0 and target : 2"}))
             .build_as_google_style()
             .c_str());
     mgate.def("CX",

--- a/include/scaluq/gate/gate_factory.hpp
+++ b/include/scaluq/gate/gate_factory.hpp
@@ -290,6 +290,18 @@ inline Gate<Prec> Swap(std::uint64_t target1,
         internal::vector_to_mask(controls, control_values));
 }
 template <Precision Prec>
+inline Gate<Prec> Ecr(std::uint64_t target1,
+                      std::uint64_t target2,
+                      const std::vector<std::uint64_t>& controls = {},
+                      std::vector<std::uint64_t> control_values = {}) {
+    internal::resize_and_check_control_values(controls, control_values);
+    return internal::GateFactory::create_gate<internal::EcrGateImpl<Prec>>(
+        internal::vector_to_mask({target1, target2}),
+        internal::vector_to_mask(controls),
+        internal::vector_to_mask(controls, control_values),
+        internal::vector_to_mask({target1}));
+}
+template <Precision Prec>
 inline Gate<Prec> Pauli(const PauliOperator<Prec>& pauli,
                         const std::vector<std::uint64_t>& controls = {},
                         std::vector<std::uint64_t> control_values = {}) {
@@ -887,6 +899,27 @@ void bind_gate_gate_factory_hpp(nb::module_& mgate) {
             .ret("Gate", "SWAP gate instance")
             .ex(DocString::Code({">>> gate = Swap(0, 1)  # Swap qubits 0 and 1",
                                  ">>> gate = Swap(1, 2, [0])  # Controlled-SWAP"}))
+            .build_as_google_style()
+            .c_str());
+    mgate.def(
+        "Ecr",
+        &gate::Swap<Prec>,
+        "target1"_a,
+        "target2"_a,
+        "controls"_a = std::vector<std::uint64_t>{},
+        "control_values"_a = std::vector<std::uint64_t>{},
+        DocString()
+            .desc("Generate ECR gate.")
+            .note(
+                "If you need to use functions specific to the :class:`~scaluq.f64.EcrGate` class, "
+                "please downcast it.")
+            .arg("target1", "int", "First target qubit index")
+            .arg("target2", "int", "Second target qubit index")
+            .arg("controls", "list[int]", true, "Control qubit indices")
+            .arg("control_values", "list[int]", true, "Control qubit values")
+            .ret("Gate", "Ecr gate instance")
+            .ex(DocString::Code({">>> gate = Ecr(0, 1)  # target1:0 and target2:1",
+                                 ">>> gate = Ecr(1, 2, [0])  # Controlled-ECR"}))
             .build_as_google_style()
             .c_str());
     mgate.def("CX",

--- a/include/scaluq/gate/gate_factory.hpp
+++ b/include/scaluq/gate/gate_factory.hpp
@@ -290,16 +290,11 @@ inline Gate<Prec> Swap(std::uint64_t target1,
         internal::vector_to_mask(controls, control_values));
 }
 template <Precision Prec>
-inline Gate<Prec> Ecr(std::uint64_t target1,
-                      std::uint64_t target2,
-                      const std::vector<std::uint64_t>& controls = {},
-                      std::vector<std::uint64_t> control_values = {}) {
-    internal::resize_and_check_control_values(controls, control_values);
+inline Gate<Prec> Ecr(std::uint64_t control, std::uint64_t target) {
     return internal::GateFactory::create_gate<internal::EcrGateImpl<Prec>>(
-        internal::vector_to_mask({target1, target2}),
-        internal::vector_to_mask(controls),
-        internal::vector_to_mask(controls, control_values),
-        internal::vector_to_mask({target1}));
+        internal::vector_to_mask({target}),
+        internal::vector_to_mask({control}),
+        internal::vector_to_mask({}));
 }
 template <Precision Prec>
 inline Gate<Prec> Pauli(const PauliOperator<Prec>& pauli,
@@ -903,23 +898,19 @@ void bind_gate_gate_factory_hpp(nb::module_& mgate) {
             .c_str());
     mgate.def(
         "Ecr",
-        &gate::Swap<Prec>,
-        "target1"_a,
-        "target2"_a,
-        "controls"_a = std::vector<std::uint64_t>{},
-        "control_values"_a = std::vector<std::uint64_t>{},
+        &gate::Ecr<Prec>,
+        "control"_a,
+        "target"_a,
         DocString()
-            .desc("Generate ECR gate.")
+            .desc("Generate ECR gate. Echoed cross-resonance gate.")
             .note(
                 "If you need to use functions specific to the :class:`~scaluq.f64.EcrGate` class, "
                 "please downcast it.")
-            .arg("target1", "int", "First target qubit index")
-            .arg("target2", "int", "Second target qubit index")
-            .arg("controls", "list[int]", true, "Control qubit indices")
-            .arg("control_values", "list[int]", true, "Control qubit values")
+            .arg("control", "int", "Control qubit index")
+            .arg("target", "int", "Target qubit index")
             .ret("Gate", "Ecr gate instance")
-            .ex(DocString::Code({">>> gate = Ecr(0, 1)  # target1:0 and target2:1",
-                                 ">>> gate = Ecr(1, 2, [0])  # Controlled-ECR"}))
+            .ex(DocString::Code({">>> gate = Ecr(0, 1)  # control : 0 and target : 1",
+                                 ">>> gate = Ecr(0, 2)  # control : 1 and target : 2"}))
             .build_as_google_style()
             .c_str());
     mgate.def("CX",

--- a/include/scaluq/gate/gate_factory.hpp
+++ b/include/scaluq/gate/gate_factory.hpp
@@ -292,9 +292,11 @@ inline Gate<Prec> Swap(std::uint64_t target1,
 template <Precision Prec>
 inline Gate<Prec> Ecr(std::uint64_t control, std::uint64_t target) {
     return internal::GateFactory::create_gate<internal::EcrGateImpl<Prec>>(
-        internal::vector_to_mask({target}),
+        internal::vector_to_mask({target, control}),
+        internal::vector_to_mask({}),
+        internal::vector_to_mask({}),
         internal::vector_to_mask({control}),
-        internal::vector_to_mask({}));
+        internal::vector_to_mask({target}));
 }
 template <Precision Prec>
 inline Gate<Prec> Pauli(const PauliOperator<Prec>& pauli,
@@ -905,7 +907,8 @@ void bind_gate_gate_factory_hpp(nb::module_& mgate) {
             .desc("Generate ECR gate. Echoed cross-resonance gate.")
             .note(
                 "If you need to use functions specific to the :class:`~scaluq.f64.EcrGate` class, "
-                "please downcast it.")
+                "please downcast it."
+                "These control and target mean physical layer")
             .arg("control", "int", "Control qubit index")
             .arg("target", "int", "Target qubit index")
             .ret("Gate", "Ecr gate instance")

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -939,8 +939,8 @@ public:
                  {"target", this->target_qubit_list()},
                  {"control", this->control_qubit_list()},
                  {"control_value", this->control_value_list()},
-                 {"physical_control", this->physical_control()},
-                 {"physical_target", this->physical_target()}};
+                 {"physical_control", mask_to_vector(this->physical_control())},
+                 {"physical_target", mask_to_vector(this->physical_target())}};
     }
 };
 

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -906,8 +906,12 @@ public:
           _physical_control_mask(physical_control_mask),
           _physical_target_mask(physical_target_mask) {}
 
-    std::vector<std::uint64_t> physical_control_index() const { return mask_to_vector(_physical_control_mask); }
-    std::vector<std::uint64_t> physical_target_index() const { return mask_to_vector(_physical_target_mask); }
+    std::vector<std::uint64_t> physical_control_indices() const {
+        return mask_to_vector(_physical_control_mask);
+    }
+    std::vector<std::uint64_t> physical_target_indices() const {
+        return mask_to_vector(_physical_target_mask);
+    }
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const EcrGateImpl<Prec>>(this->_target_mask,
@@ -939,8 +943,8 @@ public:
                  {"target", this->target_qubit_list()},
                  {"control", this->control_qubit_list()},
                  {"control_value", this->control_value_list()},
-                 {"physical_control", this->physical_control_index()},
-                 {"physical_target", this->physical_target_index()}};
+                 {"physical_control", this->physical_control_indices()},
+                 {"physical_target", this->physical_target_indices()}};
     }
 };
 
@@ -1157,12 +1161,12 @@ void bind_gate_gate_standard_hpp(nb::module_& m, nb::class_<Gate<Prec>>& gate_ba
                                             "-i & 0 & 1 & 0 \\end{bmatrix}$.")
         .def(
             "physical_control",
-            [](const EcrGate<Prec>& gate) { return gate->physical_control_index(); },
-            "Get `physical_control_index` property.")
+            [](const EcrGate<Prec>& gate) { return gate->physical_control_indices(); },
+            "Get `physical_control_indices` property.")
         .def(
             "physical_target",
-            [](const EcrGate<Prec>& gate) { return gate->physical_target_index(); },
-            "Get `physical_target_index` property.");
+            [](const EcrGate<Prec>& gate) { return gate->physical_target_indices(); },
+            "Get `physical_target_indices` property.");
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -906,8 +906,8 @@ public:
           _physical_control_mask(physical_control_mask),
           _physical_target_mask(physical_target_mask) {}
 
-    double physical_control() const { return _physical_control_mask; }
-    double physical_target() const { return _physical_target_mask; }
+    std::uint64_t physical_control() const { return _physical_control_mask; }
+    std::uint64_t physical_target() const { return _physical_target_mask; }
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const EcrGateImpl<Prec>>(this->_target_mask,

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -892,6 +892,50 @@ public:
     }
 };
 
+template <Precision Prec>
+class EcrGateImpl : public GateBase<Prec> {
+    std::uint64_t _target1_mask;
+
+public:
+    EcrGateImpl(std::uint64_t target_mask,
+                std::uint64_t control_mask,
+                std::uint64_t control_value_mask,
+                std::uint64_t target1_mask)
+        : GateBase<Prec>(target_mask, control_mask, control_value_mask),
+          _target1_mask(target1_mask) {}
+
+    std::uint64_t target1_mask() const { return _target1_mask; }
+
+    std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
+        return this->shared_from_this();
+    }
+    ComplexMatrix get_matrix() const override;
+
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(
+        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(
+        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+    void update_quantum_state(
+        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+#ifdef SCALUQ_USE_CUDA
+    void update_quantum_state(
+        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+    void update_quantum_state(
+        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+#endif  // SCALUQ_USE_CUDA
+
+    std::string to_string(const std::string& indent) const override;
+
+    void get_as_json(Json& j) const override {
+        j = Json{{"type", "Ecr"},
+                 {"target", this->target_qubit_list()},
+                 {"control", this->control_qubit_list()},
+                 {"control_value", this->control_value_list()},
+                 {"target1", this->target1_mask()}};
+    }
+};
+
 }  // namespace internal
 
 template <Precision Prec>
@@ -940,6 +984,8 @@ template <Precision Prec>
 using U3Gate = internal::GatePtr<internal::U3GateImpl<Prec>>;
 template <Precision Prec>
 using SwapGate = internal::GatePtr<internal::SwapGateImpl<Prec>>;
+template <Precision Prec>
+using EcrGate = internal::GatePtr<internal::EcrGateImpl<Prec>>;
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
@@ -1091,6 +1137,19 @@ void bind_gate_gate_standard_hpp(nb::module_& m, nb::class_<Gate<Prec>>& gate_ba
             "Get `lambda` property.");
     bind_specific_gate<SwapGate<Prec>, Prec>(
         m, gate_base_def, "SwapGate", "Specific class of two-qubit swap gate.");
+    bind_specific_gate<EcrGate<Prec>, Prec>(m,
+                                            gate_base_def,
+                                            "EcrGate",
+                                            "Specific class of two-qubit ecr gate."
+                                            "represented as "
+                                            "$\\frac{1}{\\sqrt{2}}\\begin{bmatrix}"
+                                            "0 & 1 & 0 & i \\\\ "
+                                            "1 & 0 & -i & 0 \\\\ "
+                                            "0 & i & 0 & 1 \\\\ "
+                                            "-i & 0 & 1 & 0 \\end{bmatrix}$.")
+        .def("target1_mask", [](const EcrGate<Prec>& gate) {
+            return gate->target1_mask();
+        } "Get `target1` property.");
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -906,8 +906,8 @@ public:
           _physical_control_mask(physical_control_mask),
           _physical_target_mask(physical_target_mask) {}
 
-    std::uint64_t physical_control() const { return _physical_control_mask; }
-    std::uint64_t physical_target() const { return _physical_target_mask; }
+    std::vector<std::uint64_t> physical_control_index() const { return mask_to_vector(_physical_control_mask); }
+    std::vector<std::uint64_t> physical_target_index() const { return mask_to_vector(_physical_target_mask); }
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const EcrGateImpl<Prec>>(this->_target_mask,
@@ -939,8 +939,8 @@ public:
                  {"target", this->target_qubit_list()},
                  {"control", this->control_qubit_list()},
                  {"control_value", this->control_value_list()},
-                 {"physical_control", mask_to_vector(this->physical_control())},
-                 {"physical_target", mask_to_vector(this->physical_target())}};
+                 {"physical_control", this->physical_control_index()},
+                 {"physical_target", this->physical_target_index()}};
     }
 };
 
@@ -1157,12 +1157,12 @@ void bind_gate_gate_standard_hpp(nb::module_& m, nb::class_<Gate<Prec>>& gate_ba
                                             "-i & 0 & 1 & 0 \\end{bmatrix}$.")
         .def(
             "physical_control",
-            [](const EcrGate<Prec>& gate) { return gate->physical_control(); },
-            "Get `physical_control_mask` property.")
+            [](const EcrGate<Prec>& gate) { return gate->physical_control_index(); },
+            "Get `physical_control_index` property.")
         .def(
             "physical_target",
-            [](const EcrGate<Prec>& gate) { return gate->physical_target(); },
-            "Get `physical_target_mask` property.");
+            [](const EcrGate<Prec>& gate) { return gate->physical_target_index(); },
+            "Get `physical_target_index` property.");
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -894,11 +894,27 @@ public:
 
 template <Precision Prec>
 class EcrGateImpl : public GateBase<Prec> {
+    std::uint64_t _physical_control_mask, _physical_target_mask;
+
 public:
-    using GateBase<Prec>::GateBase;
+    EcrGateImpl(std::uint64_t target_mask,
+                std::uint64_t control_mask,
+                std::uint64_t control_value_mask,
+                std::uint64_t physical_control_mask,
+                std::uint64_t physical_target_mask)
+        : GateBase<Prec>(target_mask, control_mask, control_value_mask),
+          _physical_control_mask(physical_control_mask),
+          _physical_target_mask(physical_target_mask) {}
+
+    double physical_control() const { return _physical_control_mask; }
+    double physical_target() const { return _physical_target_mask; }
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
-        return this->shared_from_this();
+        return std::make_shared<const EcrGateImpl<Prec>>(this->_target_mask,
+                                                         this->_control_mask,
+                                                         this->_control_value_mask,
+                                                         _physical_control_mask,
+                                                         _physical_target_mask);
     }
     ComplexMatrix get_matrix() const override;
 
@@ -922,7 +938,9 @@ public:
         j = Json{{"type", "Ecr"},
                  {"target", this->target_qubit_list()},
                  {"control", this->control_qubit_list()},
-                 {"control_value", this->control_value_list()}};
+                 {"control_value", this->control_value_list()},
+                 {"physical_control", this->physical_control()},
+                 {"physical_target", this->physical_target()}};
     }
 };
 
@@ -1136,7 +1154,15 @@ void bind_gate_gate_standard_hpp(nb::module_& m, nb::class_<Gate<Prec>>& gate_ba
                                             "0 & 1 & 0 & i \\\\ "
                                             "1 & 0 & -i & 0 \\\\ "
                                             "0 & i & 0 & 1 \\\\ "
-                                            "-i & 0 & 1 & 0 \\end{bmatrix}$.");
+                                            "-i & 0 & 1 & 0 \\end{bmatrix}$.")
+        .def(
+            "physical_control",
+            [](const EcrGate<Prec>& gate) { return gate->physical_control(); },
+            "Get `physical_control_mask` property.")
+        .def(
+            "physical_target",
+            [](const EcrGate<Prec>& gate) { return gate->physical_target(); },
+            "Get `physical_target_mask` property.");
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -894,17 +894,8 @@ public:
 
 template <Precision Prec>
 class EcrGateImpl : public GateBase<Prec> {
-    std::uint64_t _target1_mask;
-
 public:
-    EcrGateImpl(std::uint64_t target_mask,
-                std::uint64_t control_mask,
-                std::uint64_t control_value_mask,
-                std::uint64_t target1_mask)
-        : GateBase<Prec>(target_mask, control_mask, control_value_mask),
-          _target1_mask(target1_mask) {}
-
-    std::uint64_t target1_mask() const { return _target1_mask; }
+    using GateBase<Prec>::GateBase;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return this->shared_from_this();
@@ -931,8 +922,7 @@ public:
         j = Json{{"type", "Ecr"},
                  {"target", this->target_qubit_list()},
                  {"control", this->control_qubit_list()},
-                 {"control_value", this->control_value_list()},
-                 {"target1", this->target1_mask()}};
+                 {"control_value", this->control_value_list()}};
     }
 };
 
@@ -1142,14 +1132,11 @@ void bind_gate_gate_standard_hpp(nb::module_& m, nb::class_<Gate<Prec>>& gate_ba
                                             "EcrGate",
                                             "Specific class of two-qubit ecr gate."
                                             "represented as "
-                                            "$\\frac{1}{\\sqrt{2}}\\begin{bmatrix}"
+                                            "$\\frac{1}{\\sqrt{2}}\\begin{bmatrix} "
                                             "0 & 1 & 0 & i \\\\ "
                                             "1 & 0 & -i & 0 \\\\ "
                                             "0 & i & 0 & 1 \\\\ "
-                                            "-i & 0 & 1 & 0 \\end{bmatrix}$.")
-        .def("target1_mask", [](const EcrGate<Prec>& gate) {
-            return gate->target1_mask();
-        } "Get `target1` property.");
+                                            "-i & 0 & 1 & 0 \\end{bmatrix}$.");
 }
 }  // namespace internal
 #endif

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -768,12 +768,14 @@ std::string EcrGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_ECR_GATE_UPDATE(Class, Space)                                                   \
-    template <Precision Prec>                                                                  \
-    void EcrGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {     \
-        this->check_qubit_mask_within_bounds(state_vector);                                    \
-        ecr_gate(                                                                              \
-            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+#define DEFINE_ECR_GATE_UPDATE(Class, Space)                                               \
+    template <Precision Prec>                                                              \
+    void EcrGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
+        this->check_qubit_mask_within_bounds(state_vector);                                \
+        ecr_gate(this->_physical_target_mask,                                              \
+                 this->_physical_control_mask,                                             \
+                 this->_control_value_mask,                                                \
+                 state_vector);                                                            \
     }
 DEFINE_ECR_GATE_UPDATE(StateVector, ExecutionSpace::Host)
 DEFINE_ECR_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
@@ -910,7 +912,9 @@ std::shared_ptr<const EcrGateImpl<Prec>> GetGateFromJson<EcrGateImpl<Prec>>::get
     return std::make_shared<const EcrGateImpl<Prec>>(
         vector_to_mask(j.at("target").get<std::vector<std::uint64_t>>()),
         vector_to_mask(control_qubits),
-        vector_to_mask(control_qubits, control_values));
+        vector_to_mask(control_qubits, control_values),
+        vector_to_mask(j.at("physical_control").get<std::vector<std::uint64_t>>()),
+        vector_to_mask(j.at("physical_target").get<std::vector<std::uint64_t>>()));
 }
 template struct GetGateFromJson<EcrGateImpl<Prec>>;
 

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -774,8 +774,32 @@ ComplexMatrix EcrGateImpl<Prec>::get_matrix() const {
 template <Precision Prec>
 std::string EcrGateImpl<Prec>::to_string(const std::string& indent) const {
     std::ostringstream ss;
+    auto targets = this->target_qubit_list();
+    auto controls = this->control_qubit_list();
+    auto control_values = this->control_value_list();
+    auto physical_control = physical_control_index();
+    auto physical_target = physical_target_index();
     ss << indent << "Gate Type: Ecr\n";
-    ss << this->get_qubit_info_as_string(indent);
+    ss << indent << "  Physical Control Qubit: {";
+    ss << physical_control[0];
+    ss << "}\n";
+    ss << indent << "  Physical Target Qubit: {";
+    ss << physical_target[0];
+    ss << "}\n";
+
+    ss << indent << "  Target Qubits: {";
+    for (std::uint32_t i = 0; i < targets.size(); ++i)
+        ss << targets[i] << (i == targets.size() - 1 ? "" : ", ");
+    ss << "}\n";
+
+    ss << indent << "  Control Qubits: {";
+    for (std::uint32_t i = 0; i < controls.size(); ++i)
+        ss << controls[i] << (i == controls.size() - 1 ? "" : ", ");
+    ss << "}\n";
+    ss << indent << "  Control Value: {";
+    for (std::uint32_t i = 0; i < control_values.size(); ++i)
+        ss << control_values[i] << (i == control_values.size() - 1 ? "" : ", ");
+    ss << "}";
     return ss.str();
 }
 #define DEFINE_ECR_GATE_UPDATE(Class, Space)                                               \

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -756,9 +756,19 @@ template class SwapGateImpl<Prec>;
 template <Precision Prec>
 ComplexMatrix EcrGateImpl<Prec>::get_matrix() const {
     ComplexMatrix mat = ComplexMatrix::Identity(1 << 2, 1 << 2);
-    mat << 0, 1, 0, StdComplex(0, 1), 1, 0, StdComplex(0, -1), 0, 0, StdComplex(0, 1), 0, 1,
-        StdComplex(0, -1), 0, 1, 0;
-    mat /= Kokkos::numbers::sqrt2;
+    if (_physical_target_mask > _physical_control_mask) {
+        mat << 0, 1, 0, StdComplex(0, 1), 1, 0, StdComplex(0, -1), 0, 0, StdComplex(0, 1), 0, 1,
+            StdComplex(0, -1), 0, 1, 0;
+        mat /= Kokkos::numbers::sqrt2;
+        return mat;
+    }
+    if (_physical_target_mask < _physical_control_mask) {
+        mat << 0, 0, 1, StdComplex(0, 1), 0, 0, StdComplex(0, 1), 1, 1, StdComplex(0, -1), 0, 0,
+            StdComplex(0, -1), 1, 0, 0;
+        mat /= Kokkos::numbers::sqrt2;
+        return mat;
+    }
+
     return mat;
 }
 template <Precision Prec>

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -768,15 +768,12 @@ std::string EcrGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_ECR_GATE_UPDATE(Class, Space)                                               \
-    template <Precision Prec>                                                              \
-    void EcrGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                                \
-        ecr_gate(this->_target_mask,                                                       \
-                 this->_control_mask,                                                      \
-                 this->_control_value_mask,                                                \
-                 this->_target1_mask,                                                      \
-                 state_vector);                                                            \
+#define DEFINE_ECR_GATE_UPDATE(Class, Space)                                                   \
+    template <Precision Prec>                                                                  \
+    void EcrGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {     \
+        this->check_qubit_mask_within_bounds(state_vector);                                    \
+        ecr_gate(                                                                              \
+            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
 DEFINE_ECR_GATE_UPDATE(StateVector, ExecutionSpace::Host)
 DEFINE_ECR_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
@@ -913,8 +910,7 @@ std::shared_ptr<const EcrGateImpl<Prec>> GetGateFromJson<EcrGateImpl<Prec>>::get
     return std::make_shared<const EcrGateImpl<Prec>>(
         vector_to_mask(j.at("target").get<std::vector<std::uint64_t>>()),
         vector_to_mask(control_qubits),
-        vector_to_mask(control_qubits, control_values),
-        vector_to_mask(j.at("target1").get<std::vector<std::uint64_t>>()));
+        vector_to_mask(control_qubits, control_values));
 }
 template struct GetGateFromJson<EcrGateImpl<Prec>>;
 

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -777,8 +777,8 @@ std::string EcrGateImpl<Prec>::to_string(const std::string& indent) const {
     auto targets = this->target_qubit_list();
     auto controls = this->control_qubit_list();
     auto control_values = this->control_value_list();
-    auto physical_control = physical_control_index();
-    auto physical_target = physical_target_index();
+    auto physical_control = physical_control_indices();
+    auto physical_target = physical_target_indices();
     ss << indent << "Gate Type: Ecr\n";
     ss << indent << "  Physical Control Qubit: {";
     ss << physical_control[0];

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -808,6 +808,7 @@ std::string EcrGateImpl<Prec>::to_string(const std::string& indent) const {
         this->check_qubit_mask_within_bounds(state_vector);                                \
         ecr_gate(this->_physical_target_mask,                                              \
                  this->_physical_control_mask,                                             \
+                 this->_control_mask,                                                      \
                  this->_control_value_mask,                                                \
                  state_vector);                                                            \
     }

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -753,6 +753,42 @@ DEFINE_SWAP_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
 #undef DEFINE_SWAP_GATE_UPDATE
 template class SwapGateImpl<Prec>;
 
+template <Precision Prec>
+ComplexMatrix EcrGateImpl<Prec>::get_matrix() const {
+    ComplexMatrix mat = ComplexMatrix::Identity(1 << 2, 1 << 2);
+    mat << 0, 1, 0, StdComplex(0, 1), 1, 0, StdComplex(0, -1), 0, 0, StdComplex(0, 1), 0, 1,
+        StdComplex(0, -1), 0, 1, 0;
+    mat /= Kokkos::numbers::sqrt2;
+    return mat;
+}
+template <Precision Prec>
+std::string EcrGateImpl<Prec>::to_string(const std::string& indent) const {
+    std::ostringstream ss;
+    ss << indent << "Gate Type: Ecr\n";
+    ss << this->get_qubit_info_as_string(indent);
+    return ss.str();
+}
+#define DEFINE_ECR_GATE_UPDATE(Class, Space)                                               \
+    template <Precision Prec>                                                              \
+    void EcrGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
+        this->check_qubit_mask_within_bounds(state_vector);                                \
+        ecr_gate(this->_target_mask,                                                       \
+                 this->_control_mask,                                                      \
+                 this->_control_value_mask,                                                \
+                 this->_target1_mask,                                                      \
+                 state_vector);                                                            \
+    }
+DEFINE_ECR_GATE_UPDATE(StateVector, ExecutionSpace::Host)
+DEFINE_ECR_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
+DEFINE_ECR_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
+DEFINE_ECR_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+#ifdef SCALUQ_USE_CUDA
+DEFINE_ECR_GATE_UPDATE(StateVector, ExecutionSpace::Default)
+DEFINE_ECR_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+#endif  // SCALUQ_USE_CUDA
+#undef DEFINE_ECR_GATE_UPDATE
+template class EcrGateImpl<Prec>;
+
 // I
 template <Precision Prec>
 std::shared_ptr<const IGateImpl<Prec>> GetGateFromJson<IGateImpl<Prec>>::get(const Json&) {
@@ -868,4 +904,18 @@ std::shared_ptr<const SwapGateImpl<Prec>> GetGateFromJson<SwapGateImpl<Prec>>::g
         vector_to_mask(control_qubits, control_values));
 }
 template struct GetGateFromJson<SwapGateImpl<Prec>>;
+
+// Ecr
+template <Precision Prec>
+std::shared_ptr<const EcrGateImpl<Prec>> GetGateFromJson<EcrGateImpl<Prec>>::get(const Json& j) {
+    auto control_qubits = j.at("control").get<std::vector<std::uint64_t>>();
+    auto control_values = j.at("control_value").get<std::vector<std::uint64_t>>();
+    return std::make_shared<const EcrGateImpl<Prec>>(
+        vector_to_mask(j.at("target").get<std::vector<std::uint64_t>>()),
+        vector_to_mask(control_qubits),
+        vector_to_mask(control_qubits, control_values),
+        vector_to_mask(j.at("target1").get<std::vector<std::uint64_t>>()));
+}
+template struct GetGateFromJson<EcrGateImpl<Prec>>;
+
 }  // namespace scaluq::internal

--- a/src/gate/update_ops.hpp
+++ b/src/gate/update_ops.hpp
@@ -509,13 +509,11 @@ template <Precision Prec, ExecutionSpace Space>
 void ecr_gate(std::uint64_t target_mask,
               std::uint64_t control_mask,
               std::uint64_t control_value_mask,
-              std::uint64_t target1_mask,
               StateVector<Prec, Space>& state);
 template <Precision Prec, ExecutionSpace Space>
 void ecr_gate(std::uint64_t target_mask,
               std::uint64_t control_mask,
               std::uint64_t control_value_mask,
-              std::uint64_t target1_mask,
               StateVectorBatched<Prec, Space>& state);
 
 template <Precision Prec, ExecutionSpace Space>

--- a/src/gate/update_ops.hpp
+++ b/src/gate/update_ops.hpp
@@ -506,6 +506,19 @@ void swap_gate(std::uint64_t target_mask,
                StateVectorBatched<Prec, Space>& states);
 
 template <Precision Prec, ExecutionSpace Space>
+void ecr_gate(std::uint64_t target_mask,
+              std::uint64_t control_mask,
+              std::uint64_t control_value_mask,
+              std::uint64_t target1_mask,
+              StateVector<Prec, Space>& state);
+template <Precision Prec, ExecutionSpace Space>
+void ecr_gate(std::uint64_t target_mask,
+              std::uint64_t control_mask,
+              std::uint64_t control_value_mask,
+              std::uint64_t target1_mask,
+              StateVectorBatched<Prec, Space>& state);
+
+template <Precision Prec, ExecutionSpace Space>
 void sparse_matrix_gate(std::uint64_t target_mask,
                         std::uint64_t control_mask,
                         std::uint64_t control_value_mask,

--- a/src/gate/update_ops.hpp
+++ b/src/gate/update_ops.hpp
@@ -508,11 +508,13 @@ void swap_gate(std::uint64_t target_mask,
 template <Precision Prec, ExecutionSpace Space>
 void ecr_gate(std::uint64_t physical_target_mask,
               std::uint64_t physical_control_mask,
+              std::uint64_t control_mask,
               std::uint64_t control_value_mask,
               StateVector<Prec, Space>& state);
 template <Precision Prec, ExecutionSpace Space>
 void ecr_gate(std::uint64_t physical_target_mask,
               std::uint64_t physical_control_mask,
+              std::uint64_t control_mask,
               std::uint64_t control_value_mask,
               StateVectorBatched<Prec, Space>& states);
 

--- a/src/gate/update_ops.hpp
+++ b/src/gate/update_ops.hpp
@@ -506,13 +506,13 @@ void swap_gate(std::uint64_t target_mask,
                StateVectorBatched<Prec, Space>& states);
 
 template <Precision Prec, ExecutionSpace Space>
-void ecr_gate(std::uint64_t target_mask,
-              std::uint64_t control_mask,
+void ecr_gate(std::uint64_t physical_target_mask,
+              std::uint64_t physical_control_mask,
               std::uint64_t control_value_mask,
               StateVector<Prec, Space>& state);
 template <Precision Prec, ExecutionSpace Space>
-void ecr_gate(std::uint64_t target_mask,
-              std::uint64_t control_mask,
+void ecr_gate(std::uint64_t physical_target_mask,
+              std::uint64_t physical_control_mask,
               std::uint64_t control_value_mask,
               StateVectorBatched<Prec, Space>& state);
 

--- a/src/gate/update_ops.hpp
+++ b/src/gate/update_ops.hpp
@@ -514,7 +514,7 @@ template <Precision Prec, ExecutionSpace Space>
 void ecr_gate(std::uint64_t physical_target_mask,
               std::uint64_t physical_control_mask,
               std::uint64_t control_value_mask,
-              StateVectorBatched<Prec, Space>& state);
+              StateVectorBatched<Prec, Space>& states);
 
 template <Precision Prec, ExecutionSpace Space>
 void sparse_matrix_gate(std::uint64_t target_mask,

--- a/src/gate/update_ops_standard.cpp
+++ b/src/gate/update_ops_standard.cpp
@@ -679,20 +679,21 @@ void swap_gate(std::uint64_t target_mask,
 }
 
 template <>
-void ecr_gate(std::uint64_t target_mask,
-              std::uint64_t control_mask,
+void ecr_gate(std::uint64_t physical_target_mask,
+              std::uint64_t physical_control_mask,
               std::uint64_t control_value_mask,
               StateVector<Prec, Space>& state) {
     Kokkos::parallel_for(
         "ecr_gate",
         Kokkos::RangePolicy<SpaceType<Space>>(
-            0, state.dim() >> std::popcount(target_mask | control_mask)),
+            0, state.dim() >> std::popcount(physical_target_mask | physical_control_mask)),
         KOKKOS_LAMBDA(std::uint64_t it) {
             std::uint64_t basis_0 =
-                insert_zero_at_mask_positions(it, target_mask | control_mask) | control_value_mask;
-            std::uint64_t basis_1 = basis_0 | control_mask;
-            std::uint64_t basis_2 = basis_0 | target_mask;
-            std::uint64_t basis_3 = basis_1 | target_mask;
+                insert_zero_at_mask_positions(it, physical_target_mask | physical_control_mask) |
+                control_value_mask;
+            std::uint64_t basis_1 = basis_0 | physical_control_mask;
+            std::uint64_t basis_2 = basis_0 | physical_target_mask;
+            std::uint64_t basis_3 = basis_1 | physical_target_mask;
 
             Complex<Prec> val0 = state._raw[basis_0];
             Complex<Prec> val1 = state._raw[basis_1];
@@ -716,11 +717,12 @@ void ecr_gate(std::uint64_t target_mask,
 }
 
 template <>
-void ecr_gate(std::uint64_t target_mask,
-              std::uint64_t control_mask,
+void ecr_gate(std::uint64_t physical_target_mask,
+              std::uint64_t physical_control_mask,
               std::uint64_t control_value_mask,
               StateVectorBatched<Prec, Space>& states) {
-    const std::uint64_t span = states.dim() >> std::popcount(target_mask | control_mask);
+    const std::uint64_t span =
+        states.dim() >> std::popcount(physical_target_mask | physical_control_mask);
     Kokkos::parallel_for(
         "ecr_gate_flat",
         Kokkos::RangePolicy<SpaceType<Space>>(0, states.batch_size() * span),
@@ -728,10 +730,11 @@ void ecr_gate(std::uint64_t target_mask,
             const std::uint64_t batch_id = g / span;
             const std::uint64_t it = g % span;
             std::uint64_t basis_0 =
-                insert_zero_at_mask_positions(it, target_mask | control_mask) | control_value_mask;
-            std::uint64_t basis_1 = basis_0 | control_mask;
-            std::uint64_t basis_2 = basis_0 | target_mask;
-            std::uint64_t basis_3 = basis_1 | target_mask;
+                insert_zero_at_mask_positions(it, physical_target_mask | physical_control_mask) |
+                control_value_mask;
+            std::uint64_t basis_1 = basis_0 | physical_control_mask;
+            std::uint64_t basis_2 = basis_0 | physical_target_mask;
+            std::uint64_t basis_3 = basis_1 | physical_target_mask;
 
             Complex<Prec> val0 = states._raw(batch_id, basis_0);
             Complex<Prec> val1 = states._raw(batch_id, basis_1);

--- a/src/gate/update_ops_standard.cpp
+++ b/src/gate/update_ops_standard.cpp
@@ -677,4 +677,85 @@ void swap_gate(std::uint64_t target_mask,
                                 states._raw(batch_id, basis | upper_target_mask));
         });
 }
+
+template <>
+void ecr_gate(std::uint64_t target_mask,
+              std::uint64_t control_mask,
+              std::uint64_t control_value_mask,
+              std::uint64_t target1_mask,
+              StateVector<Prec, Space>& state) {
+    std::uint64_t target2_mask = target_mask ^ target1_mask;
+    Kokkos::parallel_for(
+        "ecr_gate",
+        Kokkos::RangePolicy<SpaceType<Space>>(
+            0, state.dim() >> std::popcount(target_mask | control_mask)),
+        KOKKOS_LAMBDA(std::uint64_t it) {
+            std::uint64_t basis_0 =
+                insert_zero_at_mask_positions(it, target_mask | control_mask) | control_value_mask;
+            std::uint64_t basis_1 = basis_0 | target1_mask;
+            std::uint64_t basis_2 = basis_0 | target2_mask;
+            std::uint64_t basis_3 = basis_0 | target_mask;
+
+            Complex<Prec> val0 = state._raw[basis_0];
+            Complex<Prec> val1 = state._raw[basis_1];
+            Complex<Prec> val2 = state._raw[basis_2];
+            Complex<Prec> val3 = state._raw[basis_3];
+
+            Complex<Prec> res0 =
+                (val1 + val3 * Complex<Prec>(0, 1)) * Complex<Prec>(INVERSE_SQRT2());
+            Complex<Prec> res1 =
+                (val0 + val2 * Complex<Prec>(0, -1)) * Complex<Prec>(INVERSE_SQRT2());
+            Complex<Prec> res2 =
+                (val1 * Complex<Prec>(0, 1) + val3) * Complex<Prec>(INVERSE_SQRT2());
+            Complex<Prec> res3 =
+                (val0 * Complex<Prec>(0, -1) + val2) * Complex<Prec>(INVERSE_SQRT2());
+
+            state._raw[basis_0] = res0;
+            state._raw[basis_1] = res1;
+            state._raw[basis_2] = res2;
+            state._raw[basis_3] = res3;
+        });
+}
+
+template <>
+void ecr_gate(std::uint64_t target_mask,
+              std::uint64_t control_mask,
+              std::uint64_t control_value_mask,
+              std::uint64_t target1_mask,
+              StateVectorBatched<Prec, Space>& states) {
+    std::uint64_t target2_mask = target_mask ^ target1_mask;
+    const std::uint64_t span = states.dim() >> std::popcount(target_mask | control_mask);
+    Kokkos::parallel_for(
+        "ecr_gate_flat",
+        Kokkos::RangePolicy<SpaceType<Space>>(0, states.batch_size() * span),
+        KOKKOS_LAMBDA(std::uint64_t g) {
+            const std::uint64_t batch_id = g / span;
+            const std::uint64_t it = g % span;
+            std::uint64_t basis_0 =
+                insert_zero_at_mask_positions(it, target_mask | control_mask) | control_value_mask;
+            std::uint64_t basis_1 = basis_0 | target1_mask;
+            std::uint64_t basis_2 = basis_0 | target2_mask;
+            std::uint64_t basis_3 = basis_0 | target_mask;
+
+            Complex<Prec> val0 = states._raw(batch_id, basis_0);
+            Complex<Prec> val1 = states._raw(batch_id, basis_1);
+            Complex<Prec> val2 = states._raw(batch_id, basis_2);
+            Complex<Prec> val3 = states._raw(batch_id, basis_3);
+
+            Complex<Prec> res0 =
+                (val1 + val3 * Complex<Prec>(0, 1)) * Complex<Prec>(INVERSE_SQRT2());
+            Complex<Prec> res1 =
+                (val0 + val2 * Complex<Prec>(0, -1)) * Complex<Prec>(INVERSE_SQRT2());
+            Complex<Prec> res2 =
+                (val1 * Complex<Prec>(0, 1) + val3) * Complex<Prec>(INVERSE_SQRT2());
+            Complex<Prec> res3 =
+                (val0 * Complex<Prec>(0, -1) + val2) * Complex<Prec>(INVERSE_SQRT2());
+
+            states._raw(batch_id, basis_0) = res0;
+            states._raw(batch_id, basis_1) = res1;
+            states._raw(batch_id, basis_2) = res2;
+            states._raw(batch_id, basis_3) = res3;
+        });
+}
+
 }  // namespace scaluq::internal

--- a/src/gate/update_ops_standard.cpp
+++ b/src/gate/update_ops_standard.cpp
@@ -681,15 +681,19 @@ void swap_gate(std::uint64_t target_mask,
 template <>
 void ecr_gate(std::uint64_t physical_target_mask,
               std::uint64_t physical_control_mask,
+              std::uint64_t control_mask,
               std::uint64_t control_value_mask,
               StateVector<Prec, Space>& state) {
     Kokkos::parallel_for(
         "ecr_gate",
         Kokkos::RangePolicy<SpaceType<Space>>(
-            0, state.dim() >> std::popcount(physical_target_mask | physical_control_mask)),
+            0,
+            state.dim() >>
+                std::popcount(physical_target_mask | physical_control_mask | control_mask)),
         KOKKOS_LAMBDA(std::uint64_t it) {
             std::uint64_t basis_0 =
-                insert_zero_at_mask_positions(it, physical_target_mask | physical_control_mask) |
+                insert_zero_at_mask_positions(
+                    it, physical_target_mask | physical_control_mask | control_mask) |
                 control_value_mask;
             std::uint64_t basis_1 = basis_0 | physical_control_mask;
             std::uint64_t basis_2 = basis_0 | physical_target_mask;
@@ -719,10 +723,11 @@ void ecr_gate(std::uint64_t physical_target_mask,
 template <>
 void ecr_gate(std::uint64_t physical_target_mask,
               std::uint64_t physical_control_mask,
+              std::uint64_t control_mask,
               std::uint64_t control_value_mask,
               StateVectorBatched<Prec, Space>& states) {
     const std::uint64_t span =
-        states.dim() >> std::popcount(physical_target_mask | physical_control_mask);
+        states.dim() >> std::popcount(physical_target_mask | physical_control_mask | control_mask);
     Kokkos::parallel_for(
         "ecr_gate_flat",
         Kokkos::RangePolicy<SpaceType<Space>>(0, states.batch_size() * span),
@@ -730,7 +735,8 @@ void ecr_gate(std::uint64_t physical_target_mask,
             const std::uint64_t batch_id = g / span;
             const std::uint64_t it = g % span;
             std::uint64_t basis_0 =
-                insert_zero_at_mask_positions(it, physical_target_mask | physical_control_mask) |
+                insert_zero_at_mask_positions(
+                    it, physical_target_mask | physical_control_mask | control_mask) |
                 control_value_mask;
             std::uint64_t basis_1 = basis_0 | physical_control_mask;
             std::uint64_t basis_2 = basis_0 | physical_target_mask;

--- a/src/gate/update_ops_standard.cpp
+++ b/src/gate/update_ops_standard.cpp
@@ -682,9 +682,7 @@ template <>
 void ecr_gate(std::uint64_t target_mask,
               std::uint64_t control_mask,
               std::uint64_t control_value_mask,
-              std::uint64_t target1_mask,
               StateVector<Prec, Space>& state) {
-    std::uint64_t target2_mask = target_mask ^ target1_mask;
     Kokkos::parallel_for(
         "ecr_gate",
         Kokkos::RangePolicy<SpaceType<Space>>(
@@ -692,9 +690,9 @@ void ecr_gate(std::uint64_t target_mask,
         KOKKOS_LAMBDA(std::uint64_t it) {
             std::uint64_t basis_0 =
                 insert_zero_at_mask_positions(it, target_mask | control_mask) | control_value_mask;
-            std::uint64_t basis_1 = basis_0 | target1_mask;
-            std::uint64_t basis_2 = basis_0 | target2_mask;
-            std::uint64_t basis_3 = basis_0 | target_mask;
+            std::uint64_t basis_1 = basis_0 | control_mask;
+            std::uint64_t basis_2 = basis_0 | target_mask;
+            std::uint64_t basis_3 = basis_1 | target_mask;
 
             Complex<Prec> val0 = state._raw[basis_0];
             Complex<Prec> val1 = state._raw[basis_1];
@@ -721,9 +719,7 @@ template <>
 void ecr_gate(std::uint64_t target_mask,
               std::uint64_t control_mask,
               std::uint64_t control_value_mask,
-              std::uint64_t target1_mask,
               StateVectorBatched<Prec, Space>& states) {
-    std::uint64_t target2_mask = target_mask ^ target1_mask;
     const std::uint64_t span = states.dim() >> std::popcount(target_mask | control_mask);
     Kokkos::parallel_for(
         "ecr_gate_flat",
@@ -733,9 +729,9 @@ void ecr_gate(std::uint64_t target_mask,
             const std::uint64_t it = g % span;
             std::uint64_t basis_0 =
                 insert_zero_at_mask_positions(it, target_mask | control_mask) | control_value_mask;
-            std::uint64_t basis_1 = basis_0 | target1_mask;
-            std::uint64_t basis_2 = basis_0 | target2_mask;
-            std::uint64_t basis_3 = basis_0 | target_mask;
+            std::uint64_t basis_1 = basis_0 | control_mask;
+            std::uint64_t basis_2 = basis_0 | target_mask;
+            std::uint64_t basis_3 = basis_1 | target_mask;
 
             Complex<Prec> val0 = states._raw(batch_id, basis_0);
             Complex<Prec> val1 = states._raw(batch_id, basis_1);

--- a/tests/gate/batched_gate_test.cpp
+++ b/tests/gate/batched_gate_test.cpp
@@ -261,6 +261,33 @@ void run_random_batched_gate_apply_two_target(std::uint64_t n_qubits) {
             }
         }
     }
+
+    for (int repeat = 0; repeat < 10; repeat++) {
+        auto states =
+            StateVectorBatched<Prec, Space>::Haar_random_state(BATCH_SIZE, n_qubits, true);
+        auto state_cp = states.get_state_vector_at(0).get_amplitudes();
+        for (int i = 0; i < dim; i++) {
+            test_state[i] = state_cp[i];
+        }
+
+        std::uint64_t physical_control = random.int64() % n_qubits;
+        std::uint64_t physical_target = random.int64() % n_qubits;
+        if (physical_control == physical_target)
+            physical_control = (physical_control + 1) % n_qubits;
+        auto gate = gate::Ecr<Prec>(physical_control, physical_target);
+        gate->update_quantum_state(states);
+
+        ComplexMatrix test_mat =
+            get_eigen_matrix_full_qubit_Ecr(physical_control, physical_target, n_qubits);
+        test_state = test_mat * test_state;
+
+        auto states_cp = states.get_amplitudes();
+        for (std::uint64_t batch_id = 0; batch_id < states.batch_size(); batch_id++) {
+            for (int i = 0; i < dim; i++) {
+                check_near<Prec>(states_cp[batch_id][i], test_state[i]);
+            }
+        }
+    }
 }
 
 template <Precision Prec, ExecutionSpace Space>
@@ -735,6 +762,11 @@ TYPED_TEST(BatchedGateTest, ApplyIBMQ) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
     run_random_batched_gate_apply_IBMQ<Prec, Space>(5, make_U);
+}
+TYPED_TEST(BatchedGateTest, ApplyTwoTargetGate) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    run_random_batched_gate_apply_two_target<Prec, Space>(5);
 }
 TYPED_TEST(BatchedGateTest, ApplySparseMatrixGate) {
     constexpr Precision Prec = TestFixture::Prec;

--- a/tests/gate/batched_gate_test.cpp
+++ b/tests/gate/batched_gate_test.cpp
@@ -1056,6 +1056,7 @@ TYPED_TEST(BatchedGateTest, Control) {
         test_batched_standard_gate_control<Prec, Space, 1, 2>(gate::U2<Prec>, n);
         test_batched_standard_gate_control<Prec, Space, 1, 3>(gate::U3<Prec>, n);
         test_batched_standard_gate_control<Prec, Space, 2, 0>(gate::Swap<Prec>, n);
+        test_batched_standard_gate_control<Prec, Space, 2, 0>(gate::Ecr<Prec>, n);
         test_batched_pauli_control<Prec, Space, false>(n);
         test_batched_pauli_control<Prec, Space, true>(n);
         test_batched_matrix_control<Prec, Space, 0>(n);

--- a/tests/gate/gate_test.cpp
+++ b/tests/gate/gate_test.cpp
@@ -232,6 +232,30 @@ void run_random_gate_apply_two_target(std::uint64_t n_qubits) {
             check_near<Prec>(state_cp[i], test_state[i]);
         }
     }
+
+    for (int repeat = 0; repeat < 10; repeat++) {
+        auto state = StateVector<Prec, Space>::Haar_random_state(n_qubits);
+        auto state_cp = state.get_amplitudes();
+        for (int i = 0; i < dim; i++) {
+            test_state[i] = state_cp[i];
+        }
+
+        std::uint64_t physical_control = random.int64() % n_qubits;
+        std::uint64_t physical_target = random.int64() % n_qubits;
+        if (physical_control == physical_target)
+            physical_control = (physical_control + 1) % n_qubits;
+        auto gate = gate::Ecr<Prec>(physical_control, physical_target);
+        gate->update_quantum_state(state);
+        state_cp = state.get_amplitudes();
+
+        ComplexMatrix test_mat =
+            get_eigen_matrix_full_qubit_Ecr(physical_control, physical_target, n_qubits);
+        test_state = test_mat * test_state;
+
+        for (int i = 0; i < dim; i++) {
+            check_near<Prec>(state_cp[i], test_state[i]);
+        }
+    }
 }
 
 template <Precision Prec, ExecutionSpace Space>
@@ -679,6 +703,12 @@ TYPED_TEST(GateTest, ApplyIBMQ) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
     run_random_gate_apply_IBMQ<Prec, Space>(5, make_U);
+}
+
+TYPED_TEST(GateTest, ApplyTwoTargetGate) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    run_random_gate_apply_two_target<Prec, Space>(5);
 }
 
 TYPED_TEST(GateTest, ApplySparseMatrixGate) {

--- a/tests/gate/gate_test.cpp
+++ b/tests/gate/gate_test.cpp
@@ -1005,6 +1005,7 @@ TYPED_TEST(GateTest, Control) {
         test_standard_gate_control<Prec, Space, 1, 2>(gate::U2<Prec>, n);
         test_standard_gate_control<Prec, Space, 1, 3>(gate::U3<Prec>, n);
         test_standard_gate_control<Prec, Space, 2, 0>(gate::Swap<Prec>, n);
+        test_standard_gate_control<Prec, Space, 2, 0>(gate::Ecr<Prec>, n);
         test_pauli_control<Prec, Space, false>(n);
         test_pauli_control<Prec, Space, true>(n);
         test_matrix_control<Prec, Space, 0>(n);

--- a/tests/gate/merge_test.cpp
+++ b/tests/gate/merge_test.cpp
@@ -158,6 +158,7 @@ void merge_gate_test() {
     single_target_rotation2(gate::U2<Prec>);
     single_target_rotation3(gate::U3<Prec>);
     double_target(gate::Swap<Prec>);
+    double_target(gate::Ecr<Prec>);
     dense_matrix(gate::DenseMatrix<Prec, Space>);
     sparse_matrix(gate::SparseMatrix<Prec, Space>);
     gates.push_back(gate::Pauli<Prec>(PauliOperator<Prec>("X 0 Y 2", random.uniform())));

--- a/tests/util/util.hpp
+++ b/tests/util/util.hpp
@@ -208,6 +208,40 @@ inline ComplexMatrix get_eigen_matrix_full_qubit_Swap(std::uint64_t target_qubit
     return result;
 }
 
+inline ComplexMatrix get_eigen_matrix_full_qubit_Ecr(std::uint64_t physical_control_qubit_index,
+                                                     std::uint64_t physical_target_qubit_index,
+                                                     std::uint64_t qubit_count) {
+    std::uint64_t dim = 1ULL << qubit_count;
+    ComplexMatrix alpha = ComplexMatrix::Zero(dim, dim);
+    ComplexMatrix beta = ComplexMatrix::Identity(1, 1);
+
+    // alpha: physical_control:X, physical_target:I
+    for (std::uint64_t i = 0; i < 1; ++i) {
+        ComplexMatrix matrix;
+        matrix = get_eigen_matrix_single_Pauli(1);
+        alpha += get_expanded_eigen_matrix_with_identity(
+            physical_control_qubit_index, matrix, qubit_count);
+    }
+
+    // beta: physical_control:Y, physical_target: X
+    for (std::uint64_t i = 0; i < qubit_count; ++i) {
+        if (i == physical_control_qubit_index) {
+            ComplexMatrix cmatrix;
+            cmatrix = get_eigen_matrix_single_Pauli(2);
+            beta = internal::kronecker_product(cmatrix, beta).eval();
+        } else if (i == physical_target_qubit_index) {
+            ComplexMatrix tmatrix;
+            tmatrix = get_eigen_matrix_single_Pauli(1);
+            beta = internal::kronecker_product(tmatrix, beta).eval();
+        } else {
+            ComplexMatrix matrix;
+            matrix = get_eigen_matrix_single_Pauli(0);
+            beta = internal::kronecker_product(matrix, beta).eval();
+        }
+    } // Ecr gate matrix representation (IX-XY)/sqrt(2)
+    return (alpha - beta) / std::sqrt(2);
+}
+
 inline ComplexMatrix make_2x2_matrix(const StdComplex& a00,
                                      const StdComplex& a01,
                                      const StdComplex& a10,


### PR DESCRIPTION
## ECR(Echoed Cross-Resonance)ゲートの追加
$$\frac{1}{\sqrt{2}}\begin{bmatrix} 0 & 1 & 0 & i \\\\ 1 & 0 & -i & 0 \\\\ 0 & i & 0 & 1 \\\\ -i & 0 & 1 & 0 \end{bmatrix}$$

のような行列なので、kokkosで2量子ビットの組み合わせ00,01,10,11への作用をparallel_forで計算させています。

- 基本的に既存のゲート(CNOTやSwapなど)と同じようにGateBaseのサブクラスとして実装し、  
`Ecr(呼び出し) -> EcrGateImpl(GateBaseサブクラス) -> ecr(kokkos処理)`
のようにEcr専用通路を実装しています。

- Ecrゲートには方向性が存在するので、kokkos処理においては
`basis_0(control,targetビットが0), basis_1(controlビットが1), basis_2(targetビットが1), basis_3(control, targetビットが1)`
として行列計算をしています。

注: Ecrゲートはすべての状態に対して行列計算が行われるため、control_value_maskは最初から{}で空括弧にしています。

## 使用方法
`Ecr(0, 1)`のように指定します。引数は`(control, target)`の2つの順序で指定します。
内部的には、GateBaseクラスのコンストラクタを使用するため、target, controlの順に管理されています。

## 実装理由およびメリット
量子コンピューター実機においてはcx,czなどその実機ごとに2qゲートを持っており、一部の実機においてはecrがネイティブゲートとして利用されるため、より実際のデバイスに即した量子回路シュミレーションが可能となります。