### PR TITLE
Add Classical Register Class

### DIFF
--- a/include/scaluq/all.hpp
+++ b/include/scaluq/all.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "classical_register/classical_register.hpp"
+#include "classical_register/classical_register_batched.hpp"
 #include "circuit/circuit.hpp"
 #include "constant.hpp"
 #include "gate/gate.hpp"
@@ -23,6 +25,8 @@
 #define SCALUQ_OMIT_TEMPLATE(Prec, Space)                                                      \
     using StateVector = ::scaluq::StateVector<Prec, Space>;                                    \
     using StateVectorBatched = ::scaluq::StateVectorBatched<Prec, Space>;                      \
+    using ClassicalRegister = ::scaluq::ClassicalRegister;                                     \
+    using ClassicalRegisterBatched = ::scaluq::ClassicalRegisterBatched;                       \
     using PauliOperator = ::scaluq::PauliOperator<Prec>;                                       \
     using Operator = ::scaluq::Operator<Prec, Space>;                                          \
     using Gate = ::scaluq::Gate<Prec>;                                                         \

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -61,16 +61,14 @@ public:
                               const std::map<std::string, double>& parameters = {},
                               std::uint64_t seed = std::random_device{}()) const;
     template <ExecutionSpace Space>
-    void update_quantum_state(
-        StateVectorBatched<Prec, Space>& states,
-        const std::map<std::string, std::vector<double>>& parameters = {},
-        std::uint64_t seed = std::random_device{}()) const;
+    void update_quantum_state(StateVectorBatched<Prec, Space>& states,
+                              const std::map<std::string, std::vector<double>>& parameters = {},
+                              std::uint64_t seed = std::random_device{}()) const;
     template <ExecutionSpace Space>
-    void update_quantum_state(
-        StateVectorBatched<Prec, Space>& states,
-        ClassicalRegisterBatched& classical_register,
-        const std::map<std::string, std::vector<double>>& parameters = {},
-        std::uint64_t seed = std::random_device{}()) const;
+    void update_quantum_state(StateVectorBatched<Prec, Space>& states,
+                              ClassicalRegisterBatched& classical_register,
+                              const std::map<std::string, std::vector<double>>& parameters = {},
+                              std::uint64_t seed = std::random_device{}()) const;
 
     Circuit copy() const;
 
@@ -132,9 +130,178 @@ private:
 
 #ifdef SCALUQ_USE_NANOBIND
 namespace internal {
+template <Precision Prec, ExecutionSpace Space>
+void register_circuit_space_bindings(nb::class_<Circuit<Prec>>& c) {
+    using namespace nb::literals;
+
+    c.def(
+         "update_quantum_state",
+         [&](const Circuit<Prec>& circuit, StateVector<Prec, Space>& state, nb::kwargs kwargs) {
+             std::map<std::string, double> parameters;
+             for (auto&& [key, param] : kwargs) {
+                 parameters[nb::cast<std::string>(key)] = nb::cast<double>(param);
+             }
+             circuit.update_quantum_state(state, parameters);
+         },
+         "state"_a,
+         "kwargs"_a,
+         "Apply gate to the StateVector. StateVector in args is directly updated. If the "
+         "circuit contains parametric gate, you have to give real value of parameter as "
+         "\"name=value\" format in kwargs.")
+        .def(
+            "update_quantum_state",
+            [](const Circuit<Prec>& circuit,
+               StateVector<Prec, Space>& state,
+               const std::map<std::string, double>& parameters,
+               std::optional<std::uint64_t> seed) {
+                circuit.update_quantum_state(
+                    state, parameters, seed.value_or(std::random_device{}()));
+            },
+            "state"_a,
+            "params"_a = std::map<std::string, double>{},
+            "seed"_a = std::nullopt,
+            "Apply gate to the StateVector. StateVector in args is directly updated. If the "
+            "circuit contains parametric gate, you have to give real value of parameter as "
+            "dict[str, float] in 2nd arg.")
+        .def(
+            "update_quantum_state",
+            [](const Circuit<Prec>& circuit,
+               StateVector<Prec, Space>& state,
+               ClassicalRegister& classical_register,
+               const std::map<std::string, double>& parameters,
+               std::optional<std::uint64_t> seed) {
+                circuit.update_quantum_state(
+                    state, classical_register, parameters, seed.value_or(std::random_device{}()));
+            },
+            "state"_a,
+            "classical_register"_a,
+            "params"_a = std::map<std::string, double>{},
+            "seed"_a = std::nullopt,
+            "Apply gate to the StateVector with classical register and optional seed.")
+        .def(
+            "update_quantum_state",
+            [&](const Circuit<Prec>& circuit,
+                StateVector<Prec, Space>& state,
+                ClassicalRegister& classical_register,
+                nb::kwargs kwargs) {
+                std::map<std::string, double> parameters;
+                for (auto&& [key, param] : kwargs) {
+                    parameters[nb::cast<std::string>(key)] = nb::cast<double>(param);
+                }
+                circuit.update_quantum_state(state, classical_register, parameters);
+            },
+            "state"_a,
+            "classical_register"_a,
+            "kwargs"_a,
+            "Apply gate to the StateVector with classical register. If the circuit contains "
+            "parametric gate, give parameter values as \"name=value\" in kwargs.")
+        .def(
+            "update_quantum_state",
+            [&](const Circuit<Prec>& circuit,
+                StateVectorBatched<Prec, Space>& states,
+                nb::kwargs kwargs) {
+                std::map<std::string, std::vector<double>> parameters;
+                for (auto&& [key, param] : kwargs) {
+                    parameters[nb::cast<std::string>(key)] = nb::cast<std::vector<double>>(param);
+                }
+                circuit.update_quantum_state(states, parameters);
+            },
+            "state"_a,
+            "kwargs"_a,
+            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
+            "If the circuit contains parametric gate, you have to give real value of parameter as "
+            "\"name=[value1, value2, ...]\" format in kwargs.")
+        .def(
+            "update_quantum_state",
+            [](const Circuit<Prec>& circuit,
+               StateVectorBatched<Prec, Space>& states,
+               const std::map<std::string, std::vector<double>>& parameters,
+               std::optional<std::uint64_t> seed) {
+                circuit.update_quantum_state(
+                    states, parameters, seed.value_or(std::random_device{}()));
+            },
+            "state"_a,
+            "params"_a = std::map<std::string, std::vector<double>>{},
+            "seed"_a = std::nullopt,
+            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
+            "If the circuit contains parametric gate, you have to give real value of parameter as "
+            "dict[str, list[float]] in 2nd arg.")
+        .def(
+            "update_quantum_state",
+            [](const Circuit<Prec>& circuit,
+               StateVectorBatched<Prec, Space>& states,
+               ClassicalRegisterBatched& classical_register,
+               const std::map<std::string, std::vector<double>>& parameters,
+               std::optional<std::uint64_t> seed) {
+                circuit.update_quantum_state(
+                    states, classical_register, parameters, seed.value_or(std::random_device{}()));
+            },
+            "state"_a,
+            "classical_register"_a,
+            "params"_a = std::map<std::string, std::vector<double>>{},
+            "seed"_a = std::nullopt,
+            "Apply gate to the StateVectorBatched with classical register and optional seed.")
+        .def(
+            "update_quantum_state",
+            [&](const Circuit<Prec>& circuit,
+                StateVectorBatched<Prec, Space>& states,
+                ClassicalRegisterBatched& classical_register,
+                nb::kwargs kwargs) {
+                std::map<std::string, std::vector<double>> parameters;
+                for (auto&& [key, param] : kwargs) {
+                    parameters[nb::cast<std::string>(key)] = nb::cast<std::vector<double>>(param);
+                }
+                circuit.update_quantum_state(states, classical_register, parameters);
+            },
+            "state"_a,
+            "classical_register"_a,
+            "kwargs"_a,
+            "Apply gate to the StateVectorBatched with classical register. If the circuit "
+            "contains parametric gate, give parameter values as "
+            "\"name=[value1, value2, ...]\" in kwargs.")
+        .def("optimize",
+             nb::overload_cast<std::uint64_t>(&Circuit<Prec>::template optimize<Space>),
+             "max_block_size"_a = 3,
+             "Optimize circuit. Create qubit dependency tree and merge neighboring gates if the "
+             "new gate has less than or equal to `max_block_size` or the new gate is Pauli.")
+        .def(
+            "simulate_noise",
+            [](const Circuit<Prec>& circuit,
+               const StateVector<Prec, Space>& initial_state,
+               std::uint64_t sampling_count,
+               const std::map<std::string, double>& parameters,
+               std::optional<std::uint64_t> seed) {
+                return circuit.template simulate_noise<Space>(
+                    initial_state,
+                    sampling_count,
+                    parameters,
+                    seed.value_or(std::random_device{}()));
+            },
+            "initial_state"_a,
+            "sampling_count"_a,
+            "parameters"_a = std::map<std::string, double>{},
+            "seed"_a = std::nullopt,
+            "Simulate noise circuit. Return all the possible states and their counts.")
+        .def("compute_expectation_gradient_backprop",
+             &Circuit<Prec>::template compute_expectation_gradient_backprop<Space>,
+             "state"_a,
+             "bistate"_a,
+             "parameters"_a,
+             "Low-level implementation for expectation gradient that assumes the forward state and "
+             "observable-applied bistate are already prepared, and computes gradient using back "
+             "propagation.")
+        .def("compute_expectation_gradient",
+             &Circuit<Prec>::template compute_expectation_gradient<Space>,
+             "observable"_a,
+             "parameters"_a,
+             "Compute gradient of expectation value of observable using back propagation.");
+}
+
 template <Precision Prec>
 void bind_circuit_circuit_hpp(nb::module_& m) {
-    nb::class_<Circuit<Prec>>(
+    using namespace nb::literals;
+
+    auto c = nb::class_<Circuit<Prec>>(
         m,
         "Circuit",
         DocString()
@@ -142,8 +309,9 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
             .ex(DocString::Code(
                 {">>> circuit = Circuit()", ">>> print(circuit.to_json())", "{\"gate_list\":[]}"}))
             .build_as_google_style()
-            .c_str())
-        .def(nb::init<>(), "Initialize empty circuit.")
+            .c_str());
+
+    c.def(nb::init<>(), "Initialize empty circuit.")
         .def("gate_list",
              &Circuit<Prec>::gate_list,
              "Get property of `gate_list`.",
@@ -170,277 +338,6 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
              nb::overload_cast<const Circuit<Prec>&>(&Circuit<Prec>::add_circuit),
              "other"_a,
              "Add all gates in specified circuit. Given gates are copied.")
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVector<Prec, ExecutionSpace::Host>& state,
-                nb::kwargs kwargs) {
-                std::map<std::string, double> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<double>(param);
-                }
-                circuit.update_quantum_state(state, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-            "circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=value\" format in kwargs.")
-        .def("update_quantum_state",
-             nb::overload_cast<StateVector<Prec, ExecutionSpace::Host>&,
-                               const std::map<std::string, double>&>(
-                 &Circuit<Prec>::template update_quantum_state<ExecutionSpace::Host>, nb::const_),
-             "state"_a,
-             "params"_a,
-             "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-             "circuit contains parametric gate, you have to give real value of parameter as "
-             "dict[str, float] in 2nd arg.")
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVectorBatched<Prec, ExecutionSpace::Host>& states,
-                nb::kwargs kwargs) {
-                std::map<std::string, std::vector<double>> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<std::vector<double>>(param);
-                }
-                circuit.update_quantum_state(states, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=[value1, value2, ...]\" format in kwargs.")
-        .def(
-            "update_quantum_state",
-            nb::overload_cast<StateVectorBatched<Prec, ExecutionSpace::Host>&,
-                              const std::map<std::string, std::vector<double>>&>(
-                &Circuit<Prec>::template update_quantum_state<ExecutionSpace::Host>, nb::const_),
-            "state"_a,
-            "params"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "dict[str, list[float]] in 2nd arg.")
-        .def("optimize",
-             nb::overload_cast<std::uint64_t>(
-                 &Circuit<Prec>::template optimize<ExecutionSpace::Host>),
-             "max_block_size"_a = 3,
-             "Optimize circuit. Create qubit dependency tree and merge neighboring gates if the "
-             "new gate has less than or equal to `max_block_size` or the new gate is Pauli.")
-        .def(
-            "simulate_noise",
-            [](const Circuit<Prec>& circuit,
-               const StateVector<Prec, ExecutionSpace::Host>& initial_state,
-               std::uint64_t sampling_count,
-               const std::map<std::string, double>& parameters,
-               std::optional<std::uint64_t> seed) {
-                return circuit.template simulate_noise<ExecutionSpace::Host>(
-                    initial_state,
-                    sampling_count,
-                    parameters,
-                    seed.value_or(std::random_device{}()));
-            },
-            "initial_state"_a,
-            "sampling_count"_a,
-            "parameters"_a = std::map<std::string, double>{},
-            "seed"_a = std::nullopt,
-            "Simulate noise circuit. Return all the possible states and their counts.")
-        .def("compute_expectation_gradient_backprop",
-             &Circuit<Prec>::template compute_expectation_gradient_backprop<ExecutionSpace::Host>,
-             "state"_a,
-             "bistate"_a,
-             "parameters"_a,
-             "Low-level implementation for expectation gradient that assumes the forward state and "
-             "observable-applied bistate are already prepared, and computes gradient using back "
-             "propagation.")
-        .def("compute_expectation_gradient",
-             &Circuit<Prec>::template compute_expectation_gradient<ExecutionSpace::Host>,
-             "observable"_a,
-             "parameters"_a,
-             "Compute gradient of expectation value of observable using back propagation.")
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVector<Prec, ExecutionSpace::HostSerial>& state,
-                nb::kwargs kwargs) {
-                std::map<std::string, double> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<double>(param);
-                }
-                circuit.update_quantum_state(state, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-            "circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=value\" format in kwargs.")
-        .def("update_quantum_state",
-             nb::overload_cast<StateVector<Prec, ExecutionSpace::HostSerial>&,
-                               const std::map<std::string, double>&>(
-                 &Circuit<Prec>::template update_quantum_state<ExecutionSpace::HostSerial>,
-                 nb::const_),
-             "state"_a,
-             "params"_a,
-             "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-             "circuit contains parametric gate, you have to give real value of parameter as "
-             "dict[str, float] in 2nd arg.")
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-                nb::kwargs kwargs) {
-                std::map<std::string, std::vector<double>> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<std::vector<double>>(param);
-                }
-                circuit.update_quantum_state(states, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=[value1, value2, ...]\" format in kwargs.")
-        .def(
-            "update_quantum_state",
-            nb::overload_cast<StateVectorBatched<Prec, ExecutionSpace::HostSerial>&,
-                              const std::map<std::string, std::vector<double>>&>(
-                &Circuit<Prec>::template update_quantum_state<ExecutionSpace::HostSerial>,
-                nb::const_),
-            "state"_a,
-            "params"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "dict[str, list[float]] in 2nd arg.")
-        .def("optimize",
-             nb::overload_cast<std::uint64_t>(
-                 &Circuit<Prec>::template optimize<ExecutionSpace::HostSerial>),
-             "max_block_size"_a = 3,
-             "Optimize circuit. Create qubit dependency tree and merge neighboring gates if the "
-             "new gate has less than or equal to `max_block_size` or the new gate is Pauli.")
-        .def(
-            "simulate_noise",
-            [](const Circuit<Prec>& circuit,
-               const StateVector<Prec, ExecutionSpace::HostSerial>& initial_state,
-               std::uint64_t sampling_count,
-               const std::map<std::string, double>& parameters,
-               std::optional<std::uint64_t> seed) {
-                return circuit.template simulate_noise<ExecutionSpace::HostSerial>(
-                    initial_state,
-                    sampling_count,
-                    parameters,
-                    seed.value_or(std::random_device{}()));
-            },
-            "initial_state"_a,
-            "sampling_count"_a,
-            "parameters"_a = std::map<std::string, double>{},
-            "seed"_a = std::nullopt,
-            "Simulate noise circuit. Return all the possible states and their counts.")
-        .def("compute_expectation_gradient_backprop",
-             &Circuit<Prec>::template compute_expectation_gradient_backprop<
-                 ExecutionSpace::HostSerial>,
-             "state"_a,
-             "bistate"_a,
-             "parameters"_a,
-             "Low-level implementation for expectation gradient that assumes the forward state and "
-             "observable-applied bistate are already prepared, and computes gradient using back "
-             "propagation.")
-        .def("compute_expectation_gradient",
-             &Circuit<Prec>::template compute_expectation_gradient<ExecutionSpace::HostSerial>,
-             "observable"_a,
-             "parameters"_a,
-             "Compute gradient of expectation value of observable using back propagation.")
-#ifdef SCALUQ_USE_CUDA
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVector<Prec, ExecutionSpace::Default>& state,
-                nb::kwargs kwargs) {
-                std::map<std::string, double> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<double>(param);
-                }
-                circuit.update_quantum_state(state, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-            "circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=value\" format in kwargs.")
-        .def(
-            "update_quantum_state",
-            nb::overload_cast<StateVector<Prec, ExecutionSpace::Default>&,
-                              const std::map<std::string, double>&>(
-                &Circuit<Prec>::template update_quantum_state<ExecutionSpace::Default>, nb::const_),
-            "state"_a,
-            "params"_a,
-            "Apply gate to the StateVector. StateVector in args is directly updated. If the "
-            "circuit contains parametric gate, you have to give real value of parameter as "
-            "dict[str, float] in 2nd arg.")
-        .def(
-            "update_quantum_state",
-            [&](const Circuit<Prec>& circuit,
-                StateVectorBatched<Prec, ExecutionSpace::Default>& states,
-                nb::kwargs kwargs) {
-                std::map<std::string, std::vector<double>> parameters;
-                for (auto&& [key, param] : kwargs) {
-                    parameters[nb::cast<std::string>(key)] = nb::cast<std::vector<double>>(param);
-                }
-                circuit.update_quantum_state(states, parameters);
-            },
-            "state"_a,
-            "kwargs"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "\"name=[value1, value2, ...]\" format in kwargs.")
-        .def(
-            "update_quantum_state",
-            nb::overload_cast<StateVectorBatched<Prec, ExecutionSpace::Default>&,
-                              const std::map<std::string, std::vector<double>>&>(
-                &Circuit<Prec>::template update_quantum_state<ExecutionSpace::Default>, nb::const_),
-            "state"_a,
-            "params"_a,
-            "Apply gate to the StateVectorBatched. StateVectorBatched in args is directly updated. "
-            "If the circuit contains parametric gate, you have to give real value of parameter as "
-            "dict[str, list[float]] in 2nd arg.")
-        .def("optimize",
-             nb::overload_cast<std::uint64_t>(
-                 &Circuit<Prec>::template optimize<ExecutionSpace::Default>),
-             "max_block_size"_a = 3,
-             "Optimize circuit. Create qubit dependency tree and merge neighboring gates if the "
-             "new gate has less than or equal to `max_block_size` or the new gate is Pauli.")
-        .def(
-            "simulate_noise",
-            [](const Circuit<Prec>& circuit,
-               const StateVector<Prec, ExecutionSpace::Default>& initial_state,
-               std::uint64_t sampling_count,
-               const std::map<std::string, double>& parameters,
-               std::optional<std::uint64_t> seed) {
-                return circuit.template simulate_noise<ExecutionSpace::Default>(
-                    initial_state,
-                    sampling_count,
-                    parameters,
-                    seed.value_or(std::random_device{}()));
-            },
-            "initial_state"_a,
-            "sampling_count"_a,
-            "parameters"_a = std::map<std::string, double>{},
-            "seed"_a = std::nullopt,
-            "Simulate noise circuit. Return all the possible states and their counts.")
-        .def(
-            "compute_expectation_gradient_backprop",
-            &Circuit<Prec>::template compute_expectation_gradient_backprop<ExecutionSpace::Default>,
-            "state"_a,
-            "bistate"_a,
-            "parameters"_a,
-            "Low-level implementation for expectation gradient that assumes the forward state and "
-            "observable-applied bistate are already prepared, and computes gradient using back "
-            "propagation.")
-        .def("compute_expectation_gradient",
-             &Circuit<Prec>::template compute_expectation_gradient<ExecutionSpace::Default>,
-             "observable"_a,
-             "parameters"_a,
-             "Compute gradient of expectation value of observable using back propagation.")
-#endif  // SCALUQ_USE_CUDA
         .def("copy",
              &Circuit<Prec>::copy,
              "Copy circuit. Returns a new circuit instance with all gates copied by reference.")
