### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
 <details>
 <summary>For external contributor</summary>
 
-~~~md
-Thanks for contributing scaluq!
-Please write in English or Japanese.
-PR title name example
-- new feature: 'Add function-name'
-- update: 'Update sample code'
-- bug: 'Fix bug-name'
-~~~
+Thanks for contributing Scaluq!  
+Please write in English or Japanese.  
+
+**PR title name examples**  
+- new feature: `Add function-name`
+- update: `Update sample code`
+- bug: `Fix bug-name`
+
 </details>
 
 ## Summary

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<details>
+<summary>For external contributor</summary>
+
+~~~md
+Thanks for contributing scaluq!
+Please write in English or Japanese.
+PR title name example
+- new feature: 'Add function-name'
+- update: 'Update sample code'
+- bug: 'Fix bug-name'
+~~~
+</details>
+
+## Summary
+Briefly describe the changes in this PR.  
+
+
+
+## What was changed? (変更点)
+- 
+
+## Why was this change needed? (変更理由)
+- 
+
+## Additional context (optional)
+-

--- a/.github/workflows/test_changed.yml
+++ b/.github/workflows/test_changed.yml
@@ -2,13 +2,6 @@ name: Test Changed Files
 
 on:
   pull_request:
-    paths-ignore:
-      - ".devcontainer/**"
-      - ".vscode/**"
-      - "doc/**"
-      - "**/*.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/workflows/lint.yml"
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ int main() {
             scaluq::StateVector<Prec, Space>::Haar_random_state(n_qubits, 0);
         std::cout << state << std::endl;
 
-        scaluq::Circuit<Prec> circuit(n_qubits);
+        scaluq::Circuit<Prec> circuit;
         circuit.add_gate(scaluq::gate::X<Prec>(0));
         circuit.add_gate(scaluq::gate::CNot<Prec>(0, 1));
         circuit.add_gate(scaluq::gate::Y<Prec>(1));

--- a/README_ja.md
+++ b/README_ja.md
@@ -131,7 +131,7 @@ int main() {
             scaluq::StateVector<Prec, Space>::Haar_random_state(n_qubits, 0);
         std::cout << state << std::endl;
 
-        scaluq::Circuit<Prec> circuit(n_qubits);
+        scaluq::Circuit<Prec> circuit;
         circuit.add_gate(scaluq::gate::X<Prec>(0));
         circuit.add_gate(scaluq::gate::CNot<Prec>(0, 1));
         circuit.add_gate(scaluq::gate::Y<Prec>(1));


### PR DESCRIPTION
## Pull request templateの追加
1つだけPRテンプレを作成しています。
- 複数テンプレートになるとissueテンプレのように選択ができず、テンプレの選択に手間がかかる。
- 外部向けと分けたかったが、テンプレ選択に手間取るのでhtmlタグ内で外部コントリビューターに説明をしています。
(ちょっとした説明を書いてますが、
htmlタグで閉じているので特に邪魔にはならないはず)

### READMEの更新
古いバージョンのサンプルコードを
`circuit` <- `circuit(n_qubits)` に更新