### PR TITLE
古典レジスタ，測定ゲート，古典分岐の実装

### DIFF
--- a/include/scaluq/all.hpp
+++ b/include/scaluq/all.hpp
@@ -42,6 +42,7 @@
     using SqrtYdagGate = ::scaluq::SqrtYdagGate<Prec>;                                         \
     using P0Gate = ::scaluq::P0Gate<Prec>;                                                     \
     using P1Gate = ::scaluq::P1Gate<Prec>;                                                     \
+    using MeasurementGate = ::scaluq::MeasurementGate<Prec>;                                   \
     using RXGate = ::scaluq::RXGate<Prec>;                                                     \
     using RYGate = ::scaluq::RYGate<Prec>;                                                     \
     using RZGate = ::scaluq::RZGate<Prec>;                                                     \
@@ -130,6 +131,9 @@
                    const std::vector<std::uint64_t>& controls = {},                            \
                    std::vector<std::uint64_t> control_values = {}) {                           \
         return ::scaluq::gate::P1<Prec>(target, controls, control_values);                     \
+    }                                                                                          \
+    inline Gate Measurement(std::uint64_t target, std::uint64_t classical_bit) {               \
+        return ::scaluq::gate::Measurement<Prec>(target, classical_bit);                       \
     }                                                                                          \
     inline Gate RX(std::uint64_t target,                                                       \
                    double angle,                                                               \
@@ -249,4 +253,6 @@
     const auto& ParamProbabilistic = ::scaluq::gate::ParamProbabilistic<Prec>;                 \
     }                                                                                          \
     inline auto& merge_gate = ::scaluq::merge_gate<Prec, Space>;                               \
+    using ClassicalCondition = ::scaluq::ClassicalCondition;                                   \
+    using ClassicalRegister = ::scaluq::ClassicalRegister;                                     \
     using Circuit = ::scaluq::Circuit<Prec>;

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -1,10 +1,17 @@
 #pragma once
 
-#include <bit>
+#include <algorithm>
+#include <functional>
 #include <map>
+#include <optional>
+#include <random>
 #include <set>
+#include <stdexcept>
+#include <string>
 #include <string_view>
+#include <utility>
 #include <variant>
+#include <vector>
 
 #include "../gate/gate.hpp"
 #include "../gate/param_gate.hpp"
@@ -12,15 +19,57 @@
 
 namespace scaluq {
 
+class ClassicalRegister {
+private:
+    const std::vector<bool>* _reg = nullptr;
+    std::uint64_t _offset = 0;
+    std::uint64_t _size = 0;
+
+public:
+    explicit ClassicalRegister(const std::vector<bool>& reg) : _reg(&reg), _size(reg.size()) {}
+    ClassicalRegister(const std::vector<bool>& reg, std::uint64_t offset, std::uint64_t size)
+        : _reg(&reg), _offset(offset), _size(size) {
+        if (_offset + _size > reg.size()) {
+            throw std::runtime_error("ClassicalRegister: offset and size are out of range.");
+        }
+    }
+
+    [[nodiscard]] bool operator[](std::uint64_t index) const {
+        if (index >= _size) return false;
+        return (*_reg)[_offset + index];
+    }
+    [[nodiscard]] std::uint64_t size() const { return _size; }
+    [[nodiscard]] bool empty() const { return _size == 0; }
+};
+
+/**
+ * @brief Classical condition evaluated against the circuit register.
+ *
+ * Any callable convertible to `std::function<bool(const ClassicalRegister&)>`
+ * can be used here, such as:
+ * - lambda expressions
+ * - function pointers
+ * - functors
+ * - `std::function`
+ *
+ * @example
+ * `[](const ClassicalRegister& reg) {`
+ * `    return reg.size() > 1 && reg[0] && reg[1];`
+ * `}`
+ */
+using ClassicalCondition = std::function<bool(const ClassicalRegister&)>;
+
 template <Precision Prec>
 class Circuit {
 public:
     using GateWithKey = std::variant<Gate<Prec>, std::pair<ParamGate<Prec>, std::string>>;
-    Circuit() = default;
+    explicit Circuit(std::uint64_t n_classical_bits = 0)
+        : _reg(n_classical_bits, false), _n_classical_bits(n_classical_bits) {}
 
     [[nodiscard]] inline const std::vector<GateWithKey>& gate_list() const { return _gate_list; }
     [[nodiscard]] inline std::uint64_t n_gates() const { return _gate_list.size(); }
     [[nodiscard]] std::set<std::string> key_set() const;
+    [[nodiscard]] inline const std::vector<bool>& classical_register() const { return _reg; }
     [[nodiscard]] inline const GateWithKey& get_gate_at(std::uint64_t idx) const {
         if (idx >= _gate_list.size()) {
             throw std::runtime_error("Circuit::get_gate_at(std::uint64_t): index out of bounds");
@@ -36,12 +85,91 @@ public:
         if (gate.index() == 0) return std::nullopt;
         return std::get<1>(gate).second;
     }
+    [[nodiscard]] inline std::optional<ClassicalCondition> get_classical_condition_at(
+        std::uint64_t idx) const {
+        if (idx >= _gate_list.size()) {
+            throw std::runtime_error(
+                "Circuit::get_classical_condition_at(std::uint64_t): index out of bounds");
+        }
+        return _classical_conditions[idx];
+    }
 
     [[nodiscard]] std::uint64_t calculate_depth() const;
 
-    void add_gate(const Gate<Prec>& gate) { _gate_list.push_back(gate); }
+    void add_gate(const Gate<Prec>& gate) {
+        if (gate.gate_type() == GateType::Measurement &&
+            MeasurementGate<Prec>(gate)->classical_bit_index() >= _n_classical_bits) {
+            throw std::runtime_error(
+                "Circuit::add_gate: measurement classical bit index is out of range.");
+        }
+        _gate_list.push_back(gate);
+        _classical_conditions.push_back(std::nullopt);
+    }
     void add_param_gate(const ParamGate<Prec>& param_gate, std::string_view parameter_key) {
         _gate_list.push_back(std::make_pair(param_gate, std::string(parameter_key)));
+        _classical_conditions.push_back(std::nullopt);
+    }
+
+    /**
+     * @brief Add a gate guarded by a user-defined classical condition.
+     *
+     * The condition is evaluated as `condition(const ClassicalRegister&)`.
+     * Missing register bits should be handled by the callable itself.
+     *
+     * @example
+     * `circuit.add_conditional_gate(gate::X<Prec>(2), [](const ClassicalRegister& reg) {`
+     * `    return reg[0] ^ reg[1];`
+     * `});`
+     */
+    void add_conditional_gate(const Gate<Prec>& gate, ClassicalCondition condition) {
+        add_gate(gate);
+        _classical_conditions.back() = std::move(condition);
+    }
+    void add_conditional_gate(const Gate<Prec>& gate,
+                              std::uint64_t classical_bit_index,
+                              bool expected_value) {
+        if (classical_bit_index >= _n_classical_bits) {
+            throw std::runtime_error(
+                "Circuit::add_conditional_gate: classical bit index is out of range.");
+        }
+        add_conditional_gate(gate,
+                             [classical_bit_index, expected_value](const ClassicalRegister& reg) {
+                                 return reg[classical_bit_index] == expected_value;
+                             });
+    }
+
+    /**
+     * @brief Add a parametric gate guarded by a user-defined classical condition.
+     *
+     * The condition is evaluated as `condition(const ClassicalRegister&)`.
+     * Missing register bits should be handled by the callable itself.
+     *
+     * @example
+     * `circuit.add_conditional_param_gate(gate::ParamRX<Prec>(0), "theta",`
+     * `    [](const ClassicalRegister& reg) {`
+     * `        return reg[0] ^ reg[1];`
+     * `    });`
+     */
+    void add_conditional_param_gate(const ParamGate<Prec>& param_gate,
+                                    std::string_view parameter_key,
+                                    ClassicalCondition condition) {
+        add_param_gate(param_gate, parameter_key);
+        _classical_conditions.back() = std::move(condition);
+    }
+    void add_conditional_param_gate(const ParamGate<Prec>& param_gate,
+                                    std::string_view parameter_key,
+                                    std::uint64_t classical_bit_index,
+                                    bool expected_value) {
+        if (classical_bit_index >= _n_classical_bits) {
+            throw std::runtime_error(
+                "Circuit::add_conditional_param_gate: classical bit index is out of range.");
+        }
+        add_conditional_param_gate(
+            param_gate,
+            parameter_key,
+            [classical_bit_index, expected_value](const ClassicalRegister& reg) {
+                return reg[classical_bit_index] == expected_value;
+            });
     }
 
     void add_circuit(const Circuit<Prec>& circuit);
@@ -49,11 +177,12 @@ public:
 
     template <ExecutionSpace Space>
     void update_quantum_state(StateVector<Prec, Space>& state,
-                              const std::map<std::string, double>& parameters = {}) const;
+                              const std::map<std::string, double>& parameters = {},
+                              std::uint64_t seed = std::random_device{}());
     template <ExecutionSpace Space>
-    void update_quantum_state(
-        StateVectorBatched<Prec, Space>& states,
-        const std::map<std::string, std::vector<double>>& parameters = {}) const;
+    void update_quantum_state(StateVectorBatched<Prec, Space>& states,
+                              const std::map<std::string, std::vector<double>>& parameters = {},
+                              std::uint64_t seed = std::random_device{}());
 
     Circuit copy() const;
 
@@ -63,18 +192,22 @@ public:
     void optimize(std::uint64_t max_block_size = 3);
 
     friend void to_json(Json& j, const Circuit& circuit) {
-        j = Json{{"gate_list", Json::array()}};
-        for (auto&& gate : circuit.gate_list()) {
-            if (gate.index() == 0)
-                j["gate_list"].emplace_back(Json{{"gate", std::get<0>(gate)}});
-            else
-                j["gate_list"].emplace_back(
-                    Json{{"gate", std::get<1>(gate).first}, {"key", std::get<1>(gate).second}});
+        j = Json{{"gate_list", Json::array()}, {"n_classical_bits", circuit._n_classical_bits}};
+        for (std::uint64_t idx = 0; idx < circuit.gate_list().size(); ++idx) {
+            if (circuit._classical_conditions[idx].has_value()) {
+                throw std::runtime_error(
+                    "Circuit::to_json: classically controlled instructions cannot be serialized.");
+            }
+            const auto& gate = circuit.gate_list()[idx];
+            Json gate_json = gate.index() == 0 ? Json{{"gate", std::get<0>(gate)}}
+                                               : Json{{"gate", std::get<1>(gate).first},
+                                                      {"key", std::get<1>(gate).second}};
+            j["gate_list"].emplace_back(std::move(gate_json));
         }
     }
 
     friend void from_json(const Json& j, Circuit& circuit) {
-        circuit = Circuit();
+        circuit = Circuit(j.value("n_classical_bits", std::uint64_t{0}));
         const Json& tmp_list = j.at("gate_list");
         for (const Json& gate_with_key : tmp_list) {
             if (gate_with_key.contains("key")) {
@@ -98,25 +231,118 @@ public:
 
 private:
     std::vector<GateWithKey> _gate_list;
+    std::vector<std::optional<ClassicalCondition>> _classical_conditions;
+    std::vector<bool> _reg;
+    std::uint64_t _n_classical_bits = 0;
 
+    [[nodiscard]] bool has_classical_conditions() const {
+        return std::any_of(_classical_conditions.begin(),
+                           _classical_conditions.end(),
+                           [](const auto& condition) { return condition.has_value(); });
+    }
     [[nodiscard]] std::uint64_t required_n_qubits() const;
     void check_state_vector_n_qubits(std::uint64_t n_qubits) const;
 };
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <Precision Prec, ExecutionSpace Space, typename ClassT>
+void bind_circuit_execution_methods(ClassT& circuit_def) {
+    circuit_def
+        .def(
+            "update_quantum_state",
+            [](Circuit<Prec>& circuit,
+               StateVector<Prec, Space>& state,
+               const std::map<std::string, double>& parameters,
+               std::optional<std::uint64_t> seed) {
+                circuit.template update_quantum_state<Space>(
+                    state, parameters, seed.value_or(std::random_device{}()));
+            },
+            "state"_a,
+            "params"_a = std::map<std::string, double>{},
+            "seed"_a = std::nullopt,
+            "Execute the circuit, including measurement and classical branching.")
+        .def(
+            "update_quantum_state",
+            [](Circuit<Prec>& circuit, StateVector<Prec, Space>& state, nb::kwargs kwargs) {
+                std::map<std::string, double> parameters;
+                for (auto&& [key, param] : kwargs) {
+                    parameters[nb::cast<std::string>(key)] = nb::cast<double>(param);
+                }
+                circuit.template update_quantum_state<Space>(state, parameters);
+            },
+            "state"_a,
+            "kwargs"_a,
+            "Execute the circuit. If the circuit contains parametric gates, pass parameters as "
+            "\"name=value\" in kwargs.")
+        .def(
+            "update_quantum_state",
+            [](Circuit<Prec>& circuit,
+               StateVectorBatched<Prec, Space>& states,
+               const std::map<std::string, std::vector<double>>& parameters,
+               std::optional<std::uint64_t> seed) {
+                circuit.template update_quantum_state<Space>(
+                    states, parameters, seed.value_or(std::random_device{}()));
+            },
+            "states"_a,
+            "params"_a = std::map<std::string, std::vector<double>>{},
+            "seed"_a = std::nullopt,
+            "Execute the circuit on a batched state vector.")
+        .def(
+            "update_quantum_state",
+            [](Circuit<Prec>& circuit, StateVectorBatched<Prec, Space>& states, nb::kwargs kwargs) {
+                std::map<std::string, std::vector<double>> parameters;
+                for (auto&& [key, param] : kwargs) {
+                    parameters[nb::cast<std::string>(key)] = nb::cast<std::vector<double>>(param);
+                }
+                circuit.template update_quantum_state<Space>(states, parameters);
+            },
+            "states"_a,
+            "kwargs"_a,
+            "Execute the circuit on a batched state vector. If the circuit contains parametric "
+            "gates, pass parameters as \"name=[value1, value2, ...]\" in kwargs.")
+        .def("optimize",
+             nb::overload_cast<std::uint64_t>(&Circuit<Prec>::template optimize<Space>),
+             "max_block_size"_a = 3,
+             "Optimize circuit. Create qubit dependency tree and merge neighboring gates if the "
+             "new gate has less than or equal to `max_block_size` or the new gate is Pauli.")
+        .def(
+            "simulate_noise",
+            [](const Circuit<Prec>& circuit,
+               const StateVector<Prec, Space>& initial_state,
+               std::uint64_t sampling_count,
+               const std::map<std::string, double>& parameters,
+               std::optional<std::uint64_t> seed) {
+                return circuit.template simulate_noise<Space>(
+                    initial_state,
+                    sampling_count,
+                    parameters,
+                    seed.value_or(std::random_device{}()));
+            },
+            "initial_state"_a,
+            "sampling_count"_a,
+            "parameters"_a = std::map<std::string, double>{},
+            "seed"_a = std::nullopt,
+            "Simulate noise circuit. Return all the possible states and their counts.");
+}
+
 template <Precision Prec>
 void bind_circuit_circuit_hpp(nb::module_& m) {
-    nb::class_<Circuit<Prec>>(
+    auto circuit_def = nb::class_<Circuit<Prec>>(
         m,
         "Circuit",
         DocString()
             .desc("Quantum circuit representation.")
-            .ex(DocString::Code(
-                {">>> circuit = Circuit()", ">>> print(circuit.to_json())", "{\"gate_list\":[]}"}))
+            .ex(DocString::Code({">>> circuit = Circuit()",
+                                 ">>> print(circuit.to_json())",
+                                 "{\"gate_list\":[],\"n_classical_bits\":0}"}))
             .build_as_google_style()
-            .c_str())
-        .def(nb::init<>(), "Initialize empty circuit.")
+            .c_str());
+
+    circuit_def.def(nb::init<>(), "Initialize circuit without classical registers.")
+        .def(nb::init<std::uint64_t>(),
+             "n_classical_bits"_a,
+             "Initialize circuit with `n_classical_bits` classical registers.")
         .def("gate_list",
              &Circuit<Prec>::gate_list,
              "Get property of `gate_list`.",
@@ -128,251 +354,56 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
              &Circuit<Prec>::get_param_key_at,
              "index"_a,
              "Get parameter key of i-th gate. If it is not parametric, return None.")
+        .def("classical_register",
+             &Circuit<Prec>::classical_register,
+             "Get property of `classical_register`.")
+        .def("get_classical_condition_at",
+             &Circuit<Prec>::get_classical_condition_at,
+             "index"_a,
+             "Get classical condition of i-th gate. If it is not conditional, return None.")
         .def("calculate_depth", &Circuit<Prec>::calculate_depth, "Get depth of circuit.")
         .def("add_gate",
              nb::overload_cast<const Gate<Prec>&>(&Circuit<Prec>::add_gate),
              "gate"_a,
              "Add gate. Given gate is copied.")
+        .def("add_conditional_gate",
+             nb::overload_cast<const Gate<Prec>&, ClassicalCondition>(
+                 &Circuit<Prec>::add_conditional_gate),
+             "gate"_a,
+             "condition"_a,
+             "Add gate with a user-defined classical condition.")
+        .def("add_conditional_gate",
+             nb::overload_cast<const Gate<Prec>&, std::uint64_t, bool>(
+                 &Circuit<Prec>::add_conditional_gate),
+             "gate"_a,
+             "classical_bit_index"_a,
+             "expected_value"_a,
+             "Add gate with classical condition.")
         .def("add_param_gate",
              nb::overload_cast<const ParamGate<Prec>&, std::string_view>(
                  &Circuit<Prec>::add_param_gate),
              "param_gate"_a,
              "param_key"_a,
              "Add parametric gate with specifying key. Given param_gate is copied.")
+        .def("add_conditional_param_gate",
+             nb::overload_cast<const ParamGate<Prec>&, std::string_view, ClassicalCondition>(
+                 &Circuit<Prec>::add_conditional_param_gate),
+             "param_gate"_a,
+             "param_key"_a,
+             "condition"_a,
+             "Add parametric gate with a user-defined classical condition.")
+        .def("add_conditional_param_gate",
+             nb::overload_cast<const ParamGate<Prec>&, std::string_view, std::uint64_t, bool>(
+                 &Circuit<Prec>::add_conditional_param_gate),
+             "param_gate"_a,
+             "param_key"_a,
+             "classical_bit_index"_a,
+             "expected_value"_a,
+             "Add parametric gate with classical condition.")
         .def("add_circuit",
              nb::overload_cast<const Circuit<Prec>&>(&Circuit<Prec>::add_circuit),
              "other"_a,
              "Add all gates in specified circuit. Given gates are copied.")
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVector<Prec, ExecutionSpace::Host>& state,
-                nb::kwargs kwargs) {
-                std::map<std::string, double> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<double>(param);
-                }
-                circuit.update_quantum_state(state, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-            "circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=value\" format in kwargs.")
-        .def("update_quantum_state",
-             nb::overload_cast<StateVector<Prec, ExecutionSpace::Host>&,
-                               const std::map<std::string, double>&>(
-                 &Circuit<Prec>::template update_quantum_state<ExecutionSpace::Host>, nb::const_),
-             "state"_a,
-             "params"_a,
-             "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-             "circuit contains parametric gate, you have to give real value of parameter as "
-             "dict[str, float] in 2nd arg.")
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVectorBatched<Prec, ExecutionSpace::Host>& states,
-                nb::kwargs kwargs) {
-                std::map<std::string, std::vector<double>> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<std::vector<double>>(param);
-                }
-                circuit.update_quantum_state(states, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=[value1, value2, ...]\" format in kwargs.")
-        .def(
-            "update_quantum_state",
-            nb::overload_cast<StateVectorBatched<Prec, ExecutionSpace::Host>&,
-                              const std::map<std::string, std::vector<double>>&>(
-                &Circuit<Prec>::template update_quantum_state<ExecutionSpace::Host>, nb::const_),
-            "state"_a,
-            "params"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "dict[str, list[float]] in 2nd arg.")
-        .def("optimize",
-             nb::overload_cast<std::uint64_t>(
-                 &Circuit<Prec>::template optimize<ExecutionSpace::Host>),
-             "max_block_size"_a = 3,
-             "Optimize circuit. Create qubit dependency tree and merge neighboring gates if the "
-             "new gate has less than or equal to `max_block_size` or the new gate is Pauli.")
-        .def(
-            "simulate_noise",
-            [](const Circuit<Prec>& circuit,
-               const StateVector<Prec, ExecutionSpace::Host>& initial_state,
-               std::uint64_t sampling_count,
-               const std::map<std::string, double>& parameters,
-               std::optional<std::uint64_t> seed) {
-                return circuit.template simulate_noise<ExecutionSpace::Host>(
-                    initial_state,
-                    sampling_count,
-                    parameters,
-                    seed.value_or(std::random_device{}()));
-            },
-            "initial_state"_a,
-            "sampling_count"_a,
-            "parameters"_a = std::map<std::string, double>{},
-            "seed"_a = std::nullopt,
-            "Simulate noise circuit. Return all the possible states and their counts.")
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVector<Prec, ExecutionSpace::HostSerial>& state,
-                nb::kwargs kwargs) {
-                std::map<std::string, double> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<double>(param);
-                }
-                circuit.update_quantum_state(state, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-            "circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=value\" format in kwargs.")
-        .def("update_quantum_state",
-             nb::overload_cast<StateVector<Prec, ExecutionSpace::HostSerial>&,
-                               const std::map<std::string, double>&>(
-                 &Circuit<Prec>::template update_quantum_state<ExecutionSpace::HostSerial>,
-                 nb::const_),
-             "state"_a,
-             "params"_a,
-             "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-             "circuit contains parametric gate, you have to give real value of parameter as "
-             "dict[str, float] in 2nd arg.")
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-                nb::kwargs kwargs) {
-                std::map<std::string, std::vector<double>> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<std::vector<double>>(param);
-                }
-                circuit.update_quantum_state(states, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=[value1, value2, ...]\" format in kwargs.")
-        .def(
-            "update_quantum_state",
-            nb::overload_cast<StateVectorBatched<Prec, ExecutionSpace::HostSerial>&,
-                              const std::map<std::string, std::vector<double>>&>(
-                &Circuit<Prec>::template update_quantum_state<ExecutionSpace::HostSerial>,
-                nb::const_),
-            "state"_a,
-            "params"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "dict[str, list[float]] in 2nd arg.")
-        .def("optimize",
-             nb::overload_cast<std::uint64_t>(
-                 &Circuit<Prec>::template optimize<ExecutionSpace::HostSerial>),
-             "max_block_size"_a = 3,
-             "Optimize circuit. Create qubit dependency tree and merge neighboring gates if the "
-             "new gate has less than or equal to `max_block_size` or the new gate is Pauli.")
-        .def(
-            "simulate_noise",
-            [](const Circuit<Prec>& circuit,
-               const StateVector<Prec, ExecutionSpace::HostSerial>& initial_state,
-               std::uint64_t sampling_count,
-               const std::map<std::string, double>& parameters,
-               std::optional<std::uint64_t> seed) {
-                return circuit.template simulate_noise<ExecutionSpace::HostSerial>(
-                    initial_state,
-                    sampling_count,
-                    parameters,
-                    seed.value_or(std::random_device{}()));
-            },
-            "initial_state"_a,
-            "sampling_count"_a,
-            "parameters"_a = std::map<std::string, double>{},
-            "seed"_a = std::nullopt,
-            "Simulate noise circuit. Return all the possible states and their counts.")
-#ifdef SCALUQ_USE_CUDA
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVector<Prec, ExecutionSpace::Default>& state,
-                nb::kwargs kwargs) {
-                std::map<std::string, double> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<double>(param);
-                }
-                circuit.update_quantum_state(state, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-            "circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=value\" format in kwargs.")
-        .def(
-            "update_quantum_state",
-            nb::overload_cast<StateVector<Prec, ExecutionSpace::Default>&,
-                              const std::map<std::string, double>&>(
-                &Circuit<Prec>::template update_quantum_state<ExecutionSpace::Default>, nb::const_),
-            "state"_a,
-            "params"_a,
-            "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-            "circuit contains parametric gate, you have to give real value of parameter as "
-            "dict[str, float] in 2nd arg.")
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVectorBatched<Prec, ExecutionSpace::Default>& states,
-                nb::kwargs kwargs) {
-                std::map<std::string, std::vector<double>> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<std::vector<double>>(param);
-                }
-                circuit.update_quantum_state(states, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=[value1, value2, ...]\" format in kwargs.")
-        .def(
-            "update_quantum_state",
-            nb::overload_cast<StateVectorBatched<Prec, ExecutionSpace::Default>&,
-                              const std::map<std::string, std::vector<double>>&>(
-                &Circuit<Prec>::template update_quantum_state<ExecutionSpace::Default>, nb::const_),
-            "state"_a,
-            "params"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "dict[str, list[float]] in 2nd arg.")
-        .def("optimize",
-             nb::overload_cast<std::uint64_t>(
-                 &Circuit<Prec>::template optimize<ExecutionSpace::Default>),
-             "max_block_size"_a = 3,
-             "Optimize circuit. Create qubit dependency tree and merge neighboring gates if the "
-             "new gate has less than or equal to `max_block_size` or the new gate is Pauli.")
-        .def(
-            "simulate_noise",
-            [](const Circuit<Prec>& circuit,
-               const StateVector<Prec, ExecutionSpace::Default>& initial_state,
-               std::uint64_t sampling_count,
-               const std::map<std::string, double>& parameters,
-               std::optional<std::uint64_t> seed) {
-                return circuit.template simulate_noise<ExecutionSpace::Default>(
-                    initial_state,
-                    sampling_count,
-                    parameters,
-                    seed.value_or(std::random_device{}()));
-            },
-            "initial_state"_a,
-            "sampling_count"_a,
-            "parameters"_a = std::map<std::string, double>{},
-            "seed"_a = std::nullopt,
-            "Simulate noise circuit. Return all the possible states and their counts.")
-#endif  // SCALUQ_USE_CUDA
         .def("copy",
              &Circuit<Prec>::copy,
              "Copy circuit. Returns a new circuit instance with all gates copied by reference.")