@@ -458,6 +355,12 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
             },
             "json_str"_a,
             "Read an object from the JSON representation of the circuit.");
+
+    register_circuit_space_bindings<Prec, ExecutionSpace::Host>(c);
+    register_circuit_space_bindings<Prec, ExecutionSpace::HostSerial>(c);
+#ifdef SCALUQ_USE_CUDA
+    register_circuit_space_bindings<Prec, ExecutionSpace::Default>(c);
+#endif  // SCALUQ_USE_CUDA
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -2,10 +2,13 @@
 
 #include <bit>
 #include <map>
+#include <random>
 #include <set>
 #include <string_view>
 #include <variant>
 
+#include "../classical_register/classical_register.hpp"
+#include "../classical_register/classical_register_batched.hpp"
 #include "../gate/gate.hpp"
 #include "../gate/param_gate.hpp"
 #include "../operator/operator.hpp"
@@ -50,11 +53,24 @@ public:
 
     template <ExecutionSpace Space>
     void update_quantum_state(StateVector<Prec, Space>& state,
-                              const std::map<std::string, double>& parameters = {}) const;
+                              const std::map<std::string, double>& parameters = {},
+                              std::uint64_t seed = std::random_device{}()) const;
+    template <ExecutionSpace Space>
+    void update_quantum_state(StateVector<Prec, Space>& state,
+                              ClassicalRegister& classical_register,
+                              const std::map<std::string, double>& parameters = {},
+                              std::uint64_t seed = std::random_device{}()) const;
     template <ExecutionSpace Space>
     void update_quantum_state(
         StateVectorBatched<Prec, Space>& states,
-        const std::map<std::string, std::vector<double>>& parameters = {}) const;
+        const std::map<std::string, std::vector<double>>& parameters = {},
+        std::uint64_t seed = std::random_device{}()) const;
+    template <ExecutionSpace Space>
+    void update_quantum_state(
+        StateVectorBatched<Prec, Space>& states,
+        ClassicalRegisterBatched& classical_register,
+        const std::map<std::string, std::vector<double>>& parameters = {},
+        std::uint64_t seed = std::random_device{}()) const;
 
     Circuit copy() const;
 

--- a/include/scaluq/classical_register/classical_register.hpp
+++ b/include/scaluq/classical_register/classical_register.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace scaluq {
+
+class ClassicalRegister {
+private:
+    std::vector<bool> _bits;
+
+public:
+    explicit ClassicalRegister(std::uint64_t size) : _bits(size, false) {}
+
+    [[nodiscard]] std::vector<bool>::reference operator[](std::uint64_t index) {
+        if (index >= _bits.size()) {
+            throw std::runtime_error(
+                "ClassicalRegister::operator[](std::uint64_t): index out of bounds");
+        }
+        return _bits[index];
+    }
+    [[nodiscard]] bool operator[](std::uint64_t index) const {
+        if (index >= _bits.size()) {
+            throw std::runtime_error(
+                "ClassicalRegister::operator[](std::uint64_t): index out of bounds");
+        }
+        return _bits[index];
+    }
+    [[nodiscard]] std::uint64_t register_size() const { return _bits.size(); }
+
+    void reset() {
+        for (auto&& bit : _bits) bit = false;
+    }
+};
+
+}  // namespace scaluq

--- a/include/scaluq/classical_register/classical_register.hpp
+++ b/include/scaluq/classical_register/classical_register.hpp
@@ -4,6 +4,10 @@
 #include <stdexcept>
 #include <vector>
 
+#ifdef SCALUQ_USE_NANOBIND
+#include "../types.hpp"
+#endif
+
 namespace scaluq {
 
 class ClassicalRegister {
@@ -33,5 +37,34 @@ public:
         for (auto&& bit : _bits) bit = false;
     }
 };
+
+#ifdef SCALUQ_USE_NANOBIND
+namespace internal {
+inline void bind_classical_register_hpp(nb::module_& m) {
+    using namespace nb::literals;
+
+    nb::class_<ClassicalRegister>(m, "ClassicalRegister", "Classical register.")
+        .def(nb::init<std::uint64_t>(), "register_size"_a, "Initialize classical register.")
+        .def("register_size", &ClassicalRegister::register_size, "Get register size.")
+        .def("__len__", &ClassicalRegister::register_size, "Get register size.")
+        .def(
+            "__getitem__",
+            [](const ClassicalRegister& classical_register, std::uint64_t index) {
+                return classical_register[index];
+            },
+            "index"_a,
+            "Get classical bit.")
+        .def(
+            "__setitem__",
+            [](ClassicalRegister& classical_register, std::uint64_t index, bool value) {
+                classical_register[index] = value;
+            },
+            "index"_a,
+            "value"_a,
+            "Set classical bit.")
+        .def("reset", &ClassicalRegister::reset, "Reset all bits to `False`.");
+}
+}  // namespace internal
+#endif
 
 }  // namespace scaluq

--- a/include/scaluq/classical_register/classical_register_batched.hpp
+++ b/include/scaluq/classical_register/classical_register_batched.hpp
@@ -4,6 +4,10 @@
 #include <stdexcept>
 #include <vector>
 
+#ifdef SCALUQ_USE_NANOBIND
+#include "../types.hpp"
+#endif
+
 #include "classical_register.hpp"
 
 namespace scaluq {
@@ -45,5 +49,30 @@ public:
         for (auto&& reg : _registers) reg.reset();
     }
 };
+
+#ifdef SCALUQ_USE_NANOBIND
+namespace internal {
+inline void bind_classical_register_batched_hpp(nb::module_& m) {
+    using namespace nb::literals;
+
+    nb::class_<ClassicalRegisterBatched>(m, "ClassicalRegisterBatched", "Batched classical register.")
+        .def(nb::init<std::uint64_t, std::uint64_t>(),
+             "register_size"_a,
+             "batch_size"_a,
+             "Initialize batched classical register.")
+        .def("register_size", &ClassicalRegisterBatched::register_size, "Get register size.")
+        .def("batch_size", &ClassicalRegisterBatched::batch_size, "Get batch size.")
+        .def("__len__", &ClassicalRegisterBatched::batch_size, "Get batch size.")
+        .def(
+            "__getitem__",
+            [](ClassicalRegisterBatched& classical_register, std::uint64_t batch_index)
+                -> ClassicalRegister& { return classical_register[batch_index]; },
+            "batch_index"_a,
+            nb::rv_policy::reference_internal,
+            "Get classical register at `batch_index`.")
+        .def("reset", &ClassicalRegisterBatched::reset, "Reset all bits to `False`.");
+}
+}  // namespace internal
+#endif
 
 }  // namespace scaluq

