### PR TITLE
Refactor ExecutionContext to use references for state and states

### DIFF
--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -192,7 +192,7 @@ constexpr GateType get_gate_type() {
 namespace internal {
 template <Precision Prec, ExecutionSpace Space>
 struct ExecutionContext {
-    StateVector<Prec, Space> state;
+    StateVector<Prec, Space>& state;
     ClassicalRegister& classical_register;
     std::mt19937_64& random_engine;
 
@@ -206,7 +206,7 @@ struct ExecutionContext {
 
 template <Precision Prec, ExecutionSpace Space>
 struct ExecutionContextBatched {
-    StateVectorBatched<Prec, Space> states;
+    StateVectorBatched<Prec, Space>& states;
     ClassicalRegisterBatched& classical_register;
     std::mt19937_64& random_engine;
 


### PR DESCRIPTION
ExecutionContextのStateVectorを値渡しにしていたことからCIでSpsrse/DenseMatrixのupdateが死んでいました...すみません．
参照を持つことで修正します．