@@ -390,6 +421,11 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
             },
             "json_str"_a,
             "Read an object from the JSON representation of the circuit.");
+    bind_circuit_execution_methods<Prec, ExecutionSpace::Host>(circuit_def);
+    bind_circuit_execution_methods<Prec, ExecutionSpace::HostSerial>(circuit_def);
+#ifdef SCALUQ_USE_CUDA
+    bind_circuit_execution_methods<Prec, ExecutionSpace::Default>(circuit_def);
+#endif  // SCALUQ_USE_CUDA
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
+#include <random>
+#include <vector>
+
 #include "../state/state_vector.hpp"
 #include "../state/state_vector_batched.hpp"
 #include "../types.hpp"
 #include "../util/utility.hpp"
 
 namespace scaluq {
+
 namespace internal {
 // forward declarations
 
@@ -44,6 +48,8 @@ template <Precision Prec>
 class P0GateImpl;
 template <Precision Prec>
 class P1GateImpl;
+template <Precision Prec>
+class MeasurementGateImpl;
 template <Precision Prec>
 class RXGateImpl;
 template <Precision Prec>
@@ -89,6 +95,7 @@ enum class GateType {
     SqrtYdag,
     P0,
     P1,
+    Measurement,
     RX,
     RY,
     RZ,
@@ -101,6 +108,40 @@ enum class GateType {
     SparseMatrix,
     DenseMatrix,
     Probabilistic
+};
+
+template <Precision Prec, ExecutionSpace Space>
+struct ExecutionContext {
+    StateVector<Prec, Space> state;
+    std::vector<bool>* reg = nullptr;
+    std::mt19937_64* rng = nullptr;
+    std::uint64_t reg_offset = 0;
+
+    explicit ExecutionContext(StateVector<Prec, Space>& state_) : state(state_) {}
+    ExecutionContext(StateVector<Prec, Space>& state_,
+                     std::vector<bool>* reg_,
+                     std::mt19937_64* rng_)
+        : state(state_), reg(reg_), rng(rng_) {}
+    ExecutionContext(StateVector<Prec, Space>& state_,
+                     std::vector<bool>* reg_,
+                     std::mt19937_64* rng_,
+                     std::uint64_t reg_offset_)
+        : state(state_), reg(reg_), rng(rng_), reg_offset(reg_offset_) {}
+};
+
+template <Precision Prec, ExecutionSpace Space>
+struct BatchedExecutionContext {
+    StateVectorBatched<Prec, Space> states;
+    std::vector<bool>* reg = nullptr;
+    std::mt19937_64* rng = nullptr;
+    std::uint64_t n_classical_bits = 0;
+
+    explicit BatchedExecutionContext(StateVectorBatched<Prec, Space>& states_) : states(states_) {}
+    BatchedExecutionContext(StateVectorBatched<Prec, Space>& states_,
+                            std::vector<bool>* reg_,
+                            std::uint64_t n_classical_bits_,
+                            std::mt19937_64* rng_)
+        : states(states_), reg(reg_), rng(rng_), n_classical_bits(n_classical_bits_) {}
 };
 
 template <typename T, Precision Prec>
@@ -140,6 +181,8 @@ constexpr GateType get_gate_type() {
         return GateType::P0;
     else if constexpr (std::is_same_v<TWithoutConst, internal::P1GateImpl<Prec>>)
         return GateType::P1;
+    else if constexpr (std::is_same_v<TWithoutConst, internal::MeasurementGateImpl<Prec>>)
+        return GateType::Measurement;
     else if constexpr (std::is_same_v<TWithoutConst, internal::RXGateImpl<Prec>>)
         return GateType::RX;
     else if constexpr (std::is_same_v<TWithoutConst, internal::RYGateImpl<Prec>>)
@@ -237,18 +280,18 @@ public:
     [[nodiscard]] virtual ComplexMatrix get_matrix() const = 0;
 
     virtual void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Host>& state_vector) const = 0;
+        ExecutionContext<Prec, ExecutionSpace::Host> context) const = 0;
     virtual void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& states) const = 0;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const = 0;
     virtual void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const = 0;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const = 0;
     virtual void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states) const = 0;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const = 0;
 #ifdef SCALUQ_USE_CUDA
     virtual void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const = 0;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const = 0;
     virtual void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& states) const = 0;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const = 0;
 #endif  // SCALUQ_USE_CUDA
 
     [[nodiscard]] virtual std::string to_string(const std::string& indent = "") const = 0;
@@ -291,6 +334,7 @@ DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(SqrtYGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(SqrtYdagGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(P0GateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(P1GateImpl)
+DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(MeasurementGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(RXGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(RYGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(RZGateImpl)
@@ -391,6 +435,7 @@ public:
         else if (type == "SqrtXdag") gate = GetGateFromJson<SqrtXdagGateImpl<Prec>>::get(j);
         else if (type == "SqrtY") gate = GetGateFromJson<SqrtYGateImpl<Prec>>::get(j);
         else if (type == "SqrtYdag") gate = GetGateFromJson<SqrtYdagGateImpl<Prec>>::get(j);
+        else if (type == "Measurement") gate = GetGateFromJson<MeasurementGateImpl<Prec>>::get(j);
         else if (type == "RX") gate = GetGateFromJson<RXGateImpl<Prec>>::get(j);
         else if (type == "RY") gate = GetGateFromJson<RYGateImpl<Prec>>::get(j);
         else if (type == "RZ") gate = GetGateFromJson<RZGateImpl<Prec>>::get(j);
@@ -412,6 +457,24 @@ using Gate = internal::GatePtr<internal::GateBase<Prec>>;
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <typename GateT, Precision Prec, ExecutionSpace Space>
+void register_gate_execution_methods(nb::class_<GateT>& c) {
+    c.def(
+         "update_quantum_state",
+         [](const GateT& gate, StateVector<Prec, Space>& state_vector) {
+             gate->update_quantum_state(ExecutionContext<Prec, Space>{state_vector});
+         },
+         "state_vector"_a,
+         "Apply gate to `state_vector`. `state_vector` in args is directly updated.")
+        .def(
+            "update_quantum_state",
+            [](const GateT& gate, StateVectorBatched<Prec, Space>& states) {
+                gate->update_quantum_state(BatchedExecutionContext<Prec, Space>{states});
+            },
+            "states"_a,
+            "Apply gate to `states`. `states` in args is directly updated.");
+}
+
 template <typename GateT, Precision Prec>
 void register_gate_common_methods(nb::class_<GateT>& c) {
     using namespace nb::literals;
@@ -457,55 +520,18 @@ void register_gate_common_methods(nb::class_<GateT>& c) {
                 if (!inv) return nb::none();
                 return nb::cast(Gate<Prec>(inv));
             },
-            "Generate inverse gate as `Gate` type. If not exists, return None.")
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate, StateVector<Prec, ExecutionSpace::Host>& state_vector) {
-                gate->update_quantum_state(state_vector);
-            },
-            "state_vector"_a,
-            "Apply gate to `state_vector`. `state_vector` in args is directly updated.")
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate, StateVectorBatched<Prec, ExecutionSpace::Host>& states) {
-                gate->update_quantum_state(states);
-            },
-            "states"_a,
-            "Apply gate to `states`. `states` in args is directly updated.")
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate, StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) {
-                gate->update_quantum_state(state_vector);
-            },
-            "state_vector"_a,
-            "Apply gate to `state_vector`. `state_vector` in args is directly updated.")
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate, StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states) {
-                gate->update_quantum_state(states);
-            },
-            "states"_a,
-            "Apply gate to `states`. `states` in args is directly updated.")
+            "Generate inverse gate as `Gate` type. If not exists, return None.");
+
+    register_gate_execution_methods<GateT, Prec, ExecutionSpace::Host>(c);
+    register_gate_execution_methods<GateT, Prec, ExecutionSpace::HostSerial>(c);
 #ifdef SCALUQ_USE_CUDA
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate, StateVector<Prec, ExecutionSpace::Default>& state_vector) {
-                gate->update_quantum_state(state_vector);
-            },
-            "state_vector"_a,
-            "Apply gate to `state_vector`. `state_vector` in args is directly updated.")
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate, StateVectorBatched<Prec, ExecutionSpace::Default>& states) {
-                gate->update_quantum_state(states);
-            },
-            "states"_a,
-            "Apply gate to `states`. `states` in args is directly updated.")
+    register_gate_execution_methods<GateT, Prec, ExecutionSpace::Default>(c);
 #endif  // SCALUQ_USE_CUDA