--- a/include/scaluq/classical_register/classical_register_batched.hpp
+++ b/include/scaluq/classical_register/classical_register_batched.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+#include "classical_register.hpp"
+
+namespace scaluq {
+
+class ClassicalRegisterBatched {
+private:
+    std::vector<ClassicalRegister> _registers;
+    std::uint64_t _register_size = 0;
+
+public:
+    ClassicalRegisterBatched(std::uint64_t register_size, std::uint64_t batch_size)
+        : _registers(batch_size, ClassicalRegister(register_size)), _register_size(register_size) {}
+
+    [[nodiscard]] std::uint64_t register_size() const { return _register_size; }
+    [[nodiscard]] std::uint64_t batch_size() const { return _registers.size(); }
+
+    [[nodiscard]] ClassicalRegister& operator[](std::uint64_t batch_index) {
+        if (batch_index >= _registers.size()) {
+            throw std::runtime_error("ClassicalRegisterBatched: batch index out of bounds");
+        }
+        return _registers[batch_index];
+    }
+    [[nodiscard]] const ClassicalRegister& operator[](std::uint64_t batch_index) const {
+        if (batch_index >= _registers.size()) {
+            throw std::runtime_error("ClassicalRegisterBatched: batch index out of bounds");
+        }
+        return _registers[batch_index];
+    }
+
+    [[nodiscard]] std::vector<bool>::reference operator()(std::uint64_t batch_index,
+                                                          std::uint64_t bit_index) {
+        return (*this)[batch_index][bit_index];
+    }
+    [[nodiscard]] bool operator()(std::uint64_t batch_index, std::uint64_t bit_index) const {
+        return (*this)[batch_index][bit_index];
+    }
+
+    void reset() {
+        for (auto&& reg : _registers) reg.reset();
+    }
+};
+
+}  // namespace scaluq

--- a/include/scaluq/classical_register/classical_register_batched.hpp
+++ b/include/scaluq/classical_register/classical_register_batched.hpp
@@ -55,7 +55,8 @@ namespace internal {
 inline void bind_classical_register_batched_hpp(nb::module_& m) {
     using namespace nb::literals;
 
-    nb::class_<ClassicalRegisterBatched>(m, "ClassicalRegisterBatched", "Batched classical register.")
+    nb::class_<ClassicalRegisterBatched>(
+        m, "ClassicalRegisterBatched", "Batched classical register.")
         .def(nb::init<std::uint64_t, std::uint64_t>(),
              "register_size"_a,
              "batch_size"_a,
@@ -70,6 +71,43 @@ inline void bind_classical_register_batched_hpp(nb::module_& m) {
             "batch_index"_a,
             nb::rv_policy::reference_internal,
             "Get classical register at `batch_index`.")
+        .def(
+            "__setitem__",
+            [](ClassicalRegisterBatched& classical_register,
+               std::uint64_t batch_index,
+               const ClassicalRegister& value) {
+                if (value.register_size() != classical_register.register_size()) {
+                    throw std::runtime_error(
+                        "__setitem__ expects a ClassicalRegister with matching register_size");
+                }
+                classical_register[batch_index] = value;
+            },
+            "batch_index"_a,
+            "value"_a,
+            "Set classical register at `batch_index`.")
+        .def(
+            "__getitem__",
+            [](ClassicalRegisterBatched& classical_register, nb::tuple idx) -> bool {
+                if (nb::len(idx) != 2) {
+                    throw std::runtime_error("__getitem__ expects 2 indices");
+                }
+                auto batch_index = nb::cast<std::uint64_t>(idx[0]);
+                auto bit_index = nb::cast<std::uint64_t>(idx[1]);
+                return classical_register(batch_index, bit_index);
+            },
+            "idx"_a)
+        .def(
+            "__setitem__",
+            [](ClassicalRegisterBatched& classical_register, nb::tuple idx, bool value) {
+                if (nb::len(idx) != 2) {
+                    throw std::runtime_error("__setitem__ expects 2 indices");
+                }
+                auto batch_index = nb::cast<std::uint64_t>(idx[0]);
+                auto bit_index = nb::cast<std::uint64_t>(idx[1]);
+                classical_register(batch_index, bit_index) = value;
+            },
+            "idx"_a,
+            "value"_a)
         .def("reset", &ClassicalRegisterBatched::reset, "Reset all bits to `False`.");
 }
 }  // namespace internal

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -184,6 +184,7 @@ constexpr GateType get_gate_type() {
         static_assert(internal::lazy_false_v<T>, "unknown GateImpl");
 }
 
+namespace internal {
 template <Precision Prec, ExecutionSpace Space>
 struct ExecutionContext {
     StateVector<Prec, Space> state;
@@ -211,10 +212,6 @@ struct ExecutionContextBatched {
           classical_register(classical_register_),
           random_engine(random_engine_) {}
 };
-
-namespace internal {
-using ::scaluq::ExecutionContext;
-using ::scaluq::ExecutionContextBatched;
 
 // GateBase テンプレートクラス
 template <Precision _Prec>

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <random>
 
 #include "../classical_register/classical_register.hpp"
@@ -805,11 +806,37 @@ void register_gate_common_methods(nb::class_<GateT>& c) {
          up_single_ptr)
         .def(
             "update_quantum_state",
+            [](const GateT& gate,
+               StateVector<Prec, ExecutionSpace::Host>& sv,
+               ClassicalRegister& classical_register,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    sv, classical_register, seed.value_or(std::random_device{}()));
+            },
+            "state_vector"_a,
+            "classical_register"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `state_vector` with `classical_register` and `seed`.")
+        .def(
+            "update_quantum_state",
             [](const GateT& gate, StateVectorBatched<Prec, ExecutionSpace::Host>& sv) {
                 gate->update_quantum_state(sv);
             },
             "states"_a,
             up_batched_ptr)
+        .def(
+            "update_quantum_state",
+            [](const GateT& gate,
+               StateVectorBatched<Prec, ExecutionSpace::Host>& sv,
+               ClassicalRegisterBatched& classical_register,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    sv, classical_register, seed.value_or(std::random_device{}()));
+            },
+            "states"_a,
+            "classical_register"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `states` with `classical_register` and `seed`.")
         .def(
             "update_quantum_state",
             [](const GateT& gate, StateVector<Prec, ExecutionSpace::HostSerial>& sv) {
@@ -819,11 +846,37 @@ void register_gate_common_methods(nb::class_<GateT>& c) {
             up_single_ptr)
         .def(
             "update_quantum_state",
+            [](const GateT& gate,
+               StateVector<Prec, ExecutionSpace::HostSerial>& sv,
+               ClassicalRegister& classical_register,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    sv, classical_register, seed.value_or(std::random_device{}()));
+            },
+            "state_vector"_a,
+            "classical_register"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `state_vector` with `classical_register` and `seed`.")
+        .def(
+            "update_quantum_state",
             [](const GateT& gate, StateVectorBatched<Prec, ExecutionSpace::HostSerial>& sv) {
                 gate->update_quantum_state(sv);
             },
             "states"_a,
-            up_batched_ptr);
+            up_batched_ptr)
+        .def(
+            "update_quantum_state",
+            [](const GateT& gate,
+               StateVectorBatched<Prec, ExecutionSpace::HostSerial>& sv,
+               ClassicalRegisterBatched& classical_register,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    sv, classical_register, seed.value_or(std::random_device{}()));
+            },
+            "states"_a,
+            "classical_register"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `states` with `classical_register` and `seed`.");
 
 #ifdef SCALUQ_USE_CUDA
     c.def(
@@ -835,11 +888,37 @@ void register_gate_common_methods(nb::class_<GateT>& c) {
          up_single_ptr)
         .def(
             "update_quantum_state",
+            [](const GateT& gate,
+               StateVector<Prec, ExecutionSpace::Default>& sv,
+               ClassicalRegister& classical_register,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    sv, classical_register, seed.value_or(std::random_device{}()));
+            },
+            "state_vector"_a,
+            "classical_register"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `state_vector` with `classical_register` and `seed`.")
+        .def(
+            "update_quantum_state",
             [](const GateT& gate, StateVectorBatched<Prec, ExecutionSpace::Default>& sv) {
                 gate->update_quantum_state(sv);
             },
             "states"_a,
-            up_batched_ptr);
+            up_batched_ptr)
+        .def(
+            "update_quantum_state",
+            [](const GateT& gate,
+               StateVectorBatched<Prec, ExecutionSpace::Default>& sv,
+               ClassicalRegisterBatched& classical_register,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    sv, classical_register, seed.value_or(std::random_device{}()));
+            },
+            "states"_a,
+            "classical_register"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `states` with `classical_register` and `seed`.");
 #endif
 }
 

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <random>
+
+#include "../classical_register/classical_register.hpp"
+#include "../classical_register/classical_register_batched.hpp"
 #include "../state/state_vector.hpp"
 #include "../state/state_vector_batched.hpp"
 #include "../types.hpp"
@@ -179,7 +183,38 @@ constexpr GateType get_gate_type() {
         static_assert(internal::lazy_false_v<T>, "unknown GateImpl");
 }
 
+template <Precision Prec, ExecutionSpace Space>
+struct ExecutionContext {
+    StateVector<Prec, Space> state;
+    ClassicalRegister& classical_register;
+    std::mt19937_64& random_engine;
+
+    ExecutionContext(StateVector<Prec, Space>& state_,
+                     ClassicalRegister& classical_register_,
+                     std::mt19937_64& random_engine_)
+        : state(state_),
+          classical_register(classical_register_),
+          random_engine(random_engine_) {}
+};
+
+template <Precision Prec, ExecutionSpace Space>
+struct ExecutionContextBatched {
+    StateVectorBatched<Prec, Space> states;
+    ClassicalRegisterBatched& classical_register;
+    std::mt19937_64& random_engine;
+
+    ExecutionContextBatched(StateVectorBatched<Prec, Space>& states_,
+                            ClassicalRegisterBatched& classical_register_,
+                            std::mt19937_64& random_engine_)
+        : states(states_),
+          classical_register(classical_register_),
+          random_engine(random_engine_) {}
+};
+
 namespace internal {
+using ::scaluq::ExecutionContext;
+using ::scaluq::ExecutionContextBatched;
+
 // GateBase テンプレートクラス
 template <Precision _Prec>
 class GateBase : public std::enable_shared_from_this<GateBase<_Prec>> {
@@ -236,20 +271,115 @@ public:
     [[nodiscard]] virtual std::shared_ptr<const GateBase<Prec>> get_inverse() const = 0;
     [[nodiscard]] virtual ComplexMatrix get_matrix() const = 0;
 
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const {
+        ClassicalRegister classical_register(0);
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(
+            ExecutionContext<Prec, ExecutionSpace::Host>{state_vector, classical_register, random_engine});
+    }
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+                              ClassicalRegister& classical_register,
+                              std::uint64_t seed = std::random_device{}()) const {
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>{
+            state_vector, classical_register, random_engine});
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states) const {
+        ClassicalRegisterBatched classical_register(0, states.batch_size());
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::Host>{
+            states, classical_register, random_engine});
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
+                              ClassicalRegisterBatched& classical_register,
+                              std::uint64_t seed = std::random_device{}()) const {
+        if (classical_register.batch_size() != states.batch_size()) {
+            throw std::runtime_error(
+                "GateBase::update_quantum_state(StateVectorBatched&, ClassicalRegisterBatched&, "
+                "...): batch size mismatch.");
+        }
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(
+            ExecutionContextBatched<Prec, ExecutionSpace::Host>{states, classical_register, random_engine});
+    }
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const {
+        ClassicalRegister classical_register(0);
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial>{
+            state_vector, classical_register, random_engine});
+    }
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+                              ClassicalRegister& classical_register,
+                              std::uint64_t seed = std::random_device{}()) const {
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial>{
+            state_vector, classical_register, random_engine});
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states) const {
+        ClassicalRegisterBatched classical_register(0, states.batch_size());
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>{
+            states, classical_register, random_engine});
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+                              ClassicalRegisterBatched& classical_register,
+                              std::uint64_t seed = std::random_device{}()) const {
+        if (classical_register.batch_size() != states.batch_size()) {
+            throw std::runtime_error(
+                "GateBase::update_quantum_state(StateVectorBatched&, ClassicalRegisterBatched&, "
+                "...): batch size mismatch.");
+        }
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>{
+            states, classical_register, random_engine});
+    }
+#ifdef SCALUQ_USE_CUDA
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector) const {
+        ClassicalRegister classical_register(0);
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(
+            ExecutionContext<Prec, ExecutionSpace::Default>{state_vector, classical_register, random_engine});
+    }
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+                              ClassicalRegister& classical_register,
+                              std::uint64_t seed = std::random_device{}()) const {
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default>{
+            state_vector, classical_register, random_engine});
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states) const {
+        ClassicalRegisterBatched classical_register(0, states.batch_size());
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::Default>{
+            states, classical_register, random_engine});
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
+                              ClassicalRegisterBatched& classical_register,
+                              std::uint64_t seed = std::random_device{}()) const {
+        if (classical_register.batch_size() != states.batch_size()) {
+            throw std::runtime_error(
+                "GateBase::update_quantum_state(StateVectorBatched&, ClassicalRegisterBatched&, "
+                "...): batch size mismatch.");
+        }
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(
+            ExecutionContextBatched<Prec, ExecutionSpace::Default>{states, classical_register, random_engine});
+    }
+#endif  // SCALUQ_USE_CUDA
     virtual void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Host>& state_vector) const = 0;
+        ExecutionContext<Prec, ExecutionSpace::Host> context) const = 0;
     virtual void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& states) const = 0;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const = 0;
     virtual void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const = 0;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const = 0;
     virtual void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states) const = 0;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const = 0;
 #ifdef SCALUQ_USE_CUDA
     virtual void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const = 0;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const = 0;
     virtual void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& states) const = 0;
