### PR TITLE
Precompile headersの導入によるＣＩの高速化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,18 @@ endif()
 # Enable pthread
 target_compile_options(scaluq_base PUBLIC -pthread)
 
+# Precompiled Headers (PCH)
+target_precompile_headers(scaluq_base PUBLIC
+    <Kokkos_Core.hpp>
+    <Eigen/Core>
+    <Eigen/Dense>
+    <vector>
+    <complex>
+    <memory>
+    <iostream>
+    <type_traits>
+)
+
 # Enable openmp
 if(SCALUQ_USE_OMP)
     target_compile_options(scaluq_base PUBLIC -fopenmp)


### PR DESCRIPTION
related to #343 

Precompile headersの導入によるCUDAコンパイル時間測定のためのdraft PRなのでレビューは不要です。