-        .def(
-            "get_matrix",
-            [](const GateT& gate) { return gate->get_matrix(); },
-            "Get matrix representation of the gate.")
+
+    c.def(
+         "get_matrix",
+         [](const GateT& gate) { return gate->get_matrix(); },
+         "Get matrix representation of the gate.")
         .def(
             "to_string",
             [](const GateT& gate) { return gate->to_string(""); },
@@ -543,6 +569,7 @@ void bind_gate_gate_hpp_without_precision_and_space(nb::module_& m) {
         .value("SqrtYdag", GateType::SqrtYdag)
         .value("P0", GateType::P0)
         .value("P1", GateType::P1)
+        .value("Measurement", GateType::Measurement)
         .value("RX", GateType::RX)
         .value("RY", GateType::RY)
         .value("RZ", GateType::RZ)

--- a/include/scaluq/gate/gate_factory.hpp
+++ b/include/scaluq/gate/gate_factory.hpp
@@ -174,6 +174,11 @@ inline Gate<Prec> P1(std::uint64_t target,
         internal::vector_to_mask(controls, control_values));
 }
 template <Precision Prec>
+inline Gate<Prec> Measurement(std::uint64_t target, std::uint64_t classical_bit) {
+    return internal::GateFactory::create_gate<internal::MeasurementGateImpl<Prec>>(
+        internal::vector_to_mask({target}), classical_bit);
+}
+template <Precision Prec>
 inline Gate<Prec> RX(std::uint64_t target,
                      double angle,
                      const std::vector<std::uint64_t>& controls = {},
@@ -483,6 +488,19 @@ void bind_gate_gate_factory_hpp(nb::module_& mgate) {
             .ret("Gate", "Pauli-Y gate instance")
             .ex(DocString::Code({">>> gate = Y(0)  # Y gate on qubit 0",
                                  ">>> gate = Y(1, [0])  # Controlled-Y with control on qubit 0"}))
+            .build_as_google_style()
+            .c_str());
+    mgate.def(
+        "Measurement",
+        &gate::Measurement<Prec>,
+        "target"_a,
+        "classical_bit"_a,
+        DocString()
+            .desc("Generate general :class:`~scaluq.f64.Gate` class instance of "
+                  ":class:`~scaluq.f64.MeasurementGate`.")
+            .arg("target", "int", "Target qubit index")
+            .arg("classical_bit", "int", "Destination classical bit index")
+            .ret("Gate", "Measurement gate instance")
             .build_as_google_style()
             .c_str());
     mgate.def(

--- a/include/scaluq/gate/gate_matrix.hpp
+++ b/include/scaluq/gate/gate_matrix.hpp
@@ -28,18 +28,18 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -72,18 +72,18 @@ public:
 
     SparseComplexMatrix get_sparse_matrix() const { return get_matrix().sparseView(); }
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/gate_pauli.hpp
+++ b/include/scaluq/gate/gate_pauli.hpp
@@ -29,18 +29,18 @@ public:
     }
     ComplexMatrix get_matrix() const override { return this->_pauli.get_matrix(); }
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& states) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& states) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -79,18 +79,18 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& states) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& states) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/gate_probabilistic.hpp
+++ b/include/scaluq/gate/gate_probabilistic.hpp
@@ -64,18 +64,18 @@ public:
             "ProbabilisticGateImpl.");
     }
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -16,18 +16,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -54,18 +54,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -104,18 +104,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -138,18 +138,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -172,18 +172,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -206,18 +206,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -258,18 +258,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -293,18 +293,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -328,18 +328,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -363,18 +363,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -399,18 +399,18 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -434,18 +434,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -470,18 +470,18 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -505,18 +505,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -539,18 +539,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -573,18 +573,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -594,6 +594,45 @@ public:
                  {"target", this->target_qubit_list()},
                  {"control", this->control_qubit_list()},
                  {"control_value", this->control_value_list()}};
+    }
+};
+
+template <Precision Prec>
+class MeasurementGateImpl : public GateBase<Prec> {
+    std::uint64_t _classical_bit_index;
+
+public:
+    MeasurementGateImpl(std::uint64_t target_mask, std::uint64_t classical_bit_index)
+        : GateBase<Prec>(target_mask, 0, 0), _classical_bit_index(classical_bit_index) {}
+
+    [[nodiscard]] std::uint64_t classical_bit_index() const { return _classical_bit_index; }
+
+    std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
+        throw std::runtime_error(
+            "Measurement::get_inverse: Measurement gate doesn't have inverse gate");
+    }
+    ComplexMatrix get_matrix() const override;
+
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+    void update_quantum_state(
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+#ifdef SCALUQ_USE_CUDA
+    void update_quantum_state(
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+    void update_quantum_state(
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+#endif  // SCALUQ_USE_CUDA
+
+    std::string to_string(const std::string& indent) const override;
+
+    void get_as_json(Json& j) const override {
+        j = Json{{"type", "Measurement"},
+                 {"target", this->target_qubit_list()},
+                 {"classical_bit", _classical_bit_index}};
     }
 };
 
@@ -608,18 +647,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -644,18 +683,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -680,18 +719,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -724,18 +763,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -775,18 +814,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -831,18 +870,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -868,18 +907,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        BatchedExecutionContext<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -926,6 +965,8 @@ template <Precision Prec>
 using P0Gate = internal::GatePtr<internal::P0GateImpl<Prec>>;
 template <Precision Prec>
 using P1Gate = internal::GatePtr<internal::P1GateImpl<Prec>>;
+template <Precision Prec>
+using MeasurementGate = internal::GatePtr<internal::MeasurementGateImpl<Prec>>;
 template <Precision Prec>
 using RXGate = internal::GatePtr<internal::RXGateImpl<Prec>>;
 template <Precision Prec>
@@ -1017,6 +1058,16 @@ void bind_gate_gate_standard_hpp(nb::module_& m, nb::class_<Gate<Prec>>& gate_ba
         "P1Gate",
         "Specific class of projection gate to $\\ket{1}$.\n\nNotes:\n\tThis gate is "
         "not unitary.");
+    bind_specific_gate<MeasurementGate<Prec>, Prec>(
+        m,
+        gate_base_def,
+        "MeasurementGate",
+        "Specific class of computational-basis measurement gate.\n\nNotes:\n\tThis gate is a "
+        "placeholder and its state-update implementation is not yet provided.")
+        .def(
+            "classical_bit_index",
+            [](const MeasurementGate<Prec>& gate) { return gate->classical_bit_index(); },
+            "Get destination classical bit index.");
     bind_specific_gate<RXGate<Prec>, Prec>(
         m,
         gate_base_def,

--- a/include/scaluq/gate/param_gate.hpp
+++ b/include/scaluq/gate/param_gate.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "gate.hpp"
+
 #include "../state/state_vector.hpp"
 #include "../state/state_vector_batched.hpp"
 #include "../types.hpp"
@@ -112,18 +114,47 @@ public:
     [[nodiscard]] virtual std::shared_ptr<const ParamGateBase<Prec>> get_inverse() const = 0;
     [[nodiscard]] virtual ComplexMatrix get_matrix(double param) const = 0;
 
-    virtual void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+                              double param) const {
+        update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>{state_vector}, param);
+    }
+    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
                                       double param) const = 0;
-    virtual void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
+                              std::vector<double> params) const {
+        update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Host>{states},
+                             std::move(params));
+    }
+    virtual void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Host> context,
                                       std::vector<double> params) const = 0;
-    virtual void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+                              double param) const {
+        update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial>{state_vector},
+                             param);
+    }
+    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                                       double param) const = 0;
-    virtual void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-                                      std::vector<double> params) const = 0;
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+                              std::vector<double> params) const {
+        update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::HostSerial>{states},
+                             std::move(params));
+    }
+    virtual void update_quantum_state(
+        BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context,
+        std::vector<double> params) const = 0;
 #ifdef SCALUQ_USE_CUDA
-    virtual void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+                              double param) const {
+        update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default>{state_vector}, param);
+    }
+    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
                                       double param) const = 0;
-    virtual void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
+                              std::vector<double> params) const {
+        update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Default>{states},
+                             std::move(params));
+    }
+    virtual void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Default> context,
                                       std::vector<double> params) const = 0;
 #endif  // SCALUQ_USE_CUDA
 
@@ -238,6 +269,28 @@ using ParamGate = internal::ParamGatePtr<internal::ParamGateBase<Prec>>;
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <typename GateT, Precision Prec, ExecutionSpace Space>
+void register_param_gate_execution_methods(nb::class_<GateT>& c) {
+    c.def(
+         "update_quantum_state",
+         [](const GateT& gate, StateVector<Prec, Space>& state_vector, double param) {
+             gate->update_quantum_state(ExecutionContext<Prec, Space>{state_vector}, param);
+         },
+         "state"_a,
+         "param"_a,
+         "Apply gate to `state_vector` with holding the parameter. `state_vector` in args is "
+         "directly updated.")
+        .def(
+            "update_quantum_state",
+            [](const GateT& gate, StateVectorBatched<Prec, Space>& states, std::vector<double> params) {
+                gate->update_quantum_state(BatchedExecutionContext<Prec, Space>{states}, params);
+            },
+            "states"_a,
+            "params"_a,
+            "Apply gate to `states` with holding the parameters. `states` in args is directly "
+            "updated.");
+}
+
 template <typename GateT, Precision Prec>
 void register_param_gate_common_methods(nb::class_<GateT>& c) {
     c.def(nb::init<GateT>(), "Downcast from ParamGate.")
@@ -279,63 +332,15 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
                 if (!inv) return nb::none();
                 return nb::cast(ParamGate<Prec>(inv));
             },
-            "Generate inverse parametric-gate as `ParamGate` type. If not exists, return None.")
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate,
-               StateVector<Prec, ExecutionSpace::Host>& state_vector,
-               double param) { gate->update_quantum_state(state_vector, param); },
-            "state"_a,
-            "param"_a,
-            "Apply gate to `state_vector` with holding the parameter. `state_vector` in args is "
-            "directly updated.")
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate,
-               StateVectorBatched<Prec, ExecutionSpace::Host>& states,
-               std::vector<double> params) { gate->update_quantum_state(states, params); },
-            "states"_a,
-            "params"_a,
-            "updated.")
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate,
-               StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
-               double param) { gate->update_quantum_state(state_vector, param); },
-            "state"_a,
-            "param"_a,
-            "Apply gate to `state_vector` with holding the parameter. `state_vector` in args is "
-            "directly updated.")
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate,
-               StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-               std::vector<double> params) { gate->update_quantum_state(states, params); },
-            "states"_a,
-            "params"_a,
-            "Apply gate to `states` with holding the parameters. `states` in args is directly "
-            "updated.")
+            "Generate inverse parametric-gate as `ParamGate` type. If not exists, return None.");
+
+    register_param_gate_execution_methods<GateT, Prec, ExecutionSpace::Host>(c);
+    register_param_gate_execution_methods<GateT, Prec, ExecutionSpace::HostSerial>(c);
 #ifdef SCALUQ_USE_CUDA
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate,
-               StateVector<Prec, ExecutionSpace::Default>& state_vector,
-               double param) { gate->update_quantum_state(state_vector, param); },
-            "state"_a,
-            "param"_a,
-            "Apply gate to `state_vector` with holding the parameter. `state_vector` in args is "
-            "directly updated.")
-        .def(
-            "update_quantum_state",
-            [](const GateT& gate,
-               StateVectorBatched<Prec, ExecutionSpace::Default>& states,
-               std::vector<double> params) { gate->update_quantum_state(states, params); },
-            "states"_a,
-            "params"_a,
-            "Apply gate to `states` with holding the parameters. `states` in args is directly "
-            "updated.")
+    register_param_gate_execution_methods<GateT, Prec, ExecutionSpace::Default>(c);
 #endif  // SCALUQ_USE_CUDA
-        .def(
+
+    c.def(
             "get_matrix",
             [](const GateT& gate, double param) { return gate->get_matrix(param); },
             "param"_a,

--- a/include/scaluq/gate/param_gate_pauli.hpp
+++ b/include/scaluq/gate/param_gate_pauli.hpp
@@ -31,18 +31,18 @@ public:
             this->_control_mask, this->_control_value_mask, _pauli, -this->_pcoef);
     }
     ComplexMatrix get_matrix(double param) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Host> context,
                               std::vector<double> params) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               std::vector<double> params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Default> context,
                               std::vector<double> params) const override;
 #endif  // SCALUQ_USE_CUDA
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/param_gate_probabilistic.hpp
+++ b/include/scaluq/gate/param_gate_probabilistic.hpp
@@ -2,7 +2,6 @@
 
 #include <variant>
 
-#include "../util/random.hpp"
 #include "gate_probabilistic.hpp"
 #include "param_gate_pauli.hpp"
 #include "param_gate_standard.hpp"
@@ -70,18 +69,18 @@ public:
             "ParamProbabilisticGateImpl.");
     }
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Host> context,
                               std::vector<double> params) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               std::vector<double> params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Default> context,
                               std::vector<double> params) const override;
 #endif  // SCALUQ_USE_CUDA
 

--- a/include/scaluq/gate/param_gate_standard.hpp
+++ b/include/scaluq/gate/param_gate_standard.hpp
@@ -18,18 +18,18 @@ public:
     }
     ComplexMatrix get_matrix(double param) const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Host> context,
                               std::vector<double> params) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               std::vector<double> params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Default> context,
                               std::vector<double> params) const override;
 #endif  // SCALUQ_USE_CUDA
 
@@ -55,18 +55,18 @@ public:
     }
     ComplexMatrix get_matrix(double param) const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Host> context,
                               std::vector<double> params) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               std::vector<double> params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Default> context,
                               std::vector<double> params) const override;
 #endif  // SCALUQ_USE_CUDA
 
@@ -92,18 +92,18 @@ public:
     }
     ComplexMatrix get_matrix(double param) const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Host> context,
                               std::vector<double> params) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               std::vector<double> params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
+    void update_quantum_state(BatchedExecutionContext<Prec, ExecutionSpace::Default> context,
                               std::vector<double> params) const override;
 #endif  // SCALUQ_USE_CUDA
 

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -4,6 +4,7 @@
 #include <nanobind/operators.h>
 #include <nanobind/stl/array.h>
 #include <nanobind/stl/complex.h>
+#include <nanobind/stl/function.h>
 #include <nanobind/stl/map.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/pair.h>

--- a/src/circuit/circuit.cpp
+++ b/src/circuit/circuit.cpp
@@ -1,3 +1,8 @@
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <numeric>
+#include <random>
 #include <scaluq/circuit/circuit.hpp>
 #include <scaluq/gate/gate_factory.hpp>
 #include <scaluq/gate/merge_gate.hpp>