-#endif  // SCALUQ_USE_CUDA
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const = 0;
+#endif
 
     [[nodiscard]] virtual std::string to_string(const std::string& indent = "") const = 0;
 

--- a/include/scaluq/gate/gate_matrix.hpp
+++ b/include/scaluq/gate/gate_matrix.hpp
@@ -22,24 +22,27 @@ public:
                         const ComplexMatrix& mat,
                         bool is_unitary = false);
 
+    using GateBase<Prec>::update_quantum_state;
+
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override;
 
     Matrix<Prec, Space> get_matrix_internal() const;
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -64,6 +67,8 @@ public:
                          std::uint64_t control_value_mask,
                          const SparseComplexMatrix& mat);
 
+    using GateBase<Prec>::update_quantum_state;
+
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override;
 
     Matrix<Prec, Space> get_matrix_internal() const;
@@ -72,18 +77,19 @@ public:
 
     SparseComplexMatrix get_sparse_matrix() const { return get_matrix().sparseView(); }
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/gate_pauli.hpp
+++ b/include/scaluq/gate/gate_pauli.hpp
@@ -21,6 +21,8 @@ public:
               vector_to_mask<false>(pauli.target_qubit_list()), control_mask, control_value_mask),
           _pauli(pauli) {}
 
+    using GateBase<Prec>::update_quantum_state;
+
     PauliOperator<Prec> pauli() const { return _pauli; };
     std::vector<std::uint64_t> pauli_id_list() const { return _pauli.pauli_id_list(); }
 
@@ -29,18 +31,19 @@ public:
     }
     ComplexMatrix get_matrix() const override { return this->_pauli.get_matrix(); }
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& states) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& states) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -68,6 +71,8 @@ public:
           _pauli(pauli),
           _angle(angle) {}
 
+    using GateBase<Prec>::update_quantum_state;
+
     PauliOperator<Prec> pauli() const { return _pauli; }
     std::vector<std::uint64_t> pauli_id_list() const { return _pauli.pauli_id_list(); }
     double angle() const { return static_cast<double>(_angle); }
@@ -79,18 +84,19 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& states) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& states) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/gate_probabilistic.hpp
+++ b/include/scaluq/gate/gate_probabilistic.hpp
@@ -15,6 +15,7 @@ class ProbabilisticGateImpl : public GateBase<Prec> {
 public:
     ProbabilisticGateImpl(const std::vector<double>& distribution,
                           const std::vector<Gate<Prec>>& gate_list);
+    using GateBase<Prec>::update_quantum_state;
     const std::vector<Gate<Prec>>& gate_list() const { return _gate_list; }
     const std::vector<double>& distribution() const { return _distribution; }
 
@@ -64,18 +65,19 @@ public:
             "ProbabilisticGateImpl.");
     }
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -11,23 +11,26 @@ class IGateImpl : public GateBase<Prec> {
 public:
     IGateImpl() : GateBase<Prec>(0, 0, 0) {}
 
+    using GateBase<Prec>::update_quantum_state;
+
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return this->shared_from_this();
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -46,6 +49,8 @@ public:
                         Float<Prec> phase)
         : GateBase<Prec>(0, control_mask, control_value_mask), _phase(phase){};
 
+    using GateBase<Prec>::update_quantum_state;
+
     [[nodiscard]] double phase() const { return _phase; }
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
@@ -54,18 +59,19 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -98,24 +104,25 @@ template <Precision Prec>
 class XGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return this->shared_from_this();
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -132,24 +139,25 @@ template <Precision Prec>
 class YGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return this->shared_from_this();
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -166,24 +174,25 @@ template <Precision Prec>
 class ZGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return this->shared_from_this();
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -200,24 +209,25 @@ template <Precision Prec>
 class HGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return this->shared_from_this();
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -251,6 +261,7 @@ template <Precision Prec>
 class SGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const SdagGateImpl<Prec>>(
@@ -258,18 +269,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -286,6 +297,7 @@ template <Precision Prec>
 class SdagGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const SGateImpl<Prec>>(
@@ -293,18 +305,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -321,6 +333,7 @@ template <Precision Prec>
 class TGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const TdagGateImpl<Prec>>(
@@ -328,18 +341,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -356,6 +369,7 @@ template <Precision Prec>
 class TdagGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const TGateImpl<Prec>>(
@@ -363,18 +377,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -391,6 +405,7 @@ template <Precision Prec>
 class SqrtXGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const SqrtXdagGateImpl<Prec>>(
@@ -399,18 +414,18 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -427,6 +442,7 @@ template <Precision Prec>
 class SqrtXdagGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const SqrtXGateImpl<Prec>>(
@@ -434,18 +450,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -462,6 +478,7 @@ template <Precision Prec>
 class SqrtYGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const SqrtYdagGateImpl<Prec>>(
@@ -470,18 +487,18 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -498,6 +515,7 @@ template <Precision Prec>
 class SqrtYdagGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const SqrtYGateImpl<Prec>>(
@@ -505,18 +523,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -533,24 +551,25 @@ template <Precision Prec>
 class P0GateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         throw std::runtime_error("P0::get_inverse: Projection gate doesn't have inverse gate");
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -567,24 +586,25 @@ template <Precision Prec>
 class P1GateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         throw std::runtime_error("P1::get_inverse: Projection gate doesn't have inverse gate");
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -601,6 +621,7 @@ template <Precision Prec>
 class RXGateImpl : public RotationGateBase<Prec> {
 public:
     using RotationGateBase<Prec>::RotationGateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const RXGateImpl<Prec>>(
@@ -608,18 +629,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -637,6 +658,7 @@ template <Precision Prec>
 class RYGateImpl : public RotationGateBase<Prec> {
 public:
     using RotationGateBase<Prec>::RotationGateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const RYGateImpl<Prec>>(
@@ -644,18 +666,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -673,6 +695,7 @@ template <Precision Prec>
 class RZGateImpl : public RotationGateBase<Prec> {
 public:
     using RotationGateBase<Prec>::RotationGateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return std::make_shared<const RZGateImpl<Prec>>(
@@ -680,18 +703,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -710,6 +733,8 @@ class U1GateImpl : public GateBase<Prec> {
     Float<Prec> _lambda;
 
 public:
+    using GateBase<Prec>::update_quantum_state;
+
     U1GateImpl(std::uint64_t target_mask,
                std::uint64_t control_mask,
                std::uint64_t control_value_mask,
@@ -724,18 +749,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -753,6 +778,8 @@ class U2GateImpl : public GateBase<Prec> {
     Float<Prec> _phi, _lambda;
 
 public:
+    using GateBase<Prec>::update_quantum_state;
+
     U2GateImpl(std::uint64_t target_mask,
                std::uint64_t control_mask,
                std::uint64_t control_value_mask,
@@ -775,18 +802,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -806,6 +833,8 @@ class U3GateImpl : public GateBase<Prec> {
     Float<Prec> _theta, _phi, _lambda;
 
 public:
+    using GateBase<Prec>::update_quantum_state;
+
     U3GateImpl(std::uint64_t target_mask,
                std::uint64_t control_mask,
                std::uint64_t control_value_mask,
@@ -831,18 +860,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -862,24 +891,25 @@ template <Precision Prec>
 class SwapGateImpl : public GateBase<Prec> {
 public:
     using GateBase<Prec>::GateBase;
+    using GateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const GateBase<Prec>> get_inverse() const override {
         return this->shared_from_this();
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Host>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::HostSerial>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        StateVector<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
     void update_quantum_state(
-        StateVectorBatched<Prec, ExecutionSpace::Default>& state_vector) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/param_gate.hpp
+++ b/include/scaluq/gate/param_gate.hpp
@@ -436,11 +436,41 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
         .def(
             "update_quantum_state",
             [](const GateT& gate,
+               StateVector<Prec, ExecutionSpace::Host>& state_vector,
+               ClassicalRegister& classical_register,
+               double param,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    state_vector, classical_register, param, seed.value_or(std::random_device{}()));
+            },
+            "state"_a,
+            "classical_register"_a,
+            "param"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `state_vector` with `classical_register`, parameter, and `seed`.")
+        .def(
+            "update_quantum_state",
+            [](const GateT& gate,
                StateVectorBatched<Prec, ExecutionSpace::Host>& states,
                const std::vector<double>& params) { gate->update_quantum_state(states, params); },
             "states"_a,
             "params"_a,
             "updated.")
+        .def(
+            "update_quantum_state",
+            [](const GateT& gate,
+               StateVectorBatched<Prec, ExecutionSpace::Host>& states,
+               ClassicalRegisterBatched& classical_register,
+               const std::vector<double>& params,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    states, classical_register, params, seed.value_or(std::random_device{}()));
+            },
+            "states"_a,
+            "classical_register"_a,
+            "params"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `states` with `classical_register`, parameters, and `seed`.")
         .def(
             "update_quantum_state",
             [](const GateT& gate,
@@ -453,12 +483,42 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
         .def(
             "update_quantum_state",
             [](const GateT& gate,
+               StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+               ClassicalRegister& classical_register,
+               double param,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    state_vector, classical_register, param, seed.value_or(std::random_device{}()));
+            },
+            "state"_a,
+            "classical_register"_a,
+            "param"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `state_vector` with `classical_register`, parameter, and `seed`.")
+        .def(
+            "update_quantum_state",
+            [](const GateT& gate,
                StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
                const std::vector<double>& params) { gate->update_quantum_state(states, params); },
             "states"_a,
             "params"_a,
             "Apply gate to `states` with holding the parameters. `states` in args is directly "
             "updated.")
+        .def(
+            "update_quantum_state",
+            [](const GateT& gate,
+               StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+               ClassicalRegisterBatched& classical_register,
+               const std::vector<double>& params,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    states, classical_register, params, seed.value_or(std::random_device{}()));
+            },
+            "states"_a,
+            "classical_register"_a,
+            "params"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `states` with `classical_register`, parameters, and `seed`.")
 #ifdef SCALUQ_USE_CUDA
         .def(
             "update_quantum_state",
@@ -472,12 +532,42 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
         .def(
             "update_quantum_state",
             [](const GateT& gate,
+               StateVector<Prec, ExecutionSpace::Default>& state_vector,
+               ClassicalRegister& classical_register,
+               double param,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    state_vector, classical_register, param, seed.value_or(std::random_device{}()));
+            },
+            "state"_a,
+            "classical_register"_a,
+            "param"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `state_vector` with `classical_register`, parameter, and `seed`.")
+        .def(
+            "update_quantum_state",
+            [](const GateT& gate,
                StateVectorBatched<Prec, ExecutionSpace::Default>& states,
                const std::vector<double>& params) { gate->update_quantum_state(states, params); },
             "states"_a,
             "params"_a,
             "Apply gate to `states` with holding the parameters. `states` in args is directly "
             "updated.")
+        .def(
+            "update_quantum_state",
+            [](const GateT& gate,
+               StateVectorBatched<Prec, ExecutionSpace::Default>& states,
+               ClassicalRegisterBatched& classical_register,
+               const std::vector<double>& params,
+               std::optional<std::uint64_t> seed) {
+                gate->update_quantum_state(
+                    states, classical_register, params, seed.value_or(std::random_device{}()));
+            },
+            "states"_a,
+            "classical_register"_a,
+            "params"_a,
+            "seed"_a = std::nullopt,
+            "Apply gate to `states` with `classical_register`, parameters, and `seed`.")
 #endif  // SCALUQ_USE_CUDA
         .def(
             "get_matrix",

--- a/include/scaluq/gate/param_gate.hpp
+++ b/include/scaluq/gate/param_gate.hpp
@@ -3,6 +3,7 @@
 #include "../state/state_vector.hpp"
 #include "../state/state_vector_batched.hpp"
 #include "../types.hpp"
+#include "gate.hpp"
 
 namespace scaluq {
 namespace internal {
@@ -112,20 +113,163 @@ public:
     [[nodiscard]] virtual std::shared_ptr<const ParamGateBase<Prec>> get_inverse() const = 0;
     [[nodiscard]] virtual ComplexMatrix get_matrix(double param) const = 0;
 
-    virtual void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
-                                      double param) const = 0;
-    virtual void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
-                                      std::vector<double> params) const = 0;
-    virtual void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
-                                      double param) const = 0;
-    virtual void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-                                      std::vector<double> params) const = 0;
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+                              double param) const {
+        ClassicalRegister classical_register(0);
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(
+            ExecutionContext<Prec, ExecutionSpace::Host>{state_vector, classical_register, random_engine},
+            param);
+    }
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+                              ClassicalRegister& classical_register,
+                              double param,
+                              std::uint64_t seed = std::random_device{}()) const {
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(
+            ExecutionContext<Prec, ExecutionSpace::Host>{
+                state_vector, classical_register, random_engine},
+            param);
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
+                              const std::vector<double>& params) const {
+        ClassicalRegisterBatched classical_register(0, states.batch_size());
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(
+            ExecutionContextBatched<Prec, ExecutionSpace::Host>{states, classical_register, random_engine},
+            params);
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
+                              ClassicalRegisterBatched& classical_register,
+                              const std::vector<double>& params,
+                              std::uint64_t seed = std::random_device{}()) const {
+        if (classical_register.batch_size() != states.batch_size()) {
+            throw std::runtime_error(
+                "ParamGateBase::update_quantum_state(StateVectorBatched&, "
+                "ClassicalRegisterBatched&, ...): batch size mismatch.");
+        }
+        if (params.size() != states.batch_size()) {
+            throw std::runtime_error(
+                "ParamGateBase::update_quantum_state(StateVectorBatched&, "
+                "ClassicalRegisterBatched&, ...): parameter size mismatch.");
+        }
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(
+            ExecutionContextBatched<Prec, ExecutionSpace::Host>{states, classical_register, random_engine},
+            params);
+    }
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+                              double param) const {
+        ClassicalRegister classical_register(0);
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(
+            ExecutionContext<Prec, ExecutionSpace::HostSerial>{
+                state_vector, classical_register, random_engine},
+            param);
+    }
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+                              ClassicalRegister& classical_register,
+                              double param,
+                              std::uint64_t seed = std::random_device{}()) const {
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(
+            ExecutionContext<Prec, ExecutionSpace::HostSerial>{
+                state_vector, classical_register, random_engine},
+            param);
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+                              const std::vector<double>& params) const {
+        ClassicalRegisterBatched classical_register(0, states.batch_size());
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(
+            ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>{
+                states, classical_register, random_engine},
+            params);
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
+                              ClassicalRegisterBatched& classical_register,
+                              const std::vector<double>& params,
+                              std::uint64_t seed = std::random_device{}()) const {
+        if (classical_register.batch_size() != states.batch_size()) {
+            throw std::runtime_error(
+                "ParamGateBase::update_quantum_state(StateVectorBatched&, "
+                "ClassicalRegisterBatched&, ...): batch size mismatch.");
+        }
+        if (params.size() != states.batch_size()) {
+            throw std::runtime_error(
+                "ParamGateBase::update_quantum_state(StateVectorBatched&, "
+                "ClassicalRegisterBatched&, ...): parameter size mismatch.");
+        }
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>{
+                                 states, classical_register, random_engine},
+                             params);
+    }
 #ifdef SCALUQ_USE_CUDA
-    virtual void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
-                                      double param) const = 0;
-    virtual void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
-                                      std::vector<double> params) const = 0;
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+                              double param) const {
+        ClassicalRegister classical_register(0);
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(
+            ExecutionContext<Prec, ExecutionSpace::Default>{state_vector, classical_register, random_engine},
+            param);
+    }
+    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+                              ClassicalRegister& classical_register,
+                              double param,
+                              std::uint64_t seed = std::random_device{}()) const {
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(
+            ExecutionContext<Prec, ExecutionSpace::Default>{
+                state_vector, classical_register, random_engine},
+            param);
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
+                              const std::vector<double>& params) const {
+        ClassicalRegisterBatched classical_register(0, states.batch_size());
+        std::mt19937_64 random_engine(std::random_device{}());
+        update_quantum_state(
+            ExecutionContextBatched<Prec, ExecutionSpace::Default>{
+                states, classical_register, random_engine},
+            params);
+    }
+    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
+                              ClassicalRegisterBatched& classical_register,
+                              const std::vector<double>& params,
+                              std::uint64_t seed = std::random_device{}()) const {
+        if (classical_register.batch_size() != states.batch_size()) {
+            throw std::runtime_error(
+                "ParamGateBase::update_quantum_state(StateVectorBatched&, "
+                "ClassicalRegisterBatched&, ...): batch size mismatch.");
+        }
+        if (params.size() != states.batch_size()) {
+            throw std::runtime_error(
+                "ParamGateBase::update_quantum_state(StateVectorBatched&, "
+                "ClassicalRegisterBatched&, ...): parameter size mismatch.");
+        }
+        std::mt19937_64 random_engine(seed);
+        update_quantum_state(
+            ExecutionContextBatched<Prec, ExecutionSpace::Default>{states, classical_register, random_engine},
+            params);
+    }
 #endif  // SCALUQ_USE_CUDA
+
+    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
+                                      double param) const = 0;
+    virtual void update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+                                      const std::vector<double>& params) const = 0;
+    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
+                                      double param) const = 0;
+    virtual void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+        const std::vector<double>& params) const = 0;
+#ifdef SCALUQ_USE_CUDA
+    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
+                                      double param) const = 0;
+    virtual void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+        const std::vector<double>& params) const = 0;
+#endif
 
     [[nodiscard]] virtual std::string to_string(const std::string& indent = "") const = 0;
 
@@ -293,7 +437,7 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
             "update_quantum_state",
             [](const GateT& gate,
                StateVectorBatched<Prec, ExecutionSpace::Host>& states,
-               std::vector<double> params) { gate->update_quantum_state(states, params); },
+               const std::vector<double>& params) { gate->update_quantum_state(states, params); },
             "states"_a,
             "params"_a,
             "updated.")
@@ -310,7 +454,7 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
             "update_quantum_state",
             [](const GateT& gate,
                StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-               std::vector<double> params) { gate->update_quantum_state(states, params); },
+               const std::vector<double>& params) { gate->update_quantum_state(states, params); },
             "states"_a,
             "params"_a,
             "Apply gate to `states` with holding the parameters. `states` in args is directly "
@@ -329,7 +473,7 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
             "update_quantum_state",
             [](const GateT& gate,
                StateVectorBatched<Prec, ExecutionSpace::Default>& states,
-               std::vector<double> params) { gate->update_quantum_state(states, params); },
+               const std::vector<double>& params) { gate->update_quantum_state(states, params); },
             "states"_a,
             "params"_a,
             "Apply gate to `states` with holding the parameters. `states` in args is directly "

--- a/include/scaluq/gate/param_gate_pauli.hpp
+++ b/include/scaluq/gate/param_gate_pauli.hpp
@@ -23,6 +23,8 @@ public:
                               param_coef),
           _pauli(pauli) {}
 
+    using ParamGateBase<Prec>::update_quantum_state;
+
     PauliOperator<Prec> pauli() const { return _pauli; }
     std::vector<std::uint64_t> pauli_id_list() const { return _pauli.pauli_id_list(); }
 
@@ -31,19 +33,23 @@ public:
             this->_control_mask, this->_control_value_mask, _pauli, -this->_pcoef);
     }
     ComplexMatrix get_matrix(double param) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
-                              std::vector<double> params) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+                              const std::vector<double>& params) const override;
+    void update_quantum_state(
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-                              std::vector<double> params) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+                              const std::vector<double>& params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
-                              std::vector<double> params) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+                              const std::vector<double>& params) const override;
 #endif  // SCALUQ_USE_CUDA
     std::string to_string(const std::string& indent) const override;
 

