### PR TITLE
Update cuda arch from 61 to 75

### DIFF
--- a/.github/workflows/install_merge.yml
+++ b/.github/workflows/install_merge.yml
@@ -46,7 +46,7 @@ jobs:
       CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
       SCALUQ_USE_CUDA: ${{ matrix.device == 'cuda' && 'ON' || 'OFF' }}
       SCALUQ_CPU_NATIVE: "OFF"
-      SCALUQ_CUDA_ARCH: "PASCAL61"
+      SCALUQ_CUDA_ARCH: "TURING75"
       SCALUQ_FLOAT16: ${{ matrix.compiler == 'clang' && 'OFF' || 'ON' }}
       SCALUQ_FLOAT32: "ON"
       SCALUQ_FLOAT64: "ON"
@@ -153,7 +153,7 @@ jobs:
       CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
       SCALUQ_USE_CUDA: ${{ matrix.device == 'cuda' && 'ON' || 'OFF' }}
       SCALUQ_CPU_NATIVE: "OFF"
-      SCALUQ_CUDA_ARCH: "PASCAL61"
+      SCALUQ_CUDA_ARCH: "TURING75"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/install_pr.yml
+++ b/.github/workflows/install_pr.yml
@@ -50,7 +50,7 @@ jobs:
       CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
       SCALUQ_USE_CUDA: ${{ matrix.device == 'cuda' && 'ON' || 'OFF' }}
       SCALUQ_CPU_NATIVE: "OFF"
-      SCALUQ_CUDA_ARCH: "PASCAL61"
+      SCALUQ_CUDA_ARCH: "TURING75"
       SCALUQ_FLOAT16: ${{ (matrix.device == 'cpu' || matrix.compiler == 'clang') && 'OFF' || 'ON' }}
       SCALUQ_FLOAT32: ${{ matrix.device == 'cpu' && 'OFF' || 'ON' }}
       SCALUQ_FLOAT64: "ON"
@@ -151,7 +151,7 @@ jobs:
       CMAKE_CXX_COMPILER: ${{ matrix.cxx-compiler }}
       SCALUQ_USE_CUDA: "OFF"
       SCALUQ_CPU_NATIVE: "OFF"
-      SCALUQ_CUDA_ARCH: "PASCAL61"
+      SCALUQ_CUDA_ARCH: "TURING75"
       SCALUQ_FLOAT32: "OFF"
       SCALUQ_FLOAT64: "ON"
     steps:

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -49,7 +49,7 @@ jobs:
       SCALUQ_USE_TEST: "ON"
       SCALUQ_USE_CUDA: ${{ matrix.device == 'cuda' && 'ON' || 'OFF' }}
       SCALUQ_CPU_NATIVE: "OFF"
-      SCALUQ_CUDA_ARCH: "PASCAL61"
+      SCALUQ_CUDA_ARCH: "TURING75"
       SCALUQ_FLOAT16: ${{ matrix.compiler == 'clang' && 'OFF' || 'ON' }}
       SCALUQ_FLOAT32: "ON"
       SCALUQ_FLOAT64: "ON"

--- a/.github/workflows/test_changed.yml
+++ b/.github/workflows/test_changed.yml
@@ -51,7 +51,7 @@ jobs:
       CMAKE_BUILD_TYPE: ${{ matrix.device == 'cuda' && 'Release' || 'Debug' }}
       SCALUQ_USE_TEST: "ON"
       SCALUQ_USE_CUDA: ${{ matrix.device == 'cuda' && 'ON' || 'OFF' }}
-      SCALUQ_CUDA_ARCH: "PASCAL61"
+      SCALUQ_CUDA_ARCH: "TURING75"
       SCALUQ_FLOAT16: ${{ matrix.compiler == 'clang' && 'OFF' || 'ON' }}
       SCALUQ_FLOAT32: "ON"
       SCALUQ_FLOAT64: "ON"


### PR DESCRIPTION
#359 のPRです。
```
nvcc warning : Support for offline compilation for architectures prior to '<compute/sm/lto>_75' 
will be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
```
の警告の解消。
75から安全圏のようなので、とりあえず`TURING75`にバージョンアップをしています。