@@ -49,39 +54,52 @@ std::uint64_t Circuit<Prec>::calculate_depth() const {
 template <Precision Prec>
 void Circuit<Prec>::add_circuit(const Circuit<Prec>& circuit) {
     _gate_list.reserve(_gate_list.size() + circuit._gate_list.size());
+    _classical_conditions.reserve(_classical_conditions.size() +
+                                  circuit._classical_conditions.size());
+    if (_n_classical_bits < circuit._n_classical_bits) {
+        _n_classical_bits = circuit._n_classical_bits;
+        _reg.resize(_n_classical_bits, false);
+    }
     for (const auto& gate : circuit._gate_list) {
         _gate_list.push_back(gate);
+    }
+    for (const auto& condition : circuit._classical_conditions) {
+        _classical_conditions.push_back(condition);
     }
 }
 template <Precision Prec>
 void Circuit<Prec>::add_circuit(Circuit<Prec>&& circuit) {
     _gate_list.reserve(_gate_list.size() + circuit._gate_list.size());
+    _classical_conditions.reserve(_classical_conditions.size() +
+                                  circuit._classical_conditions.size());
+    if (_n_classical_bits < circuit._n_classical_bits) {
+        _n_classical_bits = circuit._n_classical_bits;
+        _reg.resize(_n_classical_bits, false);
+    }
     for (auto&& gate : circuit._gate_list) {
         _gate_list.push_back(std::move(gate));
+    }
+    for (auto&& condition : circuit._classical_conditions) {
+        _classical_conditions.push_back(std::move(condition));
     }
 }
 
 template <Precision Prec>
 template <ExecutionSpace Space>
 void Circuit<Prec>::update_quantum_state(StateVector<Prec, Space>& state,
-                                         const std::map<std::string, double>& parameters) const {
+                                         const std::map<std::string, double>& parameters,
+                                         std::uint64_t seed) {
     check_state_vector_n_qubits(state.n_qubits());
-    for (auto&& gate : _gate_list) {
-        if (gate.index() == 0) continue;
-        const auto& key = std::get<1>(gate).second;
-        if (!parameters.contains(key)) {
-            using namespace std::string_literals;
-            throw std::runtime_error(
-                "Circuit::update_quantum_state(StateVector&, const std::map<std::string_view, double>&) const: parameter named "s +
-                std::string(key) + "is not given.");
-        }
-    }
-    for (auto&& gate : _gate_list) {
+    _reg.assign(_n_classical_bits, false);
+    std::mt19937_64 random_engine(seed);
+    ExecutionContext<Prec, Space> context{state, &_reg, &random_engine};
+
+    for (const auto& gate : _gate_list) {
         if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(state);
+            std::get<0>(gate)->update_quantum_state(context);
         } else {
             const auto& [param_gate, key] = std::get<1>(gate);
-            param_gate->update_quantum_state(state, parameters.at(key));
+            param_gate->update_quantum_state(context, parameters.at(key));
         }
     }
 }
@@ -90,54 +108,54 @@ template <Precision Prec>
 template <ExecutionSpace Space>
 void Circuit<Prec>::update_quantum_state(
     StateVectorBatched<Prec, Space>& states,
-    const std::map<std::string, std::vector<double>>& parameters) const {
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed) {
     check_state_vector_n_qubits(states.n_qubits());
-    for (auto&& gate : _gate_list) {
-        if (gate.index() == 0) continue;
-        const auto& key = std::get<1>(gate).second;
-        if (!parameters.contains(key)) {
-            using namespace std::string_literals;
-            throw std::runtime_error(
-                "Circuit::update_quantum_state(StateVector&, const std::map<std::string_view, double>&) const: parameter named "s +
-                std::string(key) + "is not given.");
-        }
-    }
-    for (auto&& gate : _gate_list) {
+    _reg.assign(_n_classical_bits * states.batch_size(), false);
+    std::mt19937_64 random_engine(seed);
+    BatchedExecutionContext<Prec, Space> context{
+        states, &_reg, _n_classical_bits, &random_engine};
+    for (const auto& gate : _gate_list) {
         if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(states);
+            std::get<0>(gate)->update_quantum_state(context);
         } else {
             const auto& [param_gate, key] = std::get<1>(gate);
-            param_gate->update_quantum_state(states, parameters.at(key));
+            param_gate->update_quantum_state(context, parameters.at(key));
         }
     }
 }
 
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Host>(
     StateVector<internal::Prec, ExecutionSpace::Host>& state,
-    const std::map<std::string, double>& parameters) const;
+    const std::map<std::string, double>& parameters,
+    std::uint64_t seed);
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Host>(
     StateVectorBatched<internal::Prec, ExecutionSpace::Host>& states,
-    const std::map<std::string, std::vector<double>>& parameters) const;
-
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed);
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::HostSerial>(
     StateVector<internal::Prec, ExecutionSpace::HostSerial>& state,
-    const std::map<std::string, double>& parameters) const;
+    const std::map<std::string, double>& parameters,
+    std::uint64_t seed);
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::HostSerial>(
     StateVectorBatched<internal::Prec, ExecutionSpace::HostSerial>& states,
-    const std::map<std::string, std::vector<double>>& parameters) const;
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed);
 
 #ifdef SCALUQ_USE_CUDA
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Default>(
     StateVector<internal::Prec, ExecutionSpace::Default>& state,
-    const std::map<std::string, double>& parameters) const;
+    const std::map<std::string, double>& parameters,
+    std::uint64_t seed);
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Default>(
     StateVectorBatched<internal::Prec, ExecutionSpace::Default>& states,
-    const std::map<std::string, std::vector<double>>& parameters) const;
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed);
 #endif  // SCALUQ_USE_CUDA
 
 template <Precision Prec>
 Circuit<Prec> Circuit<Prec>::copy() const {
-    Circuit<Prec> ccircuit;
+    Circuit<Prec> ccircuit(_n_classical_bits);
     ccircuit._gate_list.reserve(_gate_list.size());
     for (auto&& gate : _gate_list) {
         if (gate.index() == 0)
@@ -147,20 +165,27 @@ Circuit<Prec> Circuit<Prec>::copy() const {
             ccircuit._gate_list.push_back(std::make_pair(param_gate, key));
         }
     }
+    ccircuit._classical_conditions = _classical_conditions;
+    ccircuit._reg = _reg;
+    ccircuit._n_classical_bits = _n_classical_bits;
     return ccircuit;
 }
 
 template <Precision Prec>
 Circuit<Prec> Circuit<Prec>::get_inverse() const {
-    Circuit<Prec> icircuit;
+    Circuit<Prec> icircuit(_n_classical_bits);
     icircuit._gate_list.reserve(_gate_list.size());
-    for (auto&& gate : _gate_list | std::views::reverse) {
+    icircuit._classical_conditions.reserve(_classical_conditions.size());
+    for (std::uint64_t idx = 0; idx < _gate_list.size(); ++idx) {
+        const auto& gate = _gate_list[_gate_list.size() - 1 - idx];
         if (gate.index() == 0)
             icircuit._gate_list.push_back(std::get<0>(gate)->get_inverse());
         else {
             const auto& [param_gate, key] = std::get<1>(gate);
             icircuit._gate_list.push_back(std::make_pair(param_gate->get_inverse(), key));
         }
+        icircuit._classical_conditions.push_back(
+            _classical_conditions[_classical_conditions.size() - 1 - idx]);
     }
     return icircuit;
 }
@@ -224,8 +249,9 @@ void Circuit<Prec>::optimize(std::uint64_t max_block_size) {
 
     for (const GateWithKey& gate_with_key : _gate_list) {
         if (gate_with_key.index() == 1 ||
-            std::get<0>(gate_with_key).gate_type() == GateType::Probabilistic) {
-            // ParamGate and Probabilistic cannot be merged with others
+            std::get<0>(gate_with_key).gate_type() == GateType::Probabilistic ||
+            std::get<0>(gate_with_key).gate_type() == GateType::Measurement) {
+            // ParamGate, Probabilistic, and Measurement cannot be merged with others
             push_waiting_gates(gate_with_key);
             push(gate_with_key);
             continue;
@@ -406,7 +432,8 @@ std::vector<std::pair<StateVector<Prec, Space>, std::int64_t>> Circuit<Prec>::si
         for (std::uint64_t i = 0; i < probs.size(); ++i) {
             StateVectorBatched<Prec, Space> tmp_states(states.copy());
             if (gates[i].index() == 0) {
-                std::get<0>(gates[i])->update_quantum_state(tmp_states);
+                std::get<0>(gates[i])->update_quantum_state(
+                    BatchedExecutionContext<Prec, Space>{tmp_states});
             } else {
                 const auto& [param_gate, key] = std::get<1>(gates[i]);
                 param_gate->update_quantum_state(
@@ -464,9 +491,9 @@ std::uint64_t Circuit<Prec>::required_n_qubits() const {
 
 template <Precision Prec>
 void Circuit<Prec>::check_state_vector_n_qubits(std::uint64_t n_qubits) const {
-    if (required_n_qubits() > n_qubits) {
-        throw std::runtime_error(
-            "Circuit::update_quantum_state: state does not have enough qubits for this circuit.");
+    const std::uint64_t required = required_n_qubits();
+    if (required > n_qubits) {
+        throw std::runtime_error("Circuit: state does not have enough qubits for this circuit.");
     }
 }
 

--- a/src/gate/gate.cpp
+++ b/src/gate/gate.cpp
@@ -8,7 +8,7 @@ void GateBase<Prec>::check_qubit_mask_within_bounds(
     std::uint64_t full_mask = (1ULL << state_vector.n_qubits()) - 1;
     if ((_target_mask | _control_mask) > full_mask) [[unlikely]] {
         throw std::runtime_error(
-            "Error: Gate::update_quantum_state(StateVector& state): "
+            "Error: Gate::update_quantum_state(ExecutionContext& state): "
             "Target/Control qubit exceeds the number of qubits in the system.");
     }
 }
@@ -18,7 +18,7 @@ void GateBase<Prec>::check_qubit_mask_within_bounds(
     std::uint64_t full_mask = (1ULL << states.n_qubits()) - 1;
     if ((_target_mask | _control_mask) > full_mask) [[unlikely]] {
         throw std::runtime_error(
-            "Error: Gate::update_quantum_state(StateVectorBatched& states): "
+            "Error: Gate::update_quantum_state(BatchedExecutionContext& states): "
             "Target/Control qubit exceeds the number of qubits in the system.");
     }
 }
@@ -28,7 +28,7 @@ void GateBase<Prec>::check_qubit_mask_within_bounds(
     std::uint64_t full_mask = (1ULL << state_vector.n_qubits()) - 1;
     if ((_target_mask | _control_mask) > full_mask) [[unlikely]] {
         throw std::runtime_error(
-            "Error: Gate::update_quantum_state(StateVector& state): "
+            "Error: Gate::update_quantum_state(ExecutionContext& state): "
             "Target/Control qubit exceeds the number of qubits in the system.");
     }
 }
@@ -38,7 +38,7 @@ void GateBase<Prec>::check_qubit_mask_within_bounds(
     std::uint64_t full_mask = (1ULL << states.n_qubits()) - 1;
     if ((_target_mask | _control_mask) > full_mask) [[unlikely]] {
         throw std::runtime_error(
-            "Error: Gate::update_quantum_state(StateVectorBatched& states): "
+            "Error: Gate::update_quantum_state(BatchedExecutionContext& states): "
             "Target/Control qubit exceeds the number of qubits in the system.");
     }
 }
@@ -49,7 +49,7 @@ void GateBase<Prec>::check_qubit_mask_within_bounds(
     std::uint64_t full_mask = (1ULL << state_vector.n_qubits()) - 1;
     if ((_target_mask | _control_mask) > full_mask) [[unlikely]] {
         throw std::runtime_error(
-            "Error: Gate::update_quantum_state(StateVector& state): "
+            "Error: Gate::update_quantum_state(ExecutionContext& state): "
             "Target/Control qubit exceeds the number of qubits in the system.");
     }
 }
@@ -59,7 +59,7 @@ void GateBase<Prec>::check_qubit_mask_within_bounds(
     std::uint64_t full_mask = (1ULL << states.n_qubits()) - 1;
     if ((_target_mask | _control_mask) > full_mask) [[unlikely]] {
         throw std::runtime_error(
-            "Error: Gate::update_quantum_state(StateVectorBatched& states): "
+            "Error: Gate::update_quantum_state(BatchedExecutionContext& states): "
             "Target/Control qubit exceeds the number of qubits in the system.");
     }
 }

--- a/src/gate/gate_matrix.cpp
+++ b/src/gate/gate_matrix.cpp
@@ -42,33 +42,52 @@ std::string DenseMatrixGateImpl<Prec, Space>::to_string(const std::string& inden
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_DENSE_MATRIX_GATE_UPDATE(Class, TargetSpace)                                 \
+#define DEFINE_DENSE_MATRIX_GATE_CONTEXT_UPDATE(TargetSpace)                                \
     template <Precision Prec, ExecutionSpace GateSpace>                                     \
     void DenseMatrixGateImpl<Prec, GateSpace>::update_quantum_state(                        \
-        Class<Prec, TargetSpace>& state_vector) const {                                     \
+        ExecutionContext<Prec, TargetSpace> context) const {                                \
         if constexpr (GateSpace == TargetSpace) {                                           \
-            this->check_qubit_mask_within_bounds(state_vector);                             \
+            this->check_qubit_mask_within_bounds(context.state);                            \
             dense_matrix_gate(this->_target_mask,                                           \
                               this->_control_mask,                                          \
                               this->_control_value_mask,                                    \
                               _matrix,                                                      \
-                              state_vector);                                                \
+                              context.state);                                               \
         } else {                                                                            \
             throw std::runtime_error(                                                       \
-                "Error: DenseMatrixGateImpl::update_quantum_state(" #Class                  \
-                "& state_vector): Trying to run on " #TargetSpace                           \
+                "Error: DenseMatrixGateImpl::update_quantum_state(ExecutionContext): "      \
+                "Trying to run on " #TargetSpace                                            \
                 " execution space, but the gate is defined on different execution space."); \
         }                                                                                   \
     }
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+#define DEFINE_DENSE_MATRIX_GATE_BATCHED_UPDATE(TargetSpace)                                \
+    template <Precision Prec, ExecutionSpace GateSpace>                                     \
+    void DenseMatrixGateImpl<Prec, GateSpace>::update_quantum_state(                        \
+        BatchedExecutionContext<Prec, TargetSpace> context) const {                         \
+        if constexpr (GateSpace == TargetSpace) {                                           \
+            this->check_qubit_mask_within_bounds(context.states);                           \
+            dense_matrix_gate(this->_target_mask,                                           \
+                              this->_control_mask,                                          \
+                              this->_control_value_mask,                                    \
+                              _matrix,                                                      \
+                              context.states);                                              \
+        } else {                                                                            \
+            throw std::runtime_error(                                                       \
+                "Error: DenseMatrixGateImpl::update_quantum_state(BatchedExecutionContext)" \
+                ": Trying to run on " #TargetSpace                                          \
+                " execution space, but the gate is defined on different execution space."); \
+        }                                                                                   \
+    }
+DEFINE_DENSE_MATRIX_GATE_CONTEXT_UPDATE(ExecutionSpace::Host)
+DEFINE_DENSE_MATRIX_GATE_BATCHED_UPDATE(ExecutionSpace::Host)
+DEFINE_DENSE_MATRIX_GATE_CONTEXT_UPDATE(ExecutionSpace::HostSerial)
+DEFINE_DENSE_MATRIX_GATE_BATCHED_UPDATE(ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_DENSE_MATRIX_GATE_CONTEXT_UPDATE(ExecutionSpace::Default)
+DEFINE_DENSE_MATRIX_GATE_BATCHED_UPDATE(ExecutionSpace::Default)
 #endif
-#undef DEFINE_DENSE_MATRIX_GATE_UPDATE
+#undef DEFINE_DENSE_MATRIX_GATE_CONTEXT_UPDATE
+#undef DEFINE_DENSE_MATRIX_GATE_BATCHED_UPDATE
 template class DenseMatrixGateImpl<Prec, Space>;
 
 template <Precision Prec, ExecutionSpace Space>
@@ -111,33 +130,52 @@ std::string SparseMatrixGateImpl<Prec, Space>::to_string(const std::string& inde
     return ss.str();
 }
 
-#define DEFINE_SPARSE_MATRIX_GATE_UPDATE(Class, TargetSpace)                                \
+#define DEFINE_SPARSE_MATRIX_GATE_CONTEXT_UPDATE(TargetSpace)                               \
     template <Precision Prec, ExecutionSpace GateSpace>                                     \
     void SparseMatrixGateImpl<Prec, GateSpace>::update_quantum_state(                       \
-        Class<Prec, TargetSpace>& state_vector) const {                                     \
+        ExecutionContext<Prec, TargetSpace> context) const {                                \
         if constexpr (GateSpace == TargetSpace) {                                           \
-            this->check_qubit_mask_within_bounds(state_vector);                             \
+            this->check_qubit_mask_within_bounds(context.state);                            \
             sparse_matrix_gate(this->_target_mask,                                          \
                                this->_control_mask,                                         \
                                this->_control_value_mask,                                   \
                                _matrix,                                                     \
-                               state_vector);                                               \
+                               context.state);                                              \
         } else {                                                                            \
             throw std::runtime_error(                                                       \
-                "Error: SparseMatrixGateImpl::update_quantum_state(" #Class                 \
-                "& state_vector): Trying to run on " #TargetSpace                           \
+                "Error: SparseMatrixGateImpl::update_quantum_state(ExecutionContext): "     \
+                "Trying to run on " #TargetSpace                                            \
                 " execution space, but the gate is defined on different execution space."); \
         }                                                                                   \
     }
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+#define DEFINE_SPARSE_MATRIX_GATE_BATCHED_UPDATE(TargetSpace)                                \
+    template <Precision Prec, ExecutionSpace GateSpace>                                      \
+    void SparseMatrixGateImpl<Prec, GateSpace>::update_quantum_state(                        \
+        BatchedExecutionContext<Prec, TargetSpace> context) const {                          \
+        if constexpr (GateSpace == TargetSpace) {                                            \
+            this->check_qubit_mask_within_bounds(context.states);                            \
+            sparse_matrix_gate(this->_target_mask,                                           \
+                               this->_control_mask,                                          \
+                               this->_control_value_mask,                                    \
+                               _matrix,                                                      \
+                               context.states);                                              \
+        } else {                                                                             \
+            throw std::runtime_error(                                                        \
+                "Error: SparseMatrixGateImpl::update_quantum_state(BatchedExecutionContext)" \
+                ": Trying to run on " #TargetSpace                                           \
+                " execution space, but the gate is defined on different execution space.");  \
+        }                                                                                    \
+    }
+DEFINE_SPARSE_MATRIX_GATE_CONTEXT_UPDATE(ExecutionSpace::Host)
+DEFINE_SPARSE_MATRIX_GATE_BATCHED_UPDATE(ExecutionSpace::Host)
+DEFINE_SPARSE_MATRIX_GATE_CONTEXT_UPDATE(ExecutionSpace::HostSerial)
+DEFINE_SPARSE_MATRIX_GATE_BATCHED_UPDATE(ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SPARSE_MATRIX_GATE_CONTEXT_UPDATE(ExecutionSpace::Default)
+DEFINE_SPARSE_MATRIX_GATE_BATCHED_UPDATE(ExecutionSpace::Default)
 #endif
-#undef DEFINE_SPARSE_MATRIX_GATE_UPDATE
+#undef DEFINE_SPARSE_MATRIX_GATE_CONTEXT_UPDATE
+#undef DEFINE_SPARSE_MATRIX_GATE_BATCHED_UPDATE
 template class SparseMatrixGateImpl<Prec, Space>;
 
 template <Precision Prec, ExecutionSpace Space>

--- a/src/gate/gate_pauli.cpp
+++ b/src/gate/gate_pauli.cpp
@@ -15,26 +15,39 @@ std::string PauliGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << indent << "  Pauli Operator: \"" << _pauli.get_pauli_string() << "\"";
     return ss.str();
 }
-#define DEFINE_PAULI_GATE_UPDATE(Class, Space)                                               \
-    template <Precision Prec>                                                                \
-    void PauliGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();         \
-        apply_pauli(this->_control_mask,                                                     \
-                    this->_control_value_mask,                                               \
-                    bit_flip_mask,                                                           \
-                    phase_flip_mask,                                                         \
-                    Complex<Prec>(_pauli.coef()),                                            \
-                    state_vector);                                                           \
+#define DEFINE_PAULI_GATE_CONTEXT_UPDATE(Space)                                                   \
+    template <Precision Prec>                                                                     \
+    void PauliGateImpl<Prec>::update_quantum_state(ExecutionContext<Prec, Space> context) const { \
+        auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();              \
+        apply_pauli(this->_control_mask,                                                          \
+                    this->_control_value_mask,                                                    \
+                    bit_flip_mask,                                                                \
+                    phase_flip_mask,                                                              \
+                    Complex<Prec>(_pauli.coef()),                                                 \
+                    context.state);                                                               \
     }
-DEFINE_PAULI_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_PAULI_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_PAULI_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_PAULI_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+#define DEFINE_PAULI_GATE_BATCHED_UPDATE(Space)                                                  \
+    template <Precision Prec>                                                                    \
+    void PauliGateImpl<Prec>::update_quantum_state(BatchedExecutionContext<Prec, Space> context) \
+        const {                                                                                  \
+        auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();             \
+        apply_pauli(this->_control_mask,                                                         \
+                    this->_control_value_mask,                                                   \
+                    bit_flip_mask,                                                               \
+                    phase_flip_mask,                                                             \
+                    Complex<Prec>(_pauli.coef()),                                                \
+                    context.states);                                                             \
+    }
+DEFINE_PAULI_GATE_CONTEXT_UPDATE(ExecutionSpace::Host)
+DEFINE_PAULI_GATE_BATCHED_UPDATE(ExecutionSpace::Host)
+DEFINE_PAULI_GATE_CONTEXT_UPDATE(ExecutionSpace::HostSerial)
+DEFINE_PAULI_GATE_BATCHED_UPDATE(ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_PAULI_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_PAULI_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_PAULI_GATE_CONTEXT_UPDATE(ExecutionSpace::Default)
+DEFINE_PAULI_GATE_BATCHED_UPDATE(ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
-#undef DEFINE_PAULI_GATE_UPDATE
+#undef DEFINE_PAULI_GATE_CONTEXT_UPDATE
+#undef DEFINE_PAULI_GATE_BATCHED_UPDATE
 template class PauliGateImpl<Prec>;
 
 template <Precision Prec>
@@ -60,28 +73,42 @@ std::string PauliRotationGateImpl<Prec>::to_string(const std::string& indent) co
     ss << indent << "  Pauli Operator: \"" << _pauli.get_pauli_string() << "\"";
     return ss.str();
 }
-#define DEFINE_PAULI_ROTATION_GATE_UPDATE(Class, Space)                                      \
-    template <Precision Prec>                                                                \
-    void PauliRotationGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) \
-        const {                                                                              \
-        auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();         \
-        apply_pauli_rotation(this->_control_mask,                                            \
-                             this->_control_value_mask,                                      \
-                             bit_flip_mask,                                                  \
-                             phase_flip_mask,                                                \
-                             Complex<Prec>(_pauli.coef()),                                   \
-                             _angle,                                                         \
-                             state_vector);                                                  \
+#define DEFINE_PAULI_ROTATION_GATE_CONTEXT_UPDATE(Space)                                          \
+    template <Precision Prec>                                                                     \
+    void PauliRotationGateImpl<Prec>::update_quantum_state(ExecutionContext<Prec, Space> context) \
+        const {                                                                                   \
+        auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();              \
+        apply_pauli_rotation(this->_control_mask,                                                 \
+                             this->_control_value_mask,                                           \
+                             bit_flip_mask,                                                       \
+                             phase_flip_mask,                                                     \
+                             Complex<Prec>(_pauli.coef()),                                        \
+                             _angle,                                                              \
+                             context.state);                                                      \
     }
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+#define DEFINE_PAULI_ROTATION_GATE_BATCHED_UPDATE(Space)                             \
+    template <Precision Prec>                                                        \
+    void PauliRotationGateImpl<Prec>::update_quantum_state(                          \
+        BatchedExecutionContext<Prec, Space> context) const {                        \
+        auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation(); \
+        apply_pauli_rotation(this->_control_mask,                                    \
+                             this->_control_value_mask,                              \
+                             bit_flip_mask,                                          \
+                             phase_flip_mask,                                        \
+                             Complex<Prec>(_pauli.coef()),                           \
+                             _angle,                                                 \
+                             context.states);                                        \
+    }
+DEFINE_PAULI_ROTATION_GATE_CONTEXT_UPDATE(ExecutionSpace::Host)
+DEFINE_PAULI_ROTATION_GATE_BATCHED_UPDATE(ExecutionSpace::Host)
+DEFINE_PAULI_ROTATION_GATE_CONTEXT_UPDATE(ExecutionSpace::HostSerial)
+DEFINE_PAULI_ROTATION_GATE_BATCHED_UPDATE(ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_PAULI_ROTATION_GATE_CONTEXT_UPDATE(ExecutionSpace::Default)
+DEFINE_PAULI_ROTATION_GATE_BATCHED_UPDATE(ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
-#undef DEFINE_PAULI_ROTATION_GATE_UPDATE
+#undef DEFINE_PAULI_ROTATION_GATE_CONTEXT_UPDATE
+#undef DEFINE_PAULI_ROTATION_GATE_BATCHED_UPDATE
 template class PauliRotationGateImpl<Prec>;
 
 template <Precision Prec>

--- a/src/gate/gate_probabilistic.cpp
+++ b/src/gate/gate_probabilistic.cpp
@@ -4,6 +4,21 @@
 
 namespace scaluq::internal {
 namespace {
+template <Precision Prec, ExecutionSpace Space>
+std::uint64_t select_probabilistic_gate_index(const std::vector<double>& cumulative_distribution,
+                                              ExecutionContext<Prec, Space> context) {
+    if (context.rng == nullptr) {
+        throw std::runtime_error(
+            "ProbabilisticGateImpl::update_quantum_state(): random engine is required.");
+    }
+    std::uniform_real_distribution<double> dist(0., 1.);
+    std::uint64_t i =
+        std::distance(cumulative_distribution.begin(),
+                      std::ranges::upper_bound(cumulative_distribution, dist(*context.rng))) -
+        1;
+    return std::min<std::uint64_t>(i, cumulative_distribution.size() - 2);
+}
+
 template <Precision Prec>
 void flatten_probabilistic_gate(double prob_prefix,
                                 const Gate<Prec>& gate,
@@ -71,34 +86,30 @@ std::string ProbabilisticGateImpl<Prec>::to_string(const std::string& indent) co
     }
     return ss.str();
 }
-#define DEFINE_PROBABILISTIC_GATE_UPDATE(Space)                                                    \
-    template <Precision Prec>                                                                      \
-    void ProbabilisticGateImpl<Prec>::update_quantum_state(StateVector<Prec, Space>& state_vector) \
-        const {                                                                                    \
-        Random random;                                                                             \
-        double r = random.uniform();                                                               \
-        std::uint64_t i = std::distance(_cumulative_distribution.begin(),                          \
-                                        std::ranges::upper_bound(_cumulative_distribution, r)) -   \
-                          1;                                                                       \
-        if (i >= _gate_list.size()) i = _gate_list.size() - 1;                                     \
-        _gate_list[i]->update_quantum_state(state_vector);                                         \
-    }                                                                                              \
-    template <Precision Prec>                                                                      \
-    void ProbabilisticGateImpl<Prec>::update_quantum_state(                                        \
-        StateVectorBatched<Prec, Space>& states) const {                                           \
-        std::vector<std::uint64_t> indices(states.batch_size());                                   \
-        std::vector<double> r(states.batch_size());                                                \
-                                                                                                   \
-        Random random;                                                                             \
-        for (std::size_t i = 0; i < states.batch_size(); ++i) {                                    \
-            r[i] = random.uniform();                                                               \
-            indices[i] = std::distance(_cumulative_distribution.begin(),                           \
-                                       std::ranges::upper_bound(_cumulative_distribution, r[i])) - \
-                         1;                                                                        \
-            if (indices[i] >= _gate_list.size()) indices[i] = _gate_list.size() - 1;               \
-            auto state_vector = states.view_state_vector_at(i);                                     \
-            _gate_list[indices[i]]->update_quantum_state(state_vector);                            \
-        }                                                                                          \
+#define DEFINE_PROBABILISTIC_GATE_UPDATE(Space)                                                   \
+    template <Precision Prec>                                                                     \
+    void ProbabilisticGateImpl<Prec>::update_quantum_state(ExecutionContext<Prec, Space> context) \
+        const {                                                                                   \
+        const std::uint64_t i =                                                                   \
+            select_probabilistic_gate_index(_cumulative_distribution, context);                   \
+        _gate_list[i]->update_quantum_state(context);                                             \
+    }                                                                                             \
+    template <Precision Prec>                                                                     \
+    void ProbabilisticGateImpl<Prec>::update_quantum_state(                                       \
+        BatchedExecutionContext<Prec, Space> context) const {                                     \
+        if (context.reg != nullptr &&                                                             \
+            context.reg->size() != context.n_classical_bits * context.states.batch_size()) {      \
+            throw std::runtime_error(                                                             \
+                "ProbabilisticGateImpl::update_quantum_state(): classical register size must "    \
+                "match n_classical_bits * batch size.");                                          \
+        }                                                                                         \
+        for (std::size_t i = 0; i < context.states.batch_size(); ++i) {                           \
+            auto state_vector = context.states.view_state_vector_at(i);                           \
+            this->update_quantum_state(ExecutionContext<Prec, Space>{state_vector,                \
+                                                                     context.reg,                 \
+                                                                     context.rng,                 \
+                                                                     i * context.n_classical_bits});\
+        }                                                                                         \
     }
 DEFINE_PROBABILISTIC_GATE_UPDATE(ExecutionSpace::Host)
 DEFINE_PROBABILISTIC_GATE_UPDATE(ExecutionSpace::HostSerial)

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -4,6 +4,23 @@
 
 namespace scaluq::internal {
 template <Precision Prec>
+using HostContext = ExecutionContext<Prec, ExecutionSpace::Host>;
+template <Precision Prec>
+using HostSerialContext = ExecutionContext<Prec, ExecutionSpace::HostSerial>;
+#ifdef SCALUQ_USE_CUDA
+template <Precision Prec>
+using DefaultContext = ExecutionContext<Prec, ExecutionSpace::Default>;
+#endif
+template <Precision Prec>
+using HostBatchedContext = BatchedExecutionContext<Prec, ExecutionSpace::Host>;
+template <Precision Prec>
+using HostSerialBatchedContext = BatchedExecutionContext<Prec, ExecutionSpace::HostSerial>;
+#ifdef SCALUQ_USE_CUDA
+template <Precision Prec>
+using DefaultBatchedContext = BatchedExecutionContext<Prec, ExecutionSpace::Default>;
+#endif
+
+template <Precision Prec>
 ComplexMatrix IGateImpl<Prec>::get_matrix() const {
     return ComplexMatrix::Identity(1, 1);
 }
@@ -14,18 +31,19 @@ std::string IGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_I_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_I_GATE_UPDATE(ArgDecl, StateExpr)                                                  \
     template <Precision Prec>                                                                     \
-    void IGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
+    void IGateImpl<Prec>::update_quantum_state(ArgDecl) const {                                   \
+        auto& state_vector = StateExpr;                                                           \
         i_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_I_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_I_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_I_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_I_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_I_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_I_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_I_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_I_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_I_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_I_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_I_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_I_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_I_GATE_UPDATE
 template class IGateImpl<Prec>;
@@ -42,23 +60,24 @@ std::string GlobalPhaseGateImpl<Prec>::to_string(const std::string& indent) cons
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_GLOBAL_PHASE_GATE_UPDATE(Class, Space)                                              \
-    template <Precision Prec>                                                                      \
-    void GlobalPhaseGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                                        \
-        global_phase_gate(this->_target_mask,                                                      \
-                          this->_control_mask,                                                     \
-                          this->_control_value_mask,                                               \
-                          this->_phase,                                                            \
-                          state_vector);                                                           \
+#define DEFINE_GLOBAL_PHASE_GATE_UPDATE(ArgDecl, StateExpr)               \
+    template <Precision Prec>                                             \
+    void GlobalPhaseGateImpl<Prec>::update_quantum_state(ArgDecl) const { \
+        auto& state_vector = StateExpr;                                   \
+        this->check_qubit_mask_within_bounds(state_vector);               \
+        global_phase_gate(this->_target_mask,                             \
+                          this->_control_mask,                            \
+                          this->_control_value_mask,                      \
+                          this->_phase,                                   \
+                          state_vector);                                  \
     }
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_GLOBAL_PHASE_GATE_UPDATE
 template class GlobalPhaseGateImpl<Prec>;
@@ -76,19 +95,20 @@ std::string XGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_X_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_X_GATE_UPDATE(ArgDecl, StateExpr)                                                  \
     template <Precision Prec>                                                                     \
-    void XGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
+    void XGateImpl<Prec>::update_quantum_state(ArgDecl) const {                                   \
+        auto& state_vector = StateExpr;                                                           \
         this->check_qubit_mask_within_bounds(state_vector);                                       \
         x_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_X_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_X_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_X_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_X_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_X_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_X_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_X_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_X_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_X_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_X_GATE_UPDATE
 template class XGateImpl<Prec>;
@@ -106,19 +126,20 @@ std::string YGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_Y_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_Y_GATE_UPDATE(ArgDecl, StateExpr)                                                  \
     template <Precision Prec>                                                                     \
-    void YGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
+    void YGateImpl<Prec>::update_quantum_state(ArgDecl) const {                                   \
+        auto& state_vector = StateExpr;                                                           \
         this->check_qubit_mask_within_bounds(state_vector);                                       \
         y_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_Y_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_Y_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_Y_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_Y_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_Y_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_Y_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_Y_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_Y_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_Y_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_Y_GATE_UPDATE
 template class YGateImpl<Prec>;
@@ -136,19 +157,20 @@ std::string ZGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_Z_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_Z_GATE_UPDATE(ArgDecl, StateExpr)                                                  \
     template <Precision Prec>                                                                     \
-    void ZGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
+    void ZGateImpl<Prec>::update_quantum_state(ArgDecl) const {                                   \
+        auto& state_vector = StateExpr;                                                           \
         this->check_qubit_mask_within_bounds(state_vector);                                       \
         z_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_Z_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_Z_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_Z_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_Z_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_Z_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_Z_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_Z_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_Z_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_Z_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_Z_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_Z_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_Z_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_Z_GATE_UPDATE
 template class ZGateImpl<Prec>;
@@ -167,19 +189,20 @@ std::string HGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_H_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_H_GATE_UPDATE(ArgDecl, StateExpr)                                                  \
     template <Precision Prec>                                                                     \
-    void HGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
+    void HGateImpl<Prec>::update_quantum_state(ArgDecl) const {                                   \
+        auto& state_vector = StateExpr;                                                           \
         this->check_qubit_mask_within_bounds(state_vector);                                       \
         h_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_H_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_H_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_H_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_H_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_H_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_H_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_H_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_H_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_H_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_H_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_H_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_H_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_H_GATE_UPDATE
 template class HGateImpl<Prec>;
@@ -197,19 +220,20 @@ std::string SGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_S_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_S_GATE_UPDATE(ArgDecl, StateExpr)                                                  \
     template <Precision Prec>                                                                     \
-    void SGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
+    void SGateImpl<Prec>::update_quantum_state(ArgDecl) const {                                   \
+        auto& state_vector = StateExpr;                                                           \
         this->check_qubit_mask_within_bounds(state_vector);                                       \
         s_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_S_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_S_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_S_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_S_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_S_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_S_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_S_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_S_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_S_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_S_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_S_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_S_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_S_GATE_UPDATE
 template class SGateImpl<Prec>;
@@ -227,20 +251,21 @@ std::string SdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_S_DAG_GATE_UPDATE(Class, Space)                                                 \
+#define DEFINE_S_DAG_GATE_UPDATE(ArgDecl, StateExpr)                                           \
     template <Precision Prec>                                                                  \
-    void SdagGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {    \
+    void SdagGateImpl<Prec>::update_quantum_state(ArgDecl) const {                             \
+        auto& state_vector = StateExpr;                                                        \
         this->check_qubit_mask_within_bounds(state_vector);                                    \
         sdag_gate(                                                                             \
             this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_S_DAG_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_S_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_S_DAG_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_S_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_S_DAG_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_S_DAG_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_S_DAG_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_S_DAG_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_S_DAG_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_S_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_S_DAG_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_S_DAG_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_S_DAG_GATE_UPDATE
 template class SdagGateImpl<Prec>;
@@ -258,19 +283,20 @@ std::string TGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_T_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_T_GATE_UPDATE(ArgDecl, StateExpr)                                                  \
     template <Precision Prec>                                                                     \
-    void TGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
+    void TGateImpl<Prec>::update_quantum_state(ArgDecl) const {                                   \
+        auto& state_vector = StateExpr;                                                           \
         this->check_qubit_mask_within_bounds(state_vector);                                       \
         t_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_T_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_T_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_T_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_T_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_T_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_T_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_T_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_T_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_T_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_T_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_T_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_T_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_T_GATE_UPDATE
 template class TGateImpl<Prec>;
@@ -288,20 +314,21 @@ std::string TdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_T_DAG_GATE_UPDATE(Class, Space)                                                 \
+#define DEFINE_T_DAG_GATE_UPDATE(ArgDecl, StateExpr)                                           \
     template <Precision Prec>                                                                  \
-    void TdagGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {    \
+    void TdagGateImpl<Prec>::update_quantum_state(ArgDecl) const {                             \
+        auto& state_vector = StateExpr;                                                        \
         this->check_qubit_mask_within_bounds(state_vector);                                    \
         tdag_gate(                                                                             \
             this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_T_DAG_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_T_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_T_DAG_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_T_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_T_DAG_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_T_DAG_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_T_DAG_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_T_DAG_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_T_DAG_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_T_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_T_DAG_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_T_DAG_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_T_DAG_GATE_UPDATE
 template class TdagGateImpl<Prec>;
@@ -319,20 +346,21 @@ std::string SqrtXGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_X_GATE_UPDATE(Class, Space)                                                \
+#define DEFINE_SQRT_X_GATE_UPDATE(ArgDecl, StateExpr)                                          \
     template <Precision Prec>                                                                  \
-    void SqrtXGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {   \
+    void SqrtXGateImpl<Prec>::update_quantum_state(ArgDecl) const {                            \
+        auto& state_vector = StateExpr;                                                        \
         this->check_qubit_mask_within_bounds(state_vector);                                    \
         sqrtx_gate(                                                                            \
             this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_SQRT_X_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SQRT_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SQRT_X_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SQRT_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_SQRT_X_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_SQRT_X_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_SQRT_X_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_SQRT_X_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SQRT_X_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SQRT_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SQRT_X_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_SQRT_X_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_SQRT_X_GATE_UPDATE
 template class SqrtXGateImpl<Prec>;
@@ -350,20 +378,21 @@ std::string SqrtXdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_XDAG_GATE_UPDATE(Class, Space)                                              \
-    template <Precision Prec>                                                                   \
-    void SqrtXdagGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                                     \
-        sqrtxdag_gate(                                                                          \
-            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector);  \
+#define DEFINE_SQRT_XDAG_GATE_UPDATE(ArgDecl, StateExpr)                                       \
+    template <Precision Prec>                                                                  \
+    void SqrtXdagGateImpl<Prec>::update_quantum_state(ArgDecl) const {                         \
+        auto& state_vector = StateExpr;                                                        \
+        this->check_qubit_mask_within_bounds(state_vector);                                    \
+        sqrtxdag_gate(                                                                         \
+            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_SQRT_XDAG_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_SQRT_XDAG_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_SQRT_XDAG_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_SQRT_XDAG_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SQRT_XDAG_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_SQRT_XDAG_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_SQRT_XDAG_GATE_UPDATE
 template class SqrtXdagGateImpl<Prec>;
@@ -381,20 +410,21 @@ std::string SqrtYGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_Y_GATE_UPDATE(Class, Space)                                                \
+#define DEFINE_SQRT_Y_GATE_UPDATE(ArgDecl, StateExpr)                                          \
     template <Precision Prec>                                                                  \
-    void SqrtYGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {   \
+    void SqrtYGateImpl<Prec>::update_quantum_state(ArgDecl) const {                            \
+        auto& state_vector = StateExpr;                                                        \
         this->check_qubit_mask_within_bounds(state_vector);                                    \
         sqrty_gate(                                                                            \
             this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_SQRT_Y_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SQRT_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SQRT_Y_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SQRT_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_SQRT_Y_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_SQRT_Y_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_SQRT_Y_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_SQRT_Y_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SQRT_Y_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SQRT_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SQRT_Y_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_SQRT_Y_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_SQRT_Y_GATE_UPDATE
 template class SqrtYGateImpl<Prec>;
@@ -412,20 +442,21 @@ std::string SqrtYdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_YDAG_GATE_UPDATE(Class, Space)                                              \
-    template <Precision Prec>                                                                   \
-    void SqrtYdagGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                                     \
-        sqrtydag_gate(                                                                          \
-            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector);  \
+#define DEFINE_SQRT_YDAG_GATE_UPDATE(ArgDecl, StateExpr)                                       \
+    template <Precision Prec>                                                                  \
+    void SqrtYdagGateImpl<Prec>::update_quantum_state(ArgDecl) const {                         \
+        auto& state_vector = StateExpr;                                                        \
+        this->check_qubit_mask_within_bounds(state_vector);                                    \
+        sqrtydag_gate(                                                                         \
+            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_SQRT_YDAG_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_SQRT_YDAG_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_SQRT_YDAG_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_SQRT_YDAG_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SQRT_YDAG_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_SQRT_YDAG_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_SQRT_YDAG_GATE_UPDATE
 template class SqrtYdagGateImpl<Prec>;
@@ -443,19 +474,20 @@ std::string P0GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_P0_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_P0_GATE_UPDATE(ArgDecl, StateExpr)                                                  \
     template <Precision Prec>                                                                      \
-    void P0GateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
+    void P0GateImpl<Prec>::update_quantum_state(ArgDecl) const {                                   \
+        auto& state_vector = StateExpr;                                                            \
         this->check_qubit_mask_within_bounds(state_vector);                                        \
         p0_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_P0_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_P0_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_P0_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_P0_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_P0_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_P0_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_P0_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_P0_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_P0_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_P0_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_P0_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_P0_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_P0_GATE_UPDATE
 template class P0GateImpl<Prec>;
@@ -473,22 +505,98 @@ std::string P1GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_P1_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_P1_GATE_UPDATE(ArgDecl, StateExpr)                                                  \
     template <Precision Prec>                                                                      \
-    void P1GateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
+    void P1GateImpl<Prec>::update_quantum_state(ArgDecl) const {                                   \
+        auto& state_vector = StateExpr;                                                            \
         this->check_qubit_mask_within_bounds(state_vector);                                        \
         p1_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_P1_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_P1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_P1_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_P1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_P1_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_P1_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_P1_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_P1_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_P1_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_P1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_P1_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_P1_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_P1_GATE_UPDATE
 template class P1GateImpl<Prec>;
+
+template <Precision Prec>
+ComplexMatrix MeasurementGateImpl<Prec>::get_matrix() const {
+    throw std::runtime_error(
+        "MeasurementGate::get_matrix(): placeholder gate does not have a matrix representation");
+}
+template <Precision Prec>
+std::string MeasurementGateImpl<Prec>::to_string(const std::string& indent) const {
+    std::ostringstream ss;
+    ss << indent << "Gate Type: Measurement\n";
+    ss << indent << "  Classical Bit Index: " << _classical_bit_index << "\n";
+    ss << this->get_qubit_info_as_string(indent);
+    return ss.str();
+}
+#define DEFINE_MEASUREMENT_GATE_BATCHED_UPDATE(Space)                                          \
+    template <Precision Prec>                                                                  \
+    void MeasurementGateImpl<Prec>::update_quantum_state(                                      \
+        BatchedExecutionContext<Prec, Space> context) const {                                  \
+        if (context.reg == nullptr) {                                                          \
+            throw std::runtime_error(                                                          \
+                "MeasurementGate::update_quantum_state(): classical register is required.");   \
+        }                                                                                      \
+        if (context.reg->size() != context.n_classical_bits * context.states.batch_size()) {   \
+            throw std::runtime_error(                                                          \
+                "MeasurementGate::update_quantum_state(): classical register size must match " \
+                "n_classical_bits * batch size.");                                             \
+        }                                                                                      \
+        if (context.rng == nullptr) {                                                          \
+            throw std::runtime_error(                                                          \
+                "MeasurementGate::update_quantum_state(): random engine is required.");        \
+        }                                                                                      \
+        for (std::size_t i = 0; i < context.states.batch_size(); ++i) {                        \
+            auto state_vector = context.states.view_state_vector_at(i);                        \
+            this->update_quantum_state(ExecutionContext<Prec, Space>{state_vector,             \
+                                                                     context.reg,              \
+                                                                     context.rng,              \
+                                                                     i * context.n_classical_bits}); \
+        }                                                                                      \
+    }
+#define DEFINE_MEASUREMENT_GATE_CONTEXT_UPDATE(Space)                                           \
+    template <Precision Prec>                                                                   \
+    void MeasurementGateImpl<Prec>::update_quantum_state(ExecutionContext<Prec, Space> context) \
+        const {                                                                                 \
+        this->check_qubit_mask_within_bounds(context.state);                                    \
+        if (context.reg == nullptr) {                                                           \
+            throw std::runtime_error(                                                           \
+                "MeasurementGate::update_quantum_state(): classical register is required.");    \
+        }                                                                                       \
+        if (context.rng == nullptr) {                                                           \
+            throw std::runtime_error(                                                           \
+                "MeasurementGate::update_quantum_state(): random engine is required.");         \
+        }                                                                                       \
+        const double zero_probability =                                                         \
+            context.state.get_zero_probability(this->target_qubit_list()[0]);                   \
+        std::bernoulli_distribution zero_distribution(zero_probability);                        \
+        const bool measured_zero = zero_distribution(*context.rng);                             \
+        if (measured_zero) {                                                                    \
+            p0_gate(this->_target_mask, 0, 0, context.state);                                   \
+        } else {                                                                                \
+            p1_gate(this->_target_mask, 0, 0, context.state);                                   \
+        }                                                                                       \
+        context.state.normalize();                                                              \
+        (*context.reg)[context.reg_offset + this->_classical_bit_index] = !measured_zero;       \
+    }
+DEFINE_MEASUREMENT_GATE_CONTEXT_UPDATE(ExecutionSpace::Host)
+DEFINE_MEASUREMENT_GATE_BATCHED_UPDATE(ExecutionSpace::Host)
+DEFINE_MEASUREMENT_GATE_CONTEXT_UPDATE(ExecutionSpace::HostSerial)
+DEFINE_MEASUREMENT_GATE_BATCHED_UPDATE(ExecutionSpace::HostSerial)
+#ifdef SCALUQ_USE_CUDA
+DEFINE_MEASUREMENT_GATE_CONTEXT_UPDATE(ExecutionSpace::Default)
+DEFINE_MEASUREMENT_GATE_BATCHED_UPDATE(ExecutionSpace::Default)
+#endif  // SCALUQ_USE_CUDA
+#undef DEFINE_MEASUREMENT_GATE_BATCHED_UPDATE
+#undef DEFINE_MEASUREMENT_GATE_CONTEXT_UPDATE
+template class MeasurementGateImpl<Prec>;
 
 template <Precision Prec>
 ComplexMatrix RXGateImpl<Prec>::get_matrix() const {
@@ -506,23 +614,24 @@ std::string RXGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_RX_GATE_UPDATE(Class, Space)                                               \
-    template <Precision Prec>                                                             \
-    void RXGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
-        rx_gate(this->_target_mask,                                                       \
-                this->_control_mask,                                                      \
-                this->_control_value_mask,                                                \
-                this->_angle,                                                             \
-                state_vector);                                                            \
+#define DEFINE_RX_GATE_UPDATE(ArgDecl, StateExpr)                \
+    template <Precision Prec>                                    \
+    void RXGateImpl<Prec>::update_quantum_state(ArgDecl) const { \
+        auto& state_vector = StateExpr;                          \
+        this->check_qubit_mask_within_bounds(state_vector);      \
+        rx_gate(this->_target_mask,                              \
+                this->_control_mask,                             \
+                this->_control_value_mask,                       \
+                this->_angle,                                    \
+                state_vector);                                   \
     }
-DEFINE_RX_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_RX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_RX_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_RX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_RX_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_RX_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_RX_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_RX_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_RX_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_RX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_RX_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_RX_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_RX_GATE_UPDATE
 template class RXGateImpl<Prec>;
@@ -542,23 +651,24 @@ std::string RYGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_RY_GATE_UPDATE(Class, Space)                                               \
-    template <Precision Prec>                                                             \
-    void RYGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
-        ry_gate(this->_target_mask,                                                       \
-                this->_control_mask,                                                      \
-                this->_control_value_mask,                                                \
-                this->_angle,                                                             \
-                state_vector);                                                            \
+#define DEFINE_RY_GATE_UPDATE(ArgDecl, StateExpr)                \
+    template <Precision Prec>                                    \
+    void RYGateImpl<Prec>::update_quantum_state(ArgDecl) const { \
+        auto& state_vector = StateExpr;                          \
+        this->check_qubit_mask_within_bounds(state_vector);      \
+        ry_gate(this->_target_mask,                              \
+                this->_control_mask,                             \
+                this->_control_value_mask,                       \
+                this->_angle,                                    \
+                state_vector);                                   \
     }
-DEFINE_RY_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_RY_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_RY_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_RY_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_RY_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_RY_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_RY_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_RY_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_RY_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_RY_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_RY_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_RY_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_RY_GATE_UPDATE
 template class RYGateImpl<Prec>;
@@ -578,23 +688,24 @@ std::string RZGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_RZ_GATE_UPDATE(Class, Space)                                               \
-    template <Precision Prec>                                                             \
-    void RZGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
-        rz_gate(this->_target_mask,                                                       \
-                this->_control_mask,                                                      \
-                this->_control_value_mask,                                                \
-                this->_angle,                                                             \
-                state_vector);                                                            \
+#define DEFINE_RZ_GATE_UPDATE(ArgDecl, StateExpr)                \
+    template <Precision Prec>                                    \
+    void RZGateImpl<Prec>::update_quantum_state(ArgDecl) const { \
+        auto& state_vector = StateExpr;                          \
+        this->check_qubit_mask_within_bounds(state_vector);      \
+        rz_gate(this->_target_mask,                              \
+                this->_control_mask,                             \
+                this->_control_value_mask,                       \
+                this->_angle,                                    \
+                state_vector);                                   \
     }
-DEFINE_RZ_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_RZ_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_RZ_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_RZ_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_RZ_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_RZ_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_RZ_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_RZ_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_RZ_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_RZ_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_RZ_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_RZ_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_RZ_GATE_UPDATE
 template class RZGateImpl<Prec>;
@@ -613,23 +724,24 @@ std::string U1GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_U1_GATE_UPDATE(Class, Space)                                               \
-    template <Precision Prec>                                                             \
-    void U1GateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
-        u1_gate(this->_target_mask,                                                       \
-                this->_control_mask,                                                      \
-                this->_control_value_mask,                                                \
-                this->_lambda,                                                            \
-                state_vector);                                                            \
+#define DEFINE_U1_GATE_UPDATE(ArgDecl, StateExpr)                \
+    template <Precision Prec>                                    \
+    void U1GateImpl<Prec>::update_quantum_state(ArgDecl) const { \
+        auto& state_vector = StateExpr;                          \
+        this->check_qubit_mask_within_bounds(state_vector);      \
+        u1_gate(this->_target_mask,                              \
+                this->_control_mask,                             \
+                this->_control_value_mask,                       \
+                this->_lambda,                                   \
+                state_vector);                                   \
     }
-DEFINE_U1_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_U1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_U1_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_U1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_U1_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_U1_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_U1_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_U1_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_U1_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_U1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_U1_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_U1_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_U1_GATE_UPDATE
 template class U1GateImpl<Prec>;
@@ -654,24 +766,25 @@ std::string U2GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_U2_GATE_UPDATE(Class, Space)                                               \
-    template <Precision Prec>                                                             \
-    void U2GateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
-        u2_gate(this->_target_mask,                                                       \
-                this->_control_mask,                                                      \
-                this->_control_value_mask,                                                \
-                this->_phi,                                                               \
-                this->_lambda,                                                            \
-                state_vector);                                                            \
+#define DEFINE_U2_GATE_UPDATE(ArgDecl, StateExpr)                \
+    template <Precision Prec>                                    \
+    void U2GateImpl<Prec>::update_quantum_state(ArgDecl) const { \
+        auto& state_vector = StateExpr;                          \
+        this->check_qubit_mask_within_bounds(state_vector);      \
+        u2_gate(this->_target_mask,                              \
+                this->_control_mask,                             \
+                this->_control_value_mask,                       \
+                this->_phi,                                      \
+                this->_lambda,                                   \
+                state_vector);                                   \
     }
-DEFINE_U2_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_U2_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_U2_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_U2_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_U2_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_U2_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_U2_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_U2_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_U2_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_U2_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_U2_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_U2_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_U2_GATE_UPDATE
 template class U2GateImpl<Prec>;
@@ -699,25 +812,26 @@ std::string U3GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_U3_GATE_UPDATE(Class, Space)                                               \
-    template <Precision Prec>                                                             \
-    void U3GateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
-        u3_gate(this->_target_mask,                                                       \
-                this->_control_mask,                                                      \
-                this->_control_value_mask,                                                \
-                this->_theta,                                                             \
-                this->_phi,                                                               \
-                this->_lambda,                                                            \
-                state_vector);                                                            \
+#define DEFINE_U3_GATE_UPDATE(ArgDecl, StateExpr)                \
+    template <Precision Prec>                                    \
+    void U3GateImpl<Prec>::update_quantum_state(ArgDecl) const { \
+        auto& state_vector = StateExpr;                          \
+        this->check_qubit_mask_within_bounds(state_vector);      \
+        u3_gate(this->_target_mask,                              \
+                this->_control_mask,                             \
+                this->_control_value_mask,                       \
+                this->_theta,                                    \
+                this->_phi,                                      \
+                this->_lambda,                                   \
+                state_vector);                                   \
     }
-DEFINE_U3_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_U3_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_U3_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_U3_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_U3_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_U3_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_U3_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_U3_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_U3_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_U3_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_U3_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_U3_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_U3_GATE_UPDATE
 template class U3GateImpl<Prec>;
@@ -735,20 +849,21 @@ std::string SwapGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SWAP_GATE_UPDATE(Class, Space)                                                  \
+#define DEFINE_SWAP_GATE_UPDATE(ArgDecl, StateExpr)                                            \
     template <Precision Prec>                                                                  \
-    void SwapGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {    \
+    void SwapGateImpl<Prec>::update_quantum_state(ArgDecl) const {                             \
+        auto& state_vector = StateExpr;                                                        \
         this->check_qubit_mask_within_bounds(state_vector);                                    \
         swap_gate(                                                                             \
             this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
     }
-DEFINE_SWAP_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SWAP_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SWAP_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SWAP_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_SWAP_GATE_UPDATE(HostContext<Prec> context, context.state)
+DEFINE_SWAP_GATE_UPDATE(HostBatchedContext<Prec> context, context.states)
+DEFINE_SWAP_GATE_UPDATE(HostSerialContext<Prec> context, context.state)
+DEFINE_SWAP_GATE_UPDATE(HostSerialBatchedContext<Prec> context, context.states)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SWAP_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SWAP_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SWAP_GATE_UPDATE(DefaultContext<Prec> context, context.state)
+DEFINE_SWAP_GATE_UPDATE(DefaultBatchedContext<Prec> context, context.states)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_SWAP_GATE_UPDATE
 template class SwapGateImpl<Prec>;
@@ -800,6 +915,16 @@ DECLARE_GET_FROM_JSON_SINGLE_IMPL(SqrtYdagGateImpl)
 DECLARE_GET_FROM_JSON_SINGLE_IMPL(P0GateImpl)
 DECLARE_GET_FROM_JSON_SINGLE_IMPL(P1GateImpl)
 #undef DECLARE_GET_FROM_JSON_SINGLE_IMPL
+
+// Measurement
+template <Precision Prec>
+std::shared_ptr<const MeasurementGateImpl<Prec>> GetGateFromJson<MeasurementGateImpl<Prec>>::get(
+    const Json& j) {
+    return std::make_shared<const MeasurementGateImpl<Prec>>(
+        vector_to_mask(j.at("target").get<std::vector<std::uint64_t>>()),
+        j.at("classical_bit").get<std::uint64_t>());
+}
+template struct GetGateFromJson<MeasurementGateImpl<Prec>>;
 
 // RX, RY, RZ
 #define DECLARE_GET_FROM_JSON_R_SINGLE_IMPL(Impl)                                       \

--- a/src/gate/param_gate_pauli.cpp
+++ b/src/gate/param_gate_pauli.cpp
@@ -27,7 +27,7 @@ std::string ParamPauliRotationGateImpl<Prec>::to_string(const std::string& inden
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Host>& state_vector, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
                          this->_control_value_mask,
@@ -35,11 +35,11 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          phase_flip_mask,
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef * static_cast<Float<Prec>>(param),
-                         state_vector);
+                         context.state);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Host>& states, std::vector<double> params) const {
+    BatchedExecutionContext<Prec, ExecutionSpace::Host> context, std::vector<double> params) const {
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
@@ -55,11 +55,11 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef,
                          params_view,
-                         states);
+                         context.states);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::HostSerial>& state_vector, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
                          this->_control_value_mask,
@@ -67,11 +67,11 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          phase_flip_mask,
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef * static_cast<Float<Prec>>(param),
-                         state_vector);
+                         context.state);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+    BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context,
     std::vector<double> params) const {
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     std::vector<Float<Prec>> params_prec(params.size());
@@ -88,12 +88,12 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef,
                          params_view,
-                         states);
+                         context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Default>& state_vector, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
                          this->_control_value_mask,
@@ -101,12 +101,12 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          phase_flip_mask,
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef * static_cast<Float<Prec>>(param),
-                         state_vector);
-    std::cout << "apply end" << std::endl;
+                         context.state);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Default>& states, std::vector<double> params) const {
+    BatchedExecutionContext<Prec, ExecutionSpace::Default> context,
+    std::vector<double> params) const {
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
@@ -123,7 +123,7 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef,
                          params_view,
-                         states);
+                         context.states);
 }
 #endif
 template class ParamPauliRotationGateImpl<Prec>;

--- a/src/gate/param_gate_probabilistic.cpp
+++ b/src/gate/param_gate_probabilistic.cpp
@@ -7,6 +7,37 @@ namespace {
 template <Precision Prec>
 using EitherGate = std::variant<Gate<Prec>, ParamGate<Prec>>;
 
+template <Precision Prec, ExecutionSpace Space>
+std::uint64_t select_param_probabilistic_gate_index(
+    const std::vector<double>& cumulative_distribution,
+    ExecutionContext<Prec, Space> context) {
+    if (context.rng == nullptr) {
+        throw std::runtime_error(
+            "ParamProbabilisticGateImpl::update_quantum_state(): random engine is required.");
+    }
+
+    std::uniform_real_distribution<double> dist(0., 1.);
+    const std::uint64_t i =
+        std::distance(cumulative_distribution.begin(),
+                      std::ranges::upper_bound(cumulative_distribution, dist(*context.rng))) -
+        1;
+    return std::min<std::uint64_t>(i, cumulative_distribution.size() - 2);
+}
+
+template <Precision Prec, ExecutionSpace Space>
+void apply_param_probabilistic_gate_once(const std::vector<double>& cumulative_distribution,
+                                         const std::vector<EitherGate<Prec>>& gate_list,
+                                         ExecutionContext<Prec, Space> context,
+                                         double param) {
+    const auto& gate =
+        gate_list[select_param_probabilistic_gate_index(cumulative_distribution, context)];
+    if (gate.index() == 0) {
+        std::get<0>(gate)->update_quantum_state(context);
+    } else {
+        std::get<1>(gate)->update_quantum_state(context, param);
+    }
+}
+
 template <Precision Prec>
 void flatten_param_probabilistic_gate(double prob_prefix,
                                       const EitherGate<Prec>& gate,
@@ -96,135 +127,45 @@ std::string ParamProbabilisticGateImpl<Prec>::to_string(const std::string& inden
     }
     return ss.str();
 }
-template <Precision Prec>
-void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Host>& state_vector, double param) const {
-    Random random;
-    double r = random.uniform();
-    std::uint64_t i = std::distance(_cumulative_distribution.begin(),
-                                    std::ranges::upper_bound(_cumulative_distribution, r)) -
-                      1;
-    if (i >= _gate_list.size()) i = _gate_list.size() - 1;
-    const auto& gate = _gate_list[i];
-    if (gate.index() == 0) {
-        std::get<0>(gate)->update_quantum_state(state_vector);
-    } else {
-        std::get<1>(gate)->update_quantum_state(state_vector, param);
+#define DEFINE_PARAM_PROBABILISTIC_GATE_UPDATE(Space)                                      \
+    template <Precision Prec>                                                               \
+    void ParamProbabilisticGateImpl<Prec>::update_quantum_state(                            \
+        ExecutionContext<Prec, Space> context, double param) const {                        \
+        apply_param_probabilistic_gate_once(_cumulative_distribution, _gate_list, context,  \
+                                            param);                                          \
+    }                                                                                       \
+    template <Precision Prec>                                                               \
+    void ParamProbabilisticGateImpl<Prec>::update_quantum_state(                            \
+        BatchedExecutionContext<Prec, Space> context, std::vector<double> params) const {   \
+        if (params.size() != context.states.batch_size()) {                                 \
+            throw std::runtime_error(                                                       \
+                "ParamProbabilisticGateImpl::update_quantum_state(): params size must "     \
+                "match batch size.");                                                       \
+        }                                                                                   \
+        if (context.reg != nullptr &&                                                      \
+            context.reg->size() != context.n_classical_bits * context.states.batch_size()) { \
+            throw std::runtime_error(                                                       \
+                "ParamProbabilisticGateImpl::update_quantum_state(): classical register "    \
+                "size must match n_classical_bits * batch size.");                          \
+        }                                                                                   \
+        for (std::size_t i = 0; i < context.states.batch_size(); ++i) {                     \
+            auto state_vector = context.states.view_state_vector_at(i);                      \
+            apply_param_probabilistic_gate_once(                                            \
+                _cumulative_distribution,                                                   \
+                _gate_list,                                                                 \
+                ExecutionContext<Prec, Space>{state_vector,                                 \
+                                              context.reg,                                  \
+                                              context.rng,                                  \
+                                              i * context.n_classical_bits},                \
+                params[i]);                                                                 \
+        }                                                                                   \
     }
-}
-template <Precision Prec>
-void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Host>& states, std::vector<double> params) const {
-    Random random;
-    std::vector<double> r(states.batch_size());
-    std::ranges::generate(r, [&random]() { return random.uniform(); });
-    std::vector<std::uint64_t> indicies(states.batch_size());
-    std::ranges::transform(r, indicies.begin(), [this](double r) {
-        return std::distance(_cumulative_distribution.begin(),
-                             std::ranges::upper_bound(_cumulative_distribution, r)) -
-               1;
-    });
-    std::ranges::transform(indicies, indicies.begin(), [this](std::uint64_t i) {
-        if (i >= _gate_list.size()) i = _gate_list.size() - 1;
-        return i;
-    });
-    for (std::size_t i = 0; i < states.batch_size(); ++i) {
-        const auto& gate = _gate_list[indicies[i]];
-        auto state_vector = states.view_state_vector_at(i);
-        if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(state_vector);
-        } else {
-            std::get<1>(gate)->update_quantum_state(state_vector, params[i]);
-        }
-    }
-}
-template <Precision Prec>
-void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::HostSerial>& state_vector, double param) const {
-    Random random;
-    double r = random.uniform();
-    std::uint64_t i = std::distance(_cumulative_distribution.begin(),
-                                    std::ranges::upper_bound(_cumulative_distribution, r)) -
-                      1;
-    if (i >= _gate_list.size()) i = _gate_list.size() - 1;
-    const auto& gate = _gate_list[i];
-    if (gate.index() == 0) {
-        std::get<0>(gate)->update_quantum_state(state_vector);
-    } else {
-        std::get<1>(gate)->update_quantum_state(state_vector, param);
-    }
-}
-template <Precision Prec>
-void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-    std::vector<double> params) const {
-    Random random;
-    std::vector<double> r(states.batch_size());
-    std::ranges::generate(r, [&random]() { return random.uniform(); });
-    std::vector<std::uint64_t> indicies(states.batch_size());
-    std::ranges::transform(r, indicies.begin(), [this](double r) {
-        return std::distance(_cumulative_distribution.begin(),
-                             std::ranges::upper_bound(_cumulative_distribution, r)) -
-               1;
-    });
-    std::ranges::transform(indicies, indicies.begin(), [this](std::uint64_t i) {
-        if (i >= _gate_list.size()) i = _gate_list.size() - 1;
-        return i;
-    });
-    for (std::size_t i = 0; i < states.batch_size(); ++i) {
-        const auto& gate = _gate_list[indicies[i]];
-        auto state_vector = states.view_state_vector_at(i);
-        if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(state_vector);
-        } else {
-            std::get<1>(gate)->update_quantum_state(state_vector, params[i]);
-        }
-    }
-}
+DEFINE_PARAM_PROBABILISTIC_GATE_UPDATE(ExecutionSpace::Host)
+DEFINE_PARAM_PROBABILISTIC_GATE_UPDATE(ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-template <Precision Prec>
-void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Default>& state_vector, double param) const {
-    Random random;
-    double r = random.uniform();
-    std::uint64_t i = std::distance(_cumulative_distribution.begin(),
-                                    std::ranges::upper_bound(_cumulative_distribution, r)) -
-                      1;
-    if (i >= _gate_list.size()) i = _gate_list.size() - 1;
-    const auto& gate = _gate_list[i];
-    if (gate.index() == 0) {
-        std::get<0>(gate)->update_quantum_state(state_vector);
-    } else {
-        std::get<1>(gate)->update_quantum_state(state_vector, param);
-    }
-}
-template <Precision Prec>
-void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Default>& states, std::vector<double> params) const {
-    Random random;
-    std::vector<double> r(states.batch_size());
-    std::ranges::generate(r, [&random]() { return random.uniform(); });
-    std::vector<std::uint64_t> indicies(states.batch_size());
-    std::ranges::transform(r, indicies.begin(), [this](double r) {
-        return std::distance(_cumulative_distribution.begin(),
-                             std::ranges::upper_bound(_cumulative_distribution, r)) -
-               1;
-    });
-    std::ranges::transform(indicies, indicies.begin(), [this](std::uint64_t i) {
-        if (i >= _gate_list.size()) i = _gate_list.size() - 1;
-        return i;
-    });
-    for (std::size_t i = 0; i < states.batch_size(); ++i) {
-        const auto& gate = _gate_list[indicies[i]];
-        auto state_vector = states.view_state_vector_at(i);
-        if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(state_vector);
-        } else {
-            std::get<1>(gate)->update_quantum_state(state_vector, params[i]);
-        }
-    }
-}
+DEFINE_PARAM_PROBABILISTIC_GATE_UPDATE(ExecutionSpace::Default)
 #endif
+#undef DEFINE_PARAM_PROBABILISTIC_GATE_UPDATE
 template class ParamProbabilisticGateImpl<Prec>;
 
 template <Precision Prec>

--- a/src/gate/param_gate_standard.cpp
+++ b/src/gate/param_gate_standard.cpp
@@ -21,18 +21,18 @@ std::string ParamRXGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Host>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Host>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    BatchedExecutionContext<Prec, ExecutionSpace::Host> context, std::vector<double> params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -45,23 +45,23 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::HostSerial>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+    BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context,
     std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -74,23 +74,24 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Default>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Default>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    BatchedExecutionContext<Prec, ExecutionSpace::Default> context,
+    std::vector<double> params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -104,7 +105,7 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #endif  // SCALUQ_USE_CUDA
 template class ParamRXGateImpl<Prec>;
@@ -126,18 +127,18 @@ std::string ParamRYGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Host>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Host>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    BatchedExecutionContext<Prec, ExecutionSpace::Host> context, std::vector<double> params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -150,23 +151,23 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::HostSerial>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+    BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context,
     std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -179,23 +180,24 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Default>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Default>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    BatchedExecutionContext<Prec, ExecutionSpace::Default> context,
+    std::vector<double> params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -209,7 +211,7 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #endif  // SCALUQ_USE_CUDA
 template class ParamRYGateImpl<Prec>;
@@ -231,18 +233,18 @@ std::string ParamRZGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Host>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Host>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    BatchedExecutionContext<Prec, ExecutionSpace::Host> context, std::vector<double> params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -255,23 +257,23 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::HostSerial>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+    BatchedExecutionContext<Prec, ExecutionSpace::HostSerial> context,
     std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -284,23 +286,24 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Default>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Default>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    BatchedExecutionContext<Prec, ExecutionSpace::Default> context,
+    std::vector<double> params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -314,7 +317,7 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #endif  // SCALUQ_USE_CUDA
 template class ParamRZGateImpl<Prec>;

--- a/tests/circuit/circuit_optimize_test.cpp
+++ b/tests/circuit/circuit_optimize_test.cpp
@@ -69,8 +69,8 @@ TYPED_TEST(CircuitOptimizeTest, Basic) {
 
     auto state0 = StateVector<Prec, Space>::Haar_random_state(N);
     auto state1 = state0.copy();
-    circuit.update_quantum_state(state0, params);
+    circuit.update_quantum_state(state0, params, 0);
     circuit.template optimize<Space>();
-    circuit.update_quantum_state(state1, params);
+    circuit.update_quantum_state(state1, params, 0);
     assert(same_state(state0, state1));
 }

--- a/tests/circuit/circuit_test.cpp
+++ b/tests/circuit/circuit_test.cpp
@@ -137,7 +137,7 @@ void circuit_test() {
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target, make_U(-angle, 0, 0), n) * state_eigen;
 
-    circuit.update_quantum_state(state);
+    circuit.update_quantum_state(state, {}, 0);
 
     state_cp = state.get_amplitudes();
     for (std::uint64_t i = 0; i < dim; ++i) {
@@ -230,11 +230,11 @@ void circuit_rev_test() {
     if (target_sub >= target) target_sub++;
     circuit.add_gate(gate::Swap<Prec>(target, target_sub));
 
-    circuit.update_quantum_state(state);
+    circuit.update_quantum_state(state, {}, 0);
 
     auto revcircuit = circuit.get_inverse();
 
-    revcircuit.update_quantum_state(state);
+    revcircuit.update_quantum_state(state, {}, 0);
     state_cp = state.get_amplitudes();
     for (std::uint64_t i = 0; i < dim; ++i) {
         check_near<Prec>(state_eigen[i], state_cp[i]);
@@ -255,5 +255,102 @@ TYPED_TEST(CircuitTest, ThrowsWhenStateHasTooFewQubits) {
     circuit.add_gate(gate::X<Prec>(1));
 
     StateVector<Prec, Space> state(1);
-    ASSERT_THROW(circuit.update_quantum_state(state), std::runtime_error);
+    ASSERT_THROW(circuit.update_quantum_state(state, {}, 0), std::runtime_error);
+}
+
+TYPED_TEST(CircuitTest, UpdateQuantumStateStoresMeasurementInCircuitRegister) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    Circuit<Prec> circuit(4);
+    circuit.add_gate(gate::X<Prec>(0));
+    circuit.add_gate(gate::Measurement<Prec>(0, 3));
+
+    StateVector<Prec, Space> state(1);
+    circuit.update_quantum_state(state, {}, 0);
+
+    EXPECT_TRUE(circuit.classical_register()[3]);
+
+    const auto amplitudes = state.get_amplitudes();
+    check_near<Prec>(amplitudes[0], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[1], StdComplex{1.0, 0.0});
+}
+
+TYPED_TEST(CircuitTest, UpdateQuantumStateExecutesAdaptiveGateFromCircuitRegister) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    Circuit<Prec> circuit(2);
+    circuit.add_gate(gate::X<Prec>(0));
+    circuit.add_gate(gate::X<Prec>(1));
+    circuit.add_gate(gate::Measurement<Prec>(0, 0));
+    circuit.add_gate(gate::Measurement<Prec>(1, 1));
+    circuit.add_conditional_gate(gate::X<Prec>(2), [](const ClassicalRegister& reg) {
+        for (std::uint64_t bit = 0; bit < 2; ++bit) {
+            if (bit >= reg.size() || !reg[bit]) return false;
+        }
+        return true;
+    });
+
+    StateVector<Prec, Space> state(3);
+    circuit.update_quantum_state(state, {}, 0);
+
+    EXPECT_TRUE(circuit.classical_register()[0]);
+    EXPECT_TRUE(circuit.classical_register()[1]);
+
+    const auto amplitudes = state.get_amplitudes();
+    check_near<Prec>(amplitudes[0], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[1], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[2], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[3], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[4], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[5], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[6], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[7], StdComplex{1.0, 0.0});
+}
+
+TYPED_TEST(CircuitTest, UpdateQuantumStateBatchedStoresMeasurementInFlatRegister) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    Circuit<Prec> circuit(2);
+    circuit.add_gate(gate::X<Prec>(0));
+    circuit.add_gate(gate::Measurement<Prec>(0, 1));
+
+    StateVectorBatched<Prec, Space> states(2, 1);
+    ASSERT_NO_THROW(circuit.update_quantum_state(states, {}, 0));
+    EXPECT_TRUE(circuit.classical_register()[1]);
+    EXPECT_TRUE(circuit.classical_register()[3]);
+}
+
+TYPED_TEST(CircuitTest, AddCircuitKeepsLongerClassicalRegister) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    Circuit<Prec> lhs(1);
+    Circuit<Prec> rhs(4);
+    rhs.add_gate(gate::X<Prec>(0));
+    rhs.add_gate(gate::Measurement<Prec>(0, 3));
+
+    lhs.add_circuit(rhs);
+
+    StateVector<Prec, Space> state(1);
+    lhs.update_quantum_state(state, {}, 0);
+
+    EXPECT_TRUE(lhs.classical_register()[3]);
+}
+
+TYPED_TEST(CircuitTest, JsonRoundTripKeepsClassicalRegisterSize) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    Circuit<Prec> circuit(4);
+    circuit.add_gate(gate::X<Prec>(0));
+    circuit.add_gate(gate::Measurement<Prec>(0, 3));
+
+    auto loaded = Json(circuit).template get<Circuit<Prec>>();
+
+    StateVector<Prec, Space> state(1);
+    ASSERT_NO_THROW(loaded.update_quantum_state(state, {}, 0));
+    EXPECT_TRUE(loaded.classical_register()[3]);
 }

--- a/tests/circuit/param_circuit_test.cpp
+++ b/tests/circuit/param_circuit_test.cpp
@@ -72,8 +72,8 @@ void param_circuit_test() {
         StateVector state = StateVector<Prec, Space>::Haar_random_state(n_qubits);
         StateVector state_cp = state.copy();
         auto amplitudes_base = state.get_amplitudes();
-        circuit.update_quantum_state(state);
-        pcircuit.update_quantum_state(state_cp, pmap);
+        circuit.update_quantum_state(state, {}, 0);
+        pcircuit.update_quantum_state(state_cp, pmap, 0);
         auto amplitudes = state.get_amplitudes();
         auto amplitudes_cp = state_cp.get_amplitudes();
         for (std::uint64_t idx : std::views::iota(std::uint64_t{0}, 1ULL << n_qubits)) {
@@ -81,8 +81,8 @@ void param_circuit_test() {
         }
         auto icircuit = circuit.get_inverse();
         auto ipcircuit = pcircuit.get_inverse();
-        icircuit.update_quantum_state(state);
-        ipcircuit.update_quantum_state(state_cp, pmap);
+        icircuit.update_quantum_state(state, {}, 0);
+        ipcircuit.update_quantum_state(state_cp, pmap, 0);
         amplitudes = state.get_amplitudes();
         amplitudes_cp = state_cp.get_amplitudes();
         for (std::uint64_t idx : std::views::iota(std::uint64_t{0}, 1ULL << n_qubits)) {
@@ -107,11 +107,41 @@ TYPED_TEST(ParamCircuitTest, InsufficientParameterGiven) {
         circuit.add_param_gate(gate::ParamRX<Prec>(0), "1");
         circuit.add_param_gate(gate::ParamRX<Prec>(0), "0");
         StateVector<Prec, Space> state(1);
-        ASSERT_NO_THROW(circuit.update_quantum_state(state, {{"0", 0}, {"1", 0}}));
-        ASSERT_NO_THROW(circuit.update_quantum_state(state, {{"0", 0}, {"1", 0}, {"2", 0}}));
-        ASSERT_THROW(circuit.update_quantum_state(state), std::runtime_error);
-        ASSERT_THROW(circuit.update_quantum_state(state, {}), std::runtime_error);
-        ASSERT_THROW(circuit.update_quantum_state(state, {{"0", 0}}), std::runtime_error);
-        ASSERT_THROW(circuit.update_quantum_state(state, {{"0", 0}, {"2", 0}}), std::runtime_error);
+        ASSERT_NO_THROW(circuit.update_quantum_state(state, {{"0", 0}, {"1", 0}}, 0));
+        ASSERT_NO_THROW(circuit.update_quantum_state(
+            state, {{"0", 0}, {"1", 0}, {"2", 0}}, 0));
+        ASSERT_THROW(circuit.update_quantum_state(state, {}, 0), std::runtime_error);
+        ASSERT_THROW(circuit.update_quantum_state(state, {{"0", 0}}, 0), std::runtime_error);
+        ASSERT_THROW(circuit.update_quantum_state(state, {{"0", 0}, {"2", 0}}, 0),
+                     std::runtime_error);
     }
+}
+
+TYPED_TEST(ParamCircuitTest, UpdateQuantumStateBatchedExecutesParamProbabilisticGate) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    Circuit<Prec> circuit;
+    circuit.add_param_gate(
+        gate::ParamProbabilistic<Prec>({1.0}, {gate::ParamRX<Prec>(0)}), "theta");
+    StateVectorBatched<Prec, Space> states(2, 1);
+
+    ASSERT_NO_THROW(circuit.update_quantum_state(
+        states, {{"theta", {std::numbers::pi, std::numbers::pi}}}, 0));
+}
+
+TYPED_TEST(ParamCircuitTest, UpdateQuantumStateExecutesParamProbabilisticGate) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    Circuit<Prec> circuit;
+    circuit.add_param_gate(
+        gate::ParamProbabilistic<Prec>({1.0}, {gate::ParamRX<Prec>(0)}), "theta");
+
+    StateVector<Prec, Space> state(1);
+    circuit.update_quantum_state(state, {{"theta", std::numbers::pi}}, 0);
+
+    const auto amplitudes = state.get_amplitudes();
+    check_near<Prec>(amplitudes[0], StdComplex(0., 0.));
+    check_near<Prec>(amplitudes[1], StdComplex(0., -1.));
 }

--- a/tests/gate/batched_gate_test.cpp
+++ b/tests/gate/batched_gate_test.cpp
@@ -762,9 +762,11 @@ TYPED_TEST(BatchedGateTest, ApplyProbabilisticGate) {
         StateVectorBatched<Prec, Space> states(BATCH_SIZE, 1);
         std::vector<std::vector<std::uint64_t>> befores, afters;
         std::vector<std::uint64_t> x_counts(BATCH_SIZE), i_counts(BATCH_SIZE);
+        std::mt19937_64 rng(0);
         for ([[maybe_unused]] auto _ : std::views::iota(0, 100)) {
             befores = states.sampling(1);
-            probgate->update_quantum_state(states);
+            probgate->update_quantum_state(
+                BatchedExecutionContext<Prec, Space>{states, nullptr, 0, &rng});
             afters = states.sampling(1);
             for (std::size_t i = 0; i < BATCH_SIZE; i++) {
                 if (befores[i][0] != afters[i][0]) {
@@ -780,6 +782,61 @@ TYPED_TEST(BatchedGateTest, ApplyProbabilisticGate) {
             ASSERT_GT(i_counts[i], 0);
             ASSERT_LT(x_counts[i], i_counts[i]);
         }
+    }
+}
+
+TYPED_TEST(BatchedGateTest, ApplyMeasurementGate) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    constexpr std::uint64_t N_CLASSICAL_BITS = 2;
+
+    StateVectorBatched<Prec, Space> states(BATCH_SIZE, 1);
+    std::vector<std::vector<StdComplex>> amplitudes(BATCH_SIZE, std::vector<StdComplex>(2, 0.));
+    std::vector<bool> reg(BATCH_SIZE * N_CLASSICAL_BITS, false);
+    std::mt19937_64 rng(0);
+
+    for (std::size_t i = 0; i < BATCH_SIZE; ++i) {
+        amplitudes[i][i % 2] = 1.;
+    }
+    states.load(amplitudes);
+
+    gate::Measurement<Prec>(0, 1)->update_quantum_state(
+        BatchedExecutionContext<Prec, Space>{states, &reg, N_CLASSICAL_BITS, &rng});
+
+    const auto states_amp = states.get_amplitudes();
+    for (std::size_t i = 0; i < BATCH_SIZE; ++i) {
+        EXPECT_FALSE(reg[i * N_CLASSICAL_BITS]);
+        EXPECT_EQ(reg[i * N_CLASSICAL_BITS + 1], static_cast<bool>(i % 2));
+        check_near<Prec>(states_amp[i][0], amplitudes[i][0]);
+        check_near<Prec>(states_amp[i][1], amplitudes[i][1]);
+    }
+}
+
+TYPED_TEST(BatchedGateTest, ApplyProbabilisticMeasurementGate) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    constexpr std::uint64_t N_CLASSICAL_BITS = 2;
+
+    StateVectorBatched<Prec, Space> states(BATCH_SIZE, 1);
+    std::vector<std::vector<StdComplex>> amplitudes(BATCH_SIZE, std::vector<StdComplex>(2, 0.));
+    std::vector<bool> reg(BATCH_SIZE * N_CLASSICAL_BITS, false);
+    std::mt19937_64 rng(1);
+
+    for (std::size_t i = 0; i < BATCH_SIZE; ++i) {
+        amplitudes[i][i % 2] = 1.;
+    }
+    states.load(amplitudes);
+
+    gate::Probabilistic<Prec>({1.0}, {gate::Measurement<Prec>(0, 1)})
+        ->update_quantum_state(
+            BatchedExecutionContext<Prec, Space>{states, &reg, N_CLASSICAL_BITS, &rng});
+
+    const auto states_amp = states.get_amplitudes();
+    for (std::size_t i = 0; i < BATCH_SIZE; ++i) {
+        EXPECT_FALSE(reg[i * N_CLASSICAL_BITS]);
+        EXPECT_EQ(reg[i * N_CLASSICAL_BITS + 1], static_cast<bool>(i % 2));
+        check_near<Prec>(states_amp[i][0], amplitudes[i][0]);
+        check_near<Prec>(states_amp[i][1], amplitudes[i][1]);
     }
 }
 
@@ -805,7 +862,7 @@ void test_batched_gate(Gate<Prec> gate_control,
     }
     states_controlled.load(amplitudes_controlled);
     gate_control->update_quantum_state(states);
-    gate_simple->update_quantum_state(states_controlled);
+    gate_simple->update_quantum_state(BatchedExecutionContext<Prec, Space>{states_controlled});
     amplitudes = states.get_amplitudes();
     amplitudes_controlled = states_controlled.get_amplitudes();
     for (std::uint64_t i = 0; i < BATCH_SIZE; i++) {

--- a/tests/gate/gate_test.cpp
+++ b/tests/gate/gate_test.cpp
@@ -707,9 +707,10 @@ TYPED_TEST(GateTest, ApplyProbabilisticGate) {
         auto probgate = gate::Probabilistic<Prec>({.1, .9}, {gate::X<Prec>(0), gate::I<Prec>()});
         std::uint64_t x_cnt = 0, i_cnt = 0;
         StateVector<Prec, Space> state(1);
+        std::mt19937_64 rng(0);
         for ([[maybe_unused]] auto _ : std::views::iota(0, 100)) {
             std::uint64_t before = state.sampling(1)[0];
-            probgate->update_quantum_state(state);
+            probgate->update_quantum_state(ExecutionContext<Prec, Space>{state, nullptr, &rng});
             std::uint64_t after = state.sampling(1)[0];
             if (before != after) {
                 x_cnt++;
@@ -722,6 +723,41 @@ TYPED_TEST(GateTest, ApplyProbabilisticGate) {
         ASSERT_GT(i_cnt, 0);
         ASSERT_LT(x_cnt, i_cnt);
     }
+}
+
+TYPED_TEST(GateTest, ApplyMeasurementGateOnZeroState) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    StateVector<Prec, Space> state(1);
+    std::vector<bool> reg(1, true);
+    std::mt19937_64 rng(0);
+
+    gate::Measurement<Prec>(0, 0)->update_quantum_state(
+        ExecutionContext<Prec, Space>{state, &reg, &rng});
+
+    EXPECT_FALSE(reg[0]);
+    const auto amplitudes = state.get_amplitudes();
+    check_near<Prec>(amplitudes[0], StdComplex{1.0, 0.0});
+    check_near<Prec>(amplitudes[1], StdComplex{0.0, 0.0});
+}
+
+TYPED_TEST(GateTest, ApplyMeasurementGateOnOneState) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    StateVector<Prec, Space> state(1);
+    gate::X<Prec>(0)->update_quantum_state(state);
+    std::vector<bool> reg(1, false);
+    std::mt19937_64 rng(0);
+
+    gate::Measurement<Prec>(0, 0)->update_quantum_state(
+        ExecutionContext<Prec, Space>{state, &reg, &rng});
+
+    EXPECT_TRUE(reg[0]);
+    const auto amplitudes = state.get_amplitudes();
+    check_near<Prec>(amplitudes[0], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[1], StdComplex{1.0, 0.0});
 }
 
 TYPED_TEST(GateTest, FlattenNestedProbabilisticGate) {
@@ -761,7 +797,7 @@ void test_gate(Gate<Prec> gate_control,
     }
     state_controlled.load(amplitudes_controlled);
     gate_control->update_quantum_state(state);
-    gate_simple->update_quantum_state(state_controlled);
+    gate_simple->update_quantum_state(ExecutionContext<Prec, Space>{state_controlled});
     amplitudes = state.get_amplitudes();
     amplitudes_controlled = state_controlled.get_amplitudes();
     for (std::uint64_t i : std::views::iota(0ULL, state_controlled.dim())) {

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -121,9 +121,11 @@ TYPED_TEST(ParamGateTest, ApplyParamProbabilisticGate) {
         gate::ParamProbabilistic<Prec>({.1, .9}, {gate::ParamRX<Prec>(0), gate::I<Prec>()});
     std::uint64_t x_cnt = 0, i_cnt = 0;
     StateVector<Prec, Space> state(1);
+    std::mt19937_64 rng(0);
     for ([[maybe_unused]] auto _ : std::views::iota(0, 100)) {
         std::uint64_t before = state.sampling(1)[0];
-        probgate->update_quantum_state(state, std::numbers::pi);
+        probgate->update_quantum_state(ExecutionContext<Prec, Space>{state, nullptr, &rng},
+                                       std::numbers::pi);
         std::uint64_t after = state.sampling(1)[0];
         if (before != after) {
             x_cnt++;


### PR DESCRIPTION
- 古典レジスタを追加しました．QulacsではStateVectorが持っていたが，本実装ではCircuitクラスに保持しています．
  - 各update関数にレジスタの情報を渡す必要があったので，ExecutionContextクラスを実装．｛状態ベクトル，レジスタ，乱数生成器｝の３つ組を持つようになっています．
  - 結局これらをセットで扱う都合上，Qulacsの実装が良いのではという気にもなる．Circuit::update_quantum_stateも非constになってしまった．意見求む
  - 乱数生成器を持ったことでprobabilistic_gateでの更新にシードを持たせられるようになった
- 古典分岐を可能にしました．ラムダ式を通じてどの古典レジスタを見るか好きに設定できます．
  - レジスタのBatchedでの扱いに困ったので，2次元配列を1次元に平滑化したと仮定して頑張って持っている．無理のある実装か？
  - `std::vector<bool>` のビュー（boolなのでstd::spanは使えなかった）みたいなのを作ることでそれぞれのバッチに対してインデクスがうまくずれるようになってる
- Measurement関数を追加しました
  - このゲートのみ副作用として古典レジスタに書き込むようになっている
  - normalizeしなきゃいけないので同期も必要．ちゃんと考えていないけど，縮退によってどれだけ値を増やすべきかを考えると同期なくせそう