--- a/include/scaluq/gate/param_gate_probabilistic.hpp
+++ b/include/scaluq/gate/param_gate_probabilistic.hpp
@@ -20,6 +20,7 @@ public:
     ParamProbabilisticGateImpl(
         const std::vector<double>& distribution,
         const std::vector<std::variant<Gate<Prec>, ParamGate<Prec>>>& gate_list);
+    using ParamGateBase<Prec>::update_quantum_state;
     const std::vector<EitherGate>& gate_list() const { return _gate_list; }
     const std::vector<double>& distribution() const { return _distribution; }
 
@@ -70,19 +71,23 @@ public:
             "ParamProbabilisticGateImpl.");
     }
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
-                              std::vector<double> params) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+                              const std::vector<double>& params) const override;
+    void update_quantum_state(
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-                              std::vector<double> params) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+                              const std::vector<double>& params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
-                              std::vector<double> params) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+                              const std::vector<double>& params) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/param_gate_standard.hpp
+++ b/include/scaluq/gate/param_gate_standard.hpp
@@ -11,6 +11,7 @@ template <Precision Prec>
 class ParamRXGateImpl : public ParamGateBase<Prec> {
 public:
     using ParamGateBase<Prec>::ParamGateBase;
+    using ParamGateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const ParamGateBase<Prec>> get_inverse() const override {
         return std::make_shared<const ParamRXGateImpl<Prec>>(
@@ -18,19 +19,23 @@ public:
     }
     ComplexMatrix get_matrix(double param) const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
-                              std::vector<double> params) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+                              const std::vector<double>& params) const override;
+    void update_quantum_state(
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-                              std::vector<double> params) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+                              const std::vector<double>& params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
-                              std::vector<double> params) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+                              const std::vector<double>& params) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -48,6 +53,7 @@ template <Precision Prec>
 class ParamRYGateImpl : public ParamGateBase<Prec> {
 public:
     using ParamGateBase<Prec>::ParamGateBase;
+    using ParamGateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const ParamGateBase<Prec>> get_inverse() const override {
         return std::make_shared<const ParamRYGateImpl<Prec>>(
@@ -55,19 +61,23 @@ public:
     }
     ComplexMatrix get_matrix(double param) const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
-                              std::vector<double> params) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+                              const std::vector<double>& params) const override;
+    void update_quantum_state(
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-                              std::vector<double> params) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+                              const std::vector<double>& params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
-                              std::vector<double> params) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+                              const std::vector<double>& params) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -85,6 +95,7 @@ template <Precision Prec>
 class ParamRZGateImpl : public ParamGateBase<Prec> {
 public:
     using ParamGateBase<Prec>::ParamGateBase;
+    using ParamGateBase<Prec>::update_quantum_state;
 
     std::shared_ptr<const ParamGateBase<Prec>> get_inverse() const override {
         return std::make_shared<const ParamRZGateImpl<Prec>>(
@@ -92,19 +103,23 @@ public:
     }
     ComplexMatrix get_matrix(double param) const override;
 
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
-                              std::vector<double> params) const override;
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+                              const std::vector<double>& params) const override;
+    void update_quantum_state(
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-                              std::vector<double> params) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+                              const std::vector<double>& params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
                               double param) const override;
-    void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
-                              std::vector<double> params) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+                              const std::vector<double>& params) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/python/binding.cpp
+++ b/python/binding.cpp
@@ -73,6 +73,8 @@ void bind_on_precision(nb::module_& mp,
 
 NB_MODULE(scaluq_core, m) {
     internal::bind_kokkos_hpp(m);
+    internal::bind_classical_register_hpp(m);
+    internal::bind_classical_register_batched_hpp(m);
     internal::bind_gate_gate_hpp_without_precision_and_space(m);
     internal::bind_gate_param_gate_hpp_without_precision_and_space(m);
 

--- a/src/circuit/circuit.cpp
+++ b/src/circuit/circuit.cpp
@@ -65,7 +65,18 @@ void Circuit<Prec>::add_circuit(Circuit<Prec>&& circuit) {
 template <Precision Prec>
 template <ExecutionSpace Space>
 void Circuit<Prec>::update_quantum_state(StateVector<Prec, Space>& state,
-                                         const std::map<std::string, double>& parameters) const {
+                                         const std::map<std::string, double>& parameters,
+                                         std::uint64_t seed) const {
+    ClassicalRegister classical_register(0);
+    update_quantum_state(state, classical_register, parameters, seed);
+}
+
+template <Precision Prec>
+template <ExecutionSpace Space>
+void Circuit<Prec>::update_quantum_state(StateVector<Prec, Space>& state,
+                                         ClassicalRegister& classical_register,
+                                         const std::map<std::string, double>& parameters,
+                                         std::uint64_t seed) const {
     check_state_vector_n_qubits(state.n_qubits());
     for (auto&& gate : _gate_list) {
         if (gate.index() == 0) continue;
@@ -77,12 +88,14 @@ void Circuit<Prec>::update_quantum_state(StateVector<Prec, Space>& state,
                 std::string(key) + "is not given.");
         }
     }
+    std::mt19937_64 random_engine(seed);
+    internal::ExecutionContext<Prec, Space> context{state, classical_register, random_engine};
     for (auto&& gate : _gate_list) {
         if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(state);
+            std::get<0>(gate)->update_quantum_state(context);
         } else {
             const auto& [param_gate, key] = std::get<1>(gate);
-            param_gate->update_quantum_state(state, parameters.at(key));
+            param_gate->update_quantum_state(context, parameters.at(key));
         }
     }
 }
@@ -91,8 +104,25 @@ template <Precision Prec>
 template <ExecutionSpace Space>
 void Circuit<Prec>::update_quantum_state(
     StateVectorBatched<Prec, Space>& states,
-    const std::map<std::string, std::vector<double>>& parameters) const {
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed) const {
+    ClassicalRegisterBatched classical_register(0, states.batch_size());
+    update_quantum_state(states, classical_register, parameters, seed);
+}
+
+template <Precision Prec>
+template <ExecutionSpace Space>
+void Circuit<Prec>::update_quantum_state(
+    StateVectorBatched<Prec, Space>& states,
+    ClassicalRegisterBatched& classical_register,
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed) const {
     check_state_vector_n_qubits(states.n_qubits());
+    if (classical_register.batch_size() != states.batch_size()) {
+        throw std::runtime_error(
+            "Circuit::update_quantum_state(StateVectorBatched&, ClassicalRegisterBatched&, ...): "
+            "batch size mismatch.");
+    }
     for (auto&& gate : _gate_list) {
         if (gate.index() == 0) continue;
         const auto& key = std::get<1>(gate).second;
@@ -102,38 +132,80 @@ void Circuit<Prec>::update_quantum_state(
                 "Circuit::update_quantum_state(StateVector&, const std::map<std::string_view, double>&) const: parameter named "s +
                 std::string(key) + "is not given.");
         }
+        if (parameters.at(key).size() != states.batch_size()) {
+            throw std::runtime_error(
+                "Circuit::update_quantum_state(StateVectorBatched&, const std::map<std::string, std::vector<double>>&): parameter size mismatch.");
+        }
     }
+    std::mt19937_64 random_engine(seed);
+    internal::ExecutionContextBatched<Prec, Space> context{states, classical_register, random_engine};
     for (auto&& gate : _gate_list) {
         if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(states);
+            std::get<0>(gate)->update_quantum_state(context);
         } else {
             const auto& [param_gate, key] = std::get<1>(gate);
-            param_gate->update_quantum_state(states, parameters.at(key));
+            param_gate->update_quantum_state(context, parameters.at(key));
         }
     }
 }
 
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Host>(
     StateVector<internal::Prec, ExecutionSpace::Host>& state,
-    const std::map<std::string, double>& parameters) const;
+    const std::map<std::string, double>& parameters,
+    std::uint64_t seed) const;
+template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Host>(
+    StateVector<internal::Prec, ExecutionSpace::Host>& state,
+    ClassicalRegister& classical_register,
+    const std::map<std::string, double>& parameters,
+    std::uint64_t seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Host>(
     StateVectorBatched<internal::Prec, ExecutionSpace::Host>& states,
-    const std::map<std::string, std::vector<double>>& parameters) const;
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed) const;
+template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Host>(
+    StateVectorBatched<internal::Prec, ExecutionSpace::Host>& states,
+    ClassicalRegisterBatched& classical_register,
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed) const;
 
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::HostSerial>(
     StateVector<internal::Prec, ExecutionSpace::HostSerial>& state,
-    const std::map<std::string, double>& parameters) const;
+    const std::map<std::string, double>& parameters,
+    std::uint64_t seed) const;
+template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::HostSerial>(
+    StateVector<internal::Prec, ExecutionSpace::HostSerial>& state,
+    ClassicalRegister& classical_register,
+    const std::map<std::string, double>& parameters,
+    std::uint64_t seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::HostSerial>(
     StateVectorBatched<internal::Prec, ExecutionSpace::HostSerial>& states,
-    const std::map<std::string, std::vector<double>>& parameters) const;
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed) const;
+template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::HostSerial>(
+    StateVectorBatched<internal::Prec, ExecutionSpace::HostSerial>& states,
+    ClassicalRegisterBatched& classical_register,
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed) const;
 
 #ifdef SCALUQ_USE_CUDA
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Default>(
     StateVector<internal::Prec, ExecutionSpace::Default>& state,
-    const std::map<std::string, double>& parameters) const;
+    const std::map<std::string, double>& parameters,
+    std::uint64_t seed) const;
+template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Default>(
+    StateVector<internal::Prec, ExecutionSpace::Default>& state,
+    ClassicalRegister& classical_register,
+    const std::map<std::string, double>& parameters,
+    std::uint64_t seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Default>(
     StateVectorBatched<internal::Prec, ExecutionSpace::Default>& states,
-    const std::map<std::string, std::vector<double>>& parameters) const;
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed) const;
+template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Default>(
+    StateVectorBatched<internal::Prec, ExecutionSpace::Default>& states,
+    ClassicalRegisterBatched& classical_register,
+    const std::map<std::string, std::vector<double>>& parameters,
+    std::uint64_t seed) const;
 #endif  // SCALUQ_USE_CUDA
 
 template <Precision Prec>

--- a/src/gate/gate_matrix.cpp
+++ b/src/gate/gate_matrix.cpp
@@ -42,31 +42,31 @@ std::string DenseMatrixGateImpl<Prec, Space>::to_string(const std::string& inden
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_DENSE_MATRIX_GATE_UPDATE(Class, TargetSpace)                                 \
+#define DEFINE_DENSE_MATRIX_GATE_UPDATE(ContextClass, state_member, TargetSpace)            \
     template <Precision Prec, ExecutionSpace GateSpace>                                     \
     void DenseMatrixGateImpl<Prec, GateSpace>::update_quantum_state(                        \
-        Class<Prec, TargetSpace>& state_vector) const {                                     \
+        ContextClass<Prec, TargetSpace> context) const {                                    \
         if constexpr (GateSpace == TargetSpace) {                                           \
-            this->check_qubit_mask_within_bounds(state_vector);                             \
+            this->check_qubit_mask_within_bounds(context.state_member);                     \
             dense_matrix_gate(this->_target_mask,                                           \
                               this->_control_mask,                                          \
                               this->_control_value_mask,                                    \
                               _matrix,                                                      \
-                              state_vector);                                                \
+                              context.state_member);                                        \
         } else {                                                                            \
             throw std::runtime_error(                                                       \
-                "Error: DenseMatrixGateImpl::update_quantum_state(" #Class                  \
+                "Error: DenseMatrixGateImpl::update_quantum_state(" #ContextClass           \
                 "& state_vector): Trying to run on " #TargetSpace                           \
                 " execution space, but the gate is defined on different execution space."); \
         }                                                                                   \
     }
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_DENSE_MATRIX_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_DENSE_MATRIX_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_DENSE_MATRIX_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_DENSE_MATRIX_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_DENSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_DENSE_MATRIX_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_DENSE_MATRIX_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif
 #undef DEFINE_DENSE_MATRIX_GATE_UPDATE
 template class DenseMatrixGateImpl<Prec, Space>;
@@ -111,31 +111,31 @@ std::string SparseMatrixGateImpl<Prec, Space>::to_string(const std::string& inde
     return ss.str();
 }
 
-#define DEFINE_SPARSE_MATRIX_GATE_UPDATE(Class, TargetSpace)                                \
+#define DEFINE_SPARSE_MATRIX_GATE_UPDATE(ContextClass, state_member, TargetSpace)           \
     template <Precision Prec, ExecutionSpace GateSpace>                                     \
     void SparseMatrixGateImpl<Prec, GateSpace>::update_quantum_state(                       \
-        Class<Prec, TargetSpace>& state_vector) const {                                     \
+        ContextClass<Prec, TargetSpace> context) const {                                    \
         if constexpr (GateSpace == TargetSpace) {                                           \
-            this->check_qubit_mask_within_bounds(state_vector);                             \
+            this->check_qubit_mask_within_bounds(context.state_member);                     \
             sparse_matrix_gate(this->_target_mask,                                          \
                                this->_control_mask,                                         \
                                this->_control_value_mask,                                   \
                                _matrix,                                                     \
-                               state_vector);                                               \
+                               context.state_member);                                       \
         } else {                                                                            \
             throw std::runtime_error(                                                       \
-                "Error: SparseMatrixGateImpl::update_quantum_state(" #Class                 \
+                "Error: SparseMatrixGateImpl::update_quantum_state(" #ContextClass          \
                 "& state_vector): Trying to run on " #TargetSpace                           \
                 " execution space, but the gate is defined on different execution space."); \
         }                                                                                   \
     }
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_SPARSE_MATRIX_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_SPARSE_MATRIX_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_SPARSE_MATRIX_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_SPARSE_MATRIX_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SPARSE_MATRIX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SPARSE_MATRIX_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_SPARSE_MATRIX_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif
 #undef DEFINE_SPARSE_MATRIX_GATE_UPDATE
 template class SparseMatrixGateImpl<Prec, Space>;

--- a/src/gate/gate_pauli.cpp
+++ b/src/gate/gate_pauli.cpp
@@ -15,24 +15,24 @@ std::string PauliGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << indent << "  Pauli Operator: \"" << _pauli.get_pauli_string() << "\"";
     return ss.str();
 }
-#define DEFINE_PAULI_GATE_UPDATE(Class, Space)                                               \
+#define DEFINE_PAULI_GATE_UPDATE(ContextClass, state_member, Space)                                               \
     template <Precision Prec>                                                                \
-    void PauliGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
+    void PauliGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
         auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();         \
         apply_pauli(this->_control_mask,                                                     \
                     this->_control_value_mask,                                               \
                     bit_flip_mask,                                                           \
                     phase_flip_mask,                                                         \
                     Complex<Prec>(_pauli.coef()),                                            \
-                    state_vector);                                                           \
+                    context.state_member);                                                   \
     }
-DEFINE_PAULI_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_PAULI_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_PAULI_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_PAULI_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_PAULI_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_PAULI_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_PAULI_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_PAULI_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_PAULI_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_PAULI_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_PAULI_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_PAULI_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_PAULI_GATE_UPDATE
 template class PauliGateImpl<Prec>;
@@ -60,9 +60,9 @@ std::string PauliRotationGateImpl<Prec>::to_string(const std::string& indent) co
     ss << indent << "  Pauli Operator: \"" << _pauli.get_pauli_string() << "\"";
     return ss.str();
 }
-#define DEFINE_PAULI_ROTATION_GATE_UPDATE(Class, Space)                                      \
+#define DEFINE_PAULI_ROTATION_GATE_UPDATE(ContextClass, state_member, Space)                                      \
     template <Precision Prec>                                                                \
-    void PauliRotationGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) \
+    void PauliRotationGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) \
         const {                                                                              \
         auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();         \
         apply_pauli_rotation(this->_control_mask,                                            \
@@ -71,15 +71,15 @@ std::string PauliRotationGateImpl<Prec>::to_string(const std::string& indent) co
                              phase_flip_mask,                                                \
                              Complex<Prec>(_pauli.coef()),                                   \
                              _angle,                                                         \
-                             state_vector);                                                  \
+                             context.state_member);                                          \
     }
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_PAULI_ROTATION_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_PAULI_ROTATION_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_PAULI_ROTATION_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_PAULI_ROTATION_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_PAULI_ROTATION_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_PAULI_ROTATION_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_PAULI_ROTATION_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_PAULI_ROTATION_GATE_UPDATE
 template class PauliRotationGateImpl<Prec>;

--- a/src/gate/gate_probabilistic.cpp
+++ b/src/gate/gate_probabilistic.cpp
@@ -4,6 +4,17 @@
 
 namespace scaluq::internal {
 namespace {
+template <Precision Prec, ExecutionSpace Space>
+std::uint64_t select_probabilistic_gate_index(const std::vector<double>& cumulative_distribution,
+                                              ExecutionContext<Prec, Space> context) {
+    std::uniform_real_distribution<double> dist(0., 1.);
+    std::uint64_t i = std::distance(cumulative_distribution.begin(),
+                                    std::ranges::upper_bound(cumulative_distribution,
+                                                             dist(context.random_engine))) -
+                      1;
+    return std::min<std::uint64_t>(i, cumulative_distribution.size() - 2);
+}
+
 template <Precision Prec>
 void flatten_probabilistic_gate(double prob_prefix,
                                 const Gate<Prec>& gate,
@@ -71,41 +82,32 @@ std::string ProbabilisticGateImpl<Prec>::to_string(const std::string& indent) co
     }
     return ss.str();
 }
-#define DEFINE_PROBABILISTIC_GATE_UPDATE(Space)                                                    \
-    template <Precision Prec>                                                                      \
-    void ProbabilisticGateImpl<Prec>::update_quantum_state(StateVector<Prec, Space>& state_vector) \
-        const {                                                                                    \
-        Random random;                                                                             \
-        double r = random.uniform();                                                               \
-        std::uint64_t i = std::distance(_cumulative_distribution.begin(),                          \
-                                        std::ranges::upper_bound(_cumulative_distribution, r)) -   \
-                          1;                                                                       \
-        if (i >= _gate_list.size()) i = _gate_list.size() - 1;                                     \
-        _gate_list[i]->update_quantum_state(state_vector);                                         \
-    }                                                                                              \
-    template <Precision Prec>                                                                      \
-    void ProbabilisticGateImpl<Prec>::update_quantum_state(                                        \
-        StateVectorBatched<Prec, Space>& states) const {                                           \
-        std::vector<std::uint64_t> indices(states.batch_size());                                   \
-        std::vector<double> r(states.batch_size());                                                \
-                                                                                                   \
-        Random random;                                                                             \
-        for (std::size_t i = 0; i < states.batch_size(); ++i) {                                    \
-            r[i] = random.uniform();                                                               \
-            indices[i] = std::distance(_cumulative_distribution.begin(),                           \
-                                       std::ranges::upper_bound(_cumulative_distribution, r[i])) - \
-                         1;                                                                        \
-            if (indices[i] >= _gate_list.size()) indices[i] = _gate_list.size() - 1;               \
-            auto state_vector = states.view_state_vector_at(i);                                     \
-            _gate_list[indices[i]]->update_quantum_state(state_vector);                            \
-        }                                                                                          \
+#define DEFINE_PROBABILISTIC_GATE_CONTEXT_UPDATE(Space)                                           \
+    template <Precision Prec>                                                                     \
+    void ProbabilisticGateImpl<Prec>::update_quantum_state(ExecutionContext<Prec, Space> context) \
+        const {                                                                                   \
+        const std::uint64_t i =                                                                   \
+            select_probabilistic_gate_index(_cumulative_distribution, context);                   \
+        _gate_list[i]->update_quantum_state(context);                                             \
+    }                                                                                             \
+    template <Precision Prec>                                                                     \
+    void ProbabilisticGateImpl<Prec>::update_quantum_state(                                       \
+        ExecutionContextBatched<Prec, Space> context) const {                                     \
+        for (std::size_t i = 0; i < context.states.batch_size(); ++i) {                           \
+            auto state_vector = context.states.view_state_vector_at(i);                           \
+            this->update_quantum_state(                                                           \
+                ExecutionContext<Prec, Space>{state_vector,                                       \
+                                              context.classical_register[i],                      \
+                                              context.random_engine});                            \
+        }                                                                                         \
     }
-DEFINE_PROBABILISTIC_GATE_UPDATE(ExecutionSpace::Host)
-DEFINE_PROBABILISTIC_GATE_UPDATE(ExecutionSpace::HostSerial)
+DEFINE_PROBABILISTIC_GATE_CONTEXT_UPDATE(ExecutionSpace::Host)
+DEFINE_PROBABILISTIC_GATE_CONTEXT_UPDATE(ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_PROBABILISTIC_GATE_UPDATE(ExecutionSpace::Default)
+DEFINE_PROBABILISTIC_GATE_CONTEXT_UPDATE(ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
-#undef DEFINE_PROBABILISTIC_GATE_UPDATE
+#undef DEFINE_PROBABILISTIC_GATE_CONTEXT_UPDATE
+
 template class ProbabilisticGateImpl<Prec>;
 
 template <Precision Prec>

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -14,18 +14,18 @@ std::string IGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_I_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_I_GATE_UPDATE(ContextClass, state_member, Space)                                                        \
     template <Precision Prec>                                                                     \
-    void IGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
-        i_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+    void IGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        i_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_I_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_I_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_I_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_I_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_I_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_I_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_I_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_I_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_I_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_I_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_I_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_I_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_I_GATE_UPDATE
 template class IGateImpl<Prec>;
@@ -42,23 +42,23 @@ std::string GlobalPhaseGateImpl<Prec>::to_string(const std::string& indent) cons
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_GLOBAL_PHASE_GATE_UPDATE(Class, Space)                                              \
+#define DEFINE_GLOBAL_PHASE_GATE_UPDATE(ContextClass, state_member, Space)                                              \
     template <Precision Prec>                                                                      \
-    void GlobalPhaseGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                                        \
+    void GlobalPhaseGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                                 \
         global_phase_gate(this->_target_mask,                                                      \
                           this->_control_mask,                                                     \
                           this->_control_value_mask,                                               \
                           this->_phase,                                                            \
-                          state_vector);                                                           \
+                          context.state_member);                                                   \
     }
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_GLOBAL_PHASE_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_GLOBAL_PHASE_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_GLOBAL_PHASE_GATE_UPDATE
 template class GlobalPhaseGateImpl<Prec>;
@@ -76,19 +76,19 @@ std::string XGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_X_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_X_GATE_UPDATE(ContextClass, state_member, Space)                                                        \
     template <Precision Prec>                                                                     \
-    void XGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
-        this->check_qubit_mask_within_bounds(state_vector);                                       \
-        x_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+    void XGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                                \
+        x_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_X_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_X_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_X_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_X_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_X_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_X_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_X_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_X_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_X_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_X_GATE_UPDATE
 template class XGateImpl<Prec>;
@@ -106,19 +106,19 @@ std::string YGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_Y_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_Y_GATE_UPDATE(ContextClass, state_member, Space)                                                        \
     template <Precision Prec>                                                                     \
-    void YGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
-        this->check_qubit_mask_within_bounds(state_vector);                                       \
-        y_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+    void YGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                                \
+        y_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_Y_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_Y_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_Y_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_Y_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_Y_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_Y_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_Y_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_Y_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_Y_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_Y_GATE_UPDATE
 template class YGateImpl<Prec>;
@@ -136,19 +136,19 @@ std::string ZGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_Z_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_Z_GATE_UPDATE(ContextClass, state_member, Space)                                                        \
     template <Precision Prec>                                                                     \
-    void ZGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
-        this->check_qubit_mask_within_bounds(state_vector);                                       \
-        z_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+    void ZGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                                \
+        z_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_Z_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_Z_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_Z_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_Z_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_Z_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_Z_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_Z_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_Z_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_Z_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_Z_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_Z_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_Z_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_Z_GATE_UPDATE
 template class ZGateImpl<Prec>;
@@ -167,19 +167,19 @@ std::string HGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_H_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_H_GATE_UPDATE(ContextClass, state_member, Space)                                                        \
     template <Precision Prec>                                                                     \
-    void HGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
-        this->check_qubit_mask_within_bounds(state_vector);                                       \
-        h_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+    void HGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                                \
+        h_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_H_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_H_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_H_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_H_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_H_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_H_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_H_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_H_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_H_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_H_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_H_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_H_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_H_GATE_UPDATE
 template class HGateImpl<Prec>;
@@ -197,19 +197,19 @@ std::string SGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_S_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_S_GATE_UPDATE(ContextClass, state_member, Space)                                                        \
     template <Precision Prec>                                                                     \
-    void SGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
-        this->check_qubit_mask_within_bounds(state_vector);                                       \
-        s_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+    void SGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                                \
+        s_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_S_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_S_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_S_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_S_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_S_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_S_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_S_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_S_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_S_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_S_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_S_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_S_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_S_GATE_UPDATE
 template class SGateImpl<Prec>;
@@ -227,20 +227,20 @@ std::string SdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_S_DAG_GATE_UPDATE(Class, Space)                                                 \
+#define DEFINE_S_DAG_GATE_UPDATE(ContextClass, state_member, Space)                                                 \
     template <Precision Prec>                                                                  \
-    void SdagGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {    \
-        this->check_qubit_mask_within_bounds(state_vector);                                    \
+    void SdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                             \
         sdag_gate(                                                                             \
-            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+            this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_S_DAG_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_S_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_S_DAG_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_S_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_S_DAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_S_DAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_S_DAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_S_DAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_S_DAG_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_S_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_S_DAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_S_DAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_S_DAG_GATE_UPDATE
 template class SdagGateImpl<Prec>;
@@ -258,19 +258,19 @@ std::string TGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_T_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_T_GATE_UPDATE(ContextClass, state_member, Space)                                                        \
     template <Precision Prec>                                                                     \
-    void TGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
-        this->check_qubit_mask_within_bounds(state_vector);                                       \
-        t_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+    void TGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                                \
+        t_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_T_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_T_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_T_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_T_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_T_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_T_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_T_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_T_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_T_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_T_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_T_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_T_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_T_GATE_UPDATE
 template class TGateImpl<Prec>;
@@ -288,20 +288,20 @@ std::string TdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_T_DAG_GATE_UPDATE(Class, Space)                                                 \
+#define DEFINE_T_DAG_GATE_UPDATE(ContextClass, state_member, Space)                                                 \
     template <Precision Prec>                                                                  \
-    void TdagGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {    \
-        this->check_qubit_mask_within_bounds(state_vector);                                    \
+    void TdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                             \
         tdag_gate(                                                                             \
-            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+            this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_T_DAG_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_T_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_T_DAG_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_T_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_T_DAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_T_DAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_T_DAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_T_DAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_T_DAG_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_T_DAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_T_DAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_T_DAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_T_DAG_GATE_UPDATE
 template class TdagGateImpl<Prec>;
@@ -319,20 +319,20 @@ std::string SqrtXGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_X_GATE_UPDATE(Class, Space)                                                \
+#define DEFINE_SQRT_X_GATE_UPDATE(ContextClass, state_member, Space)                                                \
     template <Precision Prec>                                                                  \
-    void SqrtXGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {   \
-        this->check_qubit_mask_within_bounds(state_vector);                                    \
+    void SqrtXGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                             \
         sqrtx_gate(                                                                            \
-            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+            this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_SQRT_X_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SQRT_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SQRT_X_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SQRT_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_SQRT_X_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_SQRT_X_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_SQRT_X_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_SQRT_X_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SQRT_X_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SQRT_X_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SQRT_X_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_SQRT_X_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_SQRT_X_GATE_UPDATE
 template class SqrtXGateImpl<Prec>;
@@ -350,20 +350,20 @@ std::string SqrtXdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_XDAG_GATE_UPDATE(Class, Space)                                              \
+#define DEFINE_SQRT_XDAG_GATE_UPDATE(ContextClass, state_member, Space)                                              \
     template <Precision Prec>                                                                   \
-    void SqrtXdagGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                                     \
+    void SqrtXdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                              \
         sqrtxdag_gate(                                                                          \
-            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector);  \
+            this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member);  \
     }
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_SQRT_XDAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_SQRT_XDAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_SQRT_XDAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_SQRT_XDAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SQRT_XDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SQRT_XDAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_SQRT_XDAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_SQRT_XDAG_GATE_UPDATE
 template class SqrtXdagGateImpl<Prec>;
@@ -381,20 +381,20 @@ std::string SqrtYGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_Y_GATE_UPDATE(Class, Space)                                                \
+#define DEFINE_SQRT_Y_GATE_UPDATE(ContextClass, state_member, Space)                                                \
     template <Precision Prec>                                                                  \
-    void SqrtYGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {   \
-        this->check_qubit_mask_within_bounds(state_vector);                                    \
+    void SqrtYGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                             \
         sqrty_gate(                                                                            \
-            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+            this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_SQRT_Y_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SQRT_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SQRT_Y_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SQRT_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_SQRT_Y_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_SQRT_Y_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_SQRT_Y_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_SQRT_Y_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SQRT_Y_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SQRT_Y_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SQRT_Y_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_SQRT_Y_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_SQRT_Y_GATE_UPDATE
 template class SqrtYGateImpl<Prec>;
@@ -412,20 +412,20 @@ std::string SqrtYdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_YDAG_GATE_UPDATE(Class, Space)                                              \
+#define DEFINE_SQRT_YDAG_GATE_UPDATE(ContextClass, state_member, Space)                                              \
     template <Precision Prec>                                                                   \
-    void SqrtYdagGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                                     \
+    void SqrtYdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                              \
         sqrtydag_gate(                                                                          \
-            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector);  \
+            this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member);  \
     }
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_SQRT_YDAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_SQRT_YDAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_SQRT_YDAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_SQRT_YDAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SQRT_YDAG_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SQRT_YDAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_SQRT_YDAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_SQRT_YDAG_GATE_UPDATE
 template class SqrtYdagGateImpl<Prec>;
@@ -443,19 +443,19 @@ std::string P0GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_P0_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_P0_GATE_UPDATE(ContextClass, state_member, Space)                                                        \
     template <Precision Prec>                                                                      \
-    void P0GateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
-        this->check_qubit_mask_within_bounds(state_vector);                                        \
-        p0_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+    void P0GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                                 \
+        p0_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_P0_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_P0_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_P0_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_P0_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_P0_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_P0_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_P0_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_P0_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_P0_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_P0_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_P0_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_P0_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_P0_GATE_UPDATE
 template class P0GateImpl<Prec>;
@@ -473,19 +473,19 @@ std::string P1GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_P1_GATE_UPDATE(Class, Space)                                                        \
+#define DEFINE_P1_GATE_UPDATE(ContextClass, state_member, Space)                                                        \
     template <Precision Prec>                                                                      \
-    void P1GateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {          \
-        this->check_qubit_mask_within_bounds(state_vector);                                        \
-        p1_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+    void P1GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                                 \
+        p1_gate(this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_P1_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_P1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_P1_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_P1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_P1_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_P1_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_P1_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_P1_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_P1_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_P1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_P1_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_P1_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_P1_GATE_UPDATE
 template class P1GateImpl<Prec>;
@@ -506,23 +506,23 @@ std::string RXGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_RX_GATE_UPDATE(Class, Space)                                               \
+#define DEFINE_RX_GATE_UPDATE(ContextClass, state_member, Space)                                               \
     template <Precision Prec>                                                             \
-    void RXGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
+    void RXGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
         rx_gate(this->_target_mask,                                                       \
                 this->_control_mask,                                                      \
                 this->_control_value_mask,                                                \
                 this->_angle,                                                             \
-                state_vector);                                                            \
+                context.state_member);                                                    \
     }
-DEFINE_RX_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_RX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_RX_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_RX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_RX_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_RX_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_RX_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_RX_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_RX_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_RX_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_RX_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_RX_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_RX_GATE_UPDATE
 template class RXGateImpl<Prec>;
@@ -542,23 +542,23 @@ std::string RYGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_RY_GATE_UPDATE(Class, Space)                                               \
+#define DEFINE_RY_GATE_UPDATE(ContextClass, state_member, Space)                                               \
     template <Precision Prec>                                                             \
-    void RYGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
+    void RYGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
         ry_gate(this->_target_mask,                                                       \
                 this->_control_mask,                                                      \
                 this->_control_value_mask,                                                \
                 this->_angle,                                                             \
-                state_vector);                                                            \
+                context.state_member);                                                    \
     }
-DEFINE_RY_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_RY_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_RY_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_RY_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_RY_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_RY_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_RY_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_RY_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_RY_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_RY_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_RY_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_RY_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_RY_GATE_UPDATE
 template class RYGateImpl<Prec>;
@@ -578,23 +578,23 @@ std::string RZGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_RZ_GATE_UPDATE(Class, Space)                                               \
+#define DEFINE_RZ_GATE_UPDATE(ContextClass, state_member, Space)                                               \
     template <Precision Prec>                                                             \
-    void RZGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
+    void RZGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
         rz_gate(this->_target_mask,                                                       \
                 this->_control_mask,                                                      \
                 this->_control_value_mask,                                                \
                 this->_angle,                                                             \
-                state_vector);                                                            \
+                context.state_member);                                                    \
     }
-DEFINE_RZ_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_RZ_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_RZ_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_RZ_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_RZ_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_RZ_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_RZ_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_RZ_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_RZ_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_RZ_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_RZ_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_RZ_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_RZ_GATE_UPDATE
 template class RZGateImpl<Prec>;
@@ -613,23 +613,23 @@ std::string U1GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_U1_GATE_UPDATE(Class, Space)                                               \
+#define DEFINE_U1_GATE_UPDATE(ContextClass, state_member, Space)                                               \
     template <Precision Prec>                                                             \
-    void U1GateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
+    void U1GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
         u1_gate(this->_target_mask,                                                       \
                 this->_control_mask,                                                      \
                 this->_control_value_mask,                                                \
                 this->_lambda,                                                            \
-                state_vector);                                                            \
+                context.state_member);                                                    \
     }
-DEFINE_U1_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_U1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_U1_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_U1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_U1_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_U1_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_U1_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_U1_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_U1_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_U1_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_U1_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_U1_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_U1_GATE_UPDATE
 template class U1GateImpl<Prec>;
@@ -654,24 +654,24 @@ std::string U2GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_U2_GATE_UPDATE(Class, Space)                                               \
+#define DEFINE_U2_GATE_UPDATE(ContextClass, state_member, Space)                                               \
     template <Precision Prec>                                                             \
-    void U2GateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
+    void U2GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
         u2_gate(this->_target_mask,                                                       \
                 this->_control_mask,                                                      \
                 this->_control_value_mask,                                                \
                 this->_phi,                                                               \
                 this->_lambda,                                                            \
-                state_vector);                                                            \
+                context.state_member);                                                    \
     }
-DEFINE_U2_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_U2_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_U2_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_U2_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_U2_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_U2_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_U2_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_U2_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_U2_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_U2_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_U2_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_U2_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_U2_GATE_UPDATE
 template class U2GateImpl<Prec>;
@@ -699,25 +699,25 @@ std::string U3GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_U3_GATE_UPDATE(Class, Space)                                               \
+#define DEFINE_U3_GATE_UPDATE(ContextClass, state_member, Space)                                               \
     template <Precision Prec>                                                             \
-    void U3GateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const { \
-        this->check_qubit_mask_within_bounds(state_vector);                               \
+    void U3GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
         u3_gate(this->_target_mask,                                                       \
                 this->_control_mask,                                                      \
                 this->_control_value_mask,                                                \
                 this->_theta,                                                             \
                 this->_phi,                                                               \
                 this->_lambda,                                                            \
-                state_vector);                                                            \
+                context.state_member);                                                    \
     }
-DEFINE_U3_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_U3_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_U3_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_U3_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_U3_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_U3_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_U3_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_U3_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_U3_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_U3_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_U3_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_U3_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_U3_GATE_UPDATE
 template class U3GateImpl<Prec>;
@@ -735,20 +735,20 @@ std::string SwapGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SWAP_GATE_UPDATE(Class, Space)                                                  \
+#define DEFINE_SWAP_GATE_UPDATE(ContextClass, state_member, Space)                                                  \
     template <Precision Prec>                                                                  \
-    void SwapGateImpl<Prec>::update_quantum_state(Class<Prec, Space>& state_vector) const {    \
-        this->check_qubit_mask_within_bounds(state_vector);                                    \
+    void SwapGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                             \
         swap_gate(                                                                             \
-            this->_target_mask, this->_control_mask, this->_control_value_mask, state_vector); \
+            this->_target_mask, this->_control_mask, this->_control_value_mask, context.state_member); \
     }
-DEFINE_SWAP_GATE_UPDATE(StateVector, ExecutionSpace::Host)
-DEFINE_SWAP_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Host)
-DEFINE_SWAP_GATE_UPDATE(StateVector, ExecutionSpace::HostSerial)
-DEFINE_SWAP_GATE_UPDATE(StateVectorBatched, ExecutionSpace::HostSerial)
+DEFINE_SWAP_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_SWAP_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_SWAP_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_SWAP_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
 #ifdef SCALUQ_USE_CUDA
-DEFINE_SWAP_GATE_UPDATE(StateVector, ExecutionSpace::Default)
-DEFINE_SWAP_GATE_UPDATE(StateVectorBatched, ExecutionSpace::Default)
+DEFINE_SWAP_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_SWAP_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #endif  // SCALUQ_USE_CUDA
 #undef DEFINE_SWAP_GATE_UPDATE
 template class SwapGateImpl<Prec>;

--- a/src/gate/param_gate_pauli.cpp
+++ b/src/gate/param_gate_pauli.cpp
@@ -27,8 +27,8 @@ std::string ParamPauliRotationGateImpl<Prec>::to_string(const std::string& inden
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Host>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
                          this->_control_value_mask,
@@ -36,12 +36,13 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          phase_flip_mask,
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef * static_cast<Float<Prec>>(param),
-                         state_vector);
+                         context.state);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Host>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
@@ -57,12 +58,12 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef,
                          params_view,
-                         states);
+                         context.states);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::HostSerial>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
                          this->_control_value_mask,
@@ -70,13 +71,13 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          phase_flip_mask,
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef * static_cast<Float<Prec>>(param),
-                         state_vector);
+                         context.state);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-    std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
@@ -92,13 +93,13 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef,
                          params_view,
-                         states);
+                         context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Default>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
                          this->_control_value_mask,
@@ -106,12 +107,13 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          phase_flip_mask,
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef * static_cast<Float<Prec>>(param),
-                         state_vector);
+                         context.state);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Default>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
@@ -128,7 +130,7 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef,
                          params_view,
-                         states);
+                         context.states);
 }
 #endif
 template class ParamPauliRotationGateImpl<Prec>;

--- a/src/gate/param_gate_probabilistic.cpp
+++ b/src/gate/param_gate_probabilistic.cpp
@@ -7,6 +7,17 @@ namespace {
 template <Precision Prec>
 using EitherGate = std::variant<Gate<Prec>, ParamGate<Prec>>;
 
+template <Precision Prec, ExecutionSpace Space>
+std::uint64_t select_probabilistic_gate_index(const std::vector<double>& cumulative_distribution,
+                                              ExecutionContext<Prec, Space> context) {
+    std::uniform_real_distribution<double> dist(0., 1.);
+    std::uint64_t i = std::distance(cumulative_distribution.begin(),
+                                    std::ranges::upper_bound(cumulative_distribution,
+                                                             dist(context.random_engine))) -
+                      1;
+    return std::min<std::uint64_t>(i, cumulative_distribution.size() - 2);
+}
+
 template <Precision Prec>
 void flatten_param_probabilistic_gate(double prob_prefix,
                                       const EitherGate<Prec>& gate,
@@ -98,130 +109,75 @@ std::string ParamProbabilisticGateImpl<Prec>::to_string(const std::string& inden
 }
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Host>& state_vector, double param) const {
-    Random random;
-    double r = random.uniform();
-    std::uint64_t i = std::distance(_cumulative_distribution.begin(),
-                                    std::ranges::upper_bound(_cumulative_distribution, r)) -
-                      1;
-    if (i >= _gate_list.size()) i = _gate_list.size() - 1;
+    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    const std::uint64_t i = select_probabilistic_gate_index(_cumulative_distribution, context);
     const auto& gate = _gate_list[i];
     if (gate.index() == 0) {
-        std::get<0>(gate)->update_quantum_state(state_vector);
+        std::get<0>(gate)->update_quantum_state(context);
     } else {
-        std::get<1>(gate)->update_quantum_state(state_vector, param);
+        std::get<1>(gate)->update_quantum_state(context, param);
     }
 }
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Host>& states, std::vector<double> params) const {
-    Random random;
-    std::vector<double> r(states.batch_size());
-    std::ranges::generate(r, [&random]() { return random.uniform(); });
-    std::vector<std::uint64_t> indicies(states.batch_size());
-    std::ranges::transform(r, indicies.begin(), [this](double r) {
-        return std::distance(_cumulative_distribution.begin(),
-                             std::ranges::upper_bound(_cumulative_distribution, r)) -
-               1;
-    });
-    std::ranges::transform(indicies, indicies.begin(), [this](std::uint64_t i) {
-        if (i >= _gate_list.size()) i = _gate_list.size() - 1;
-        return i;
-    });
-    for (std::size_t i = 0; i < states.batch_size(); ++i) {
-        const auto& gate = _gate_list[indicies[i]];
-        auto state_vector = states.view_state_vector_at(i);
-        if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(state_vector);
-        } else {
-            std::get<1>(gate)->update_quantum_state(state_vector, params[i]);
-        }
+    ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+    const std::vector<double>& params) const {
+    for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
+        auto state_vector = context.states.view_state_vector_at(i);
+        this->update_quantum_state(
+            ExecutionContext<Prec, ExecutionSpace::Host>{state_vector,
+                                                         context.classical_register[i],
+                                                         context.random_engine},
+            params[i]);
     }
 }
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::HostSerial>& state_vector, double param) const {
-    Random random;
-    double r = random.uniform();
-    std::uint64_t i = std::distance(_cumulative_distribution.begin(),
-                                    std::ranges::upper_bound(_cumulative_distribution, r)) -
-                      1;
-    if (i >= _gate_list.size()) i = _gate_list.size() - 1;
+    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    const std::uint64_t i = select_probabilistic_gate_index(_cumulative_distribution, context);
     const auto& gate = _gate_list[i];
     if (gate.index() == 0) {
-        std::get<0>(gate)->update_quantum_state(state_vector);
+        std::get<0>(gate)->update_quantum_state(context);
     } else {
-        std::get<1>(gate)->update_quantum_state(state_vector, param);
+        std::get<1>(gate)->update_quantum_state(context, param);
     }
 }
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-    std::vector<double> params) const {
-    Random random;
-    std::vector<double> r(states.batch_size());
-    std::ranges::generate(r, [&random]() { return random.uniform(); });
-    std::vector<std::uint64_t> indicies(states.batch_size());
-    std::ranges::transform(r, indicies.begin(), [this](double r) {
-        return std::distance(_cumulative_distribution.begin(),
-                             std::ranges::upper_bound(_cumulative_distribution, r)) -
-               1;
-    });
-    std::ranges::transform(indicies, indicies.begin(), [this](std::uint64_t i) {
-        if (i >= _gate_list.size()) i = _gate_list.size() - 1;
-        return i;
-    });
-    for (std::size_t i = 0; i < states.batch_size(); ++i) {
-        const auto& gate = _gate_list[indicies[i]];
-        auto state_vector = states.view_state_vector_at(i);
-        if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(state_vector);
-        } else {
-            std::get<1>(gate)->update_quantum_state(state_vector, params[i]);
-        }
+    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+    const std::vector<double>& params) const {
+    for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
+        auto state_vector = context.states.view_state_vector_at(i);
+        this->update_quantum_state(
+            ExecutionContext<Prec, ExecutionSpace::HostSerial>{state_vector,
+                                                               context.classical_register[i],
+                                                               context.random_engine},
+            params[i]);
     }
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Default>& state_vector, double param) const {
-    Random random;
-    double r = random.uniform();
-    std::uint64_t i = std::distance(_cumulative_distribution.begin(),
-                                    std::ranges::upper_bound(_cumulative_distribution, r)) -
-                      1;
-    if (i >= _gate_list.size()) i = _gate_list.size() - 1;
+    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    const std::uint64_t i = select_probabilistic_gate_index(_cumulative_distribution, context);
     const auto& gate = _gate_list[i];
     if (gate.index() == 0) {
-        std::get<0>(gate)->update_quantum_state(state_vector);
+        std::get<0>(gate)->update_quantum_state(context);
     } else {
-        std::get<1>(gate)->update_quantum_state(state_vector, param);
+        std::get<1>(gate)->update_quantum_state(context, param);
     }
 }
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Default>& states, std::vector<double> params) const {
-    Random random;
-    std::vector<double> r(states.batch_size());
-    std::ranges::generate(r, [&random]() { return random.uniform(); });
-    std::vector<std::uint64_t> indicies(states.batch_size());
-    std::ranges::transform(r, indicies.begin(), [this](double r) {
-        return std::distance(_cumulative_distribution.begin(),
-                             std::ranges::upper_bound(_cumulative_distribution, r)) -
-               1;
-    });
-    std::ranges::transform(indicies, indicies.begin(), [this](std::uint64_t i) {
-        if (i >= _gate_list.size()) i = _gate_list.size() - 1;
-        return i;
-    });
-    for (std::size_t i = 0; i < states.batch_size(); ++i) {
-        const auto& gate = _gate_list[indicies[i]];
-        auto state_vector = states.view_state_vector_at(i);
-        if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(state_vector);
-        } else {
-            std::get<1>(gate)->update_quantum_state(state_vector, params[i]);
-        }
+    ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+    const std::vector<double>& params) const {
+    for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
+        auto state_vector = context.states.view_state_vector_at(i);
+        this->update_quantum_state(
+            ExecutionContext<Prec, ExecutionSpace::Default>{state_vector,
+                                                            context.classical_register[i],
+                                                            context.random_engine},
+            params[i]);
     }
 }
 #endif

--- a/src/gate/param_gate_standard.cpp
+++ b/src/gate/param_gate_standard.cpp
@@ -21,18 +21,19 @@ std::string ParamRXGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Host>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Host>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -45,23 +46,23 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::HostSerial>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-    std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -74,23 +75,24 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Default>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Default>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -104,7 +106,7 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #endif  // SCALUQ_USE_CUDA
 template class ParamRXGateImpl<Prec>;
@@ -126,18 +128,19 @@ std::string ParamRYGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Host>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Host>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -150,23 +153,23 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::HostSerial>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-    std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -179,23 +182,24 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Default>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Default>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -209,7 +213,7 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #endif  // SCALUQ_USE_CUDA
 template class ParamRYGateImpl<Prec>;
@@ -231,18 +235,19 @@ std::string ParamRZGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Host>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Host>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -255,23 +260,23 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::HostSerial>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
-    std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -284,23 +289,24 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVector<Prec, ExecutionSpace::Default>& state_vector, double param) const {
-    this->check_qubit_mask_within_bounds(state_vector);
+    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    this->check_qubit_mask_within_bounds(context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            state_vector);
+            context.state);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    StateVectorBatched<Prec, ExecutionSpace::Default>& states, std::vector<double> params) const {
-    this->check_qubit_mask_within_bounds(states);
+    ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+    const std::vector<double>& params) const {
+    this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -314,7 +320,7 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            states);
+            context.states);
 }
 #endif  // SCALUQ_USE_CUDA
 template class ParamRZGateImpl<Prec>;


### PR DESCRIPTION
#347でいただいたレビューを受けて，修正を分割しました．
- Circuitの中にレジスタを持たせるのをやめて，古典レジスタのクラス（バッチ／非バッチ用）を追加しました．
  - resetメソッドも追加 
- ExecutionContextによって各ゲートの更新関数へレジスタと擬似乱数生成エンジンを届けます．