### PR TITLE
add clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks: -*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,google-*,hicpp-*,llvm-*,openmp-*,performance-*,readability-*,-bugprone-easily-swappable-parameters,-readability-identifier-length,-cppcoreguidelines-macro-usage,-llvm-header-guard,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers
+HeaderFilterRegex: 'include/scaluq/.*'
+---

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 ---
-Checks: -*,bugprone-*,cert-*,clang-analyzer-*,cppcoreguidelines-*,google-*,hicpp-*,llvm-*,openmp-*,performance-*,readability-*,-bugprone-easily-swappable-parameters,-readability-identifier-length,-cppcoreguidelines-macro-usage,-llvm-header-guard,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers
+Checks: -*,bugprone-*,clang-analyzer-*,cppcoreguidelines-*,performance-*,readability-*,-bugprone-easily-swappable-parameters,-readability-identifier-length,-cppcoreguidelines-macro-usage,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-braces-around-statements,-readability-implicit-bool-conversion,-cppcoreguidelines-misleading-capture-default-by-value
 HeaderFilterRegex: 'include/scaluq/.*'
 ---

--- a/.devcontainer/cpu/Dockerfile
+++ b/.devcontainer/cpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -9,9 +9,6 @@ ENV PYTHONPATH="${PROJECT_DIR}/dist:${PYTHONPATH}"
 ENV PYTHONPATH="${PROJECT_DIR}/build:${PYTHONPATH}"
 
 RUN apt-get update && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository ppa:ubuntu-toolchain-r/test && \
-    apt-get update && \
     apt-get install -y gcc-13 g++-13 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100 && \
@@ -20,6 +17,8 @@ RUN apt-get update && \
     ca-certificates \
     ccache \
     clang-format \
+    clang-tidy \
+    libomp-dev \
     curl \
     git \
     gdb \
@@ -32,7 +31,9 @@ RUN apt-get update && \
     wget && \
     apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* && \
     update-alternatives --set gcc /usr/bin/gcc-13 && \
-    update-alternatives --set g++ /usr/bin/g++-13
+    update-alternatives --set g++ /usr/bin/g++-13 && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
 
 ENV CC=/usr/lib/ccache/gcc
 ENV CXX=/usr/lib/ccache/g++
@@ -52,21 +53,16 @@ RUN git clone --recursive https://github.com/kokkos/kokkos.git /tmp/kokkos --dep
     cp -r /tmp/kokkos-build/include /usr/local/include/kokkos && \
     rm -rf /tmp/kokkos /tmp/kokkos-build
 
-RUN pip install nanobind==2.0.0
+RUN pip install nanobind==2.0.0 --break-system-packages
 
 RUN locale-gen en_US.UTF-8
 
-ARG USERNAME=vscode
-ARG GROUPNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-RUN groupadd --gid $USER_GID $GROUPNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    && apt-get update \
+ARG USERNAME=ubuntu
+RUN apt-get update \
     && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
-USER vscode
+USER ubuntu
 
-ENV PATH="/home/vscode/.local/bin:${PATH}"
+ENV PATH="/home/ubuntu/.local/bin:${PATH}"

--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -74,11 +74,11 @@
 	// A location of gpg might differ from host machine's git config.
 	// This config accepts string or array. If you use array form destructure command like following; not a list of commands.
 	// ["echo", "hello"]
-	"postStartCommand": "/usr/bin/git config --global gpg.program /usr/bin/gpg && git config --global safe.directory /workspaces/scaluq && sudo chown vscode build",
+	"postStartCommand": "/usr/bin/git config --global gpg.program /usr/bin/gpg && git config --global safe.directory /workspaces/scaluq && sudo chown ubuntu build",
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "gcc -v",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode",
+	"remoteUser": "ubuntu",
 }

--- a/.devcontainer/gpu/Dockerfile
+++ b/.devcontainer/gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.1-devel-ubuntu22.04
+FROM nvidia/cuda:12.6.1-devel-ubuntu24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -9,9 +9,6 @@ ENV PYTHONPATH="${PROJECT_DIR}/dist:${PYTHONPATH}"
 ENV PYTHONPATH="${PROJECT_DIR}/build:${PYTHONPATH}"
 
 RUN apt-get update && \
-    apt-get install -y software-properties-common && \
-    add-apt-repository ppa:ubuntu-toolchain-r/test && \
-    apt-get update && \
     apt-get install -y gcc-13 g++-13 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100 && \
@@ -19,6 +16,8 @@ RUN apt-get update && \
     ca-certificates \
     ccache \
     clang-format \
+    clang-tidy \
+    libomp-dev \
     curl \
     git \
     gdb \
@@ -30,7 +29,9 @@ RUN apt-get update && \
     wget && \
     apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* && \
     update-alternatives --set gcc /usr/bin/gcc-13 && \
-    update-alternatives --set g++ /usr/bin/g++-13
+    update-alternatives --set g++ /usr/bin/g++-13 && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
 
 ENV CC=/usr/lib/ccache/gcc
 ENV CXX=/usr/lib/ccache/g++
@@ -50,6 +51,14 @@ RUN git clone --recursive https://github.com/kokkos/kokkos.git /tmp/kokkos --dep
     cp -r /tmp/kokkos-build/include /usr/local/include/kokkos && \
     rm -rf /tmp/kokkos /tmp/kokkos-build
 
-RUN pip install nanobind==2.0.0
+RUN pip install nanobind==2.0.0 --break-system-packages
 
-USER vscode
+ARG USERNAME=ubuntu
+RUN apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+USER ubuntu
+
+ENV PATH="/home/ubuntu/.local/bin:${PATH}"

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -79,11 +79,11 @@
 	// A location of gpg might differ from host machine's git config.
 	// This config accepts string or array. If you use array form destructure command like following; not a list of commands.
 	// ["echo", "hello"]
-	"postStartCommand": "/usr/bin/git config --global gpg.program /usr/bin/gpg && sudo chown vscode build",
+	"postStartCommand": "/usr/bin/git config --global gpg.program /usr/bin/gpg && git config --global safe.directory /workspaces/scaluq && sudo chown ubuntu build",
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "gcc -v",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode",
+	"remoteUser": "ubuntu",
 }

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,48 @@
+name: clang-tidy
+
+on:
+  merge_group:
+  push:
+    paths-ignore:
+      - ".devcontainer/**"
+      - ".vscode/**"
+      - "doc/**"
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/workflows/lint.yml"
+
+jobs:
+  clang-tidy:
+    name: Run clang-tidy
+    runs-on: "ubuntu-24.04"
+    env:
+      CMAKE_C_COMPILER: "clang"
+      CMAKE_CXX_COMPILER: "clang++"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup cmake
+        uses: lukka/get-cmake@latest
+
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install -y ninja-build libomp-dev
+
+      - name: Configure
+        run: |
+          script/configure
+
+      - name: Run clang-tidy
+        run: |
+          ninja -C build clang-tidy
+
+  clang-tidy-passed:
+    name: clang-tidy Passed
+    needs: [clang-tidy]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: All checks passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1
+          fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.24)
 
 project(scaluq)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 include(FetchContent)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
@@ -281,6 +283,23 @@ if(SKBUILD)
         DEPENDS scaluq_core
     )
 endif(SKBUILD)
+
+# clang-tidy
+find_program(CLANG_TIDY "clang-tidy")
+if(CLANG_TIDY)
+    file(GLOB_RECURSE ALL_CXX_TIDY_SOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp
+    )
+    add_custom_target(
+        clang-tidy
+        COMMAND ${CLANG_TIDY}
+        -p=${CMAKE_BINARY_DIR}
+        --warnings-as-errors=*
+        ${ALL_CXX_TIDY_SOURCE_FILES}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()
 
 # format
 find_program(CLANG_FORMAT "clang-format")

--- a/include/scaluq/constant.hpp
+++ b/include/scaluq/constant.hpp
@@ -71,7 +71,8 @@ KOKKOS_INLINE_FUNCTION Matrix2x2<Prec> T_DAG_GATE_MATRIX() {
 template <Precision Prec>
 KOKKOS_INLINE_FUNCTION Matrix2x2<Prec> HADAMARD_MATRIX() {
     Float<Prec> ISQRT2 = static_cast<Float<Prec>>(INVERSE_SQRT2());
-    return {{{{ISQRT2, ISQRT2}}, {{ISQRT2, -ISQRT2}}}};
+    return {{{{Complex<Prec>(ISQRT2), Complex<Prec>(ISQRT2)}},
+             {{Complex<Prec>(ISQRT2), Complex<Prec>(-ISQRT2)}}}};
 }
 //! square root of X gate
 template <Precision Prec>
@@ -100,22 +101,24 @@ KOKKOS_INLINE_FUNCTION Matrix2x2<Prec> SQRT_Y_DAG_GATE_MATRIX() {
 //! Projection to 0
 template <Precision Prec>
 KOKKOS_INLINE_FUNCTION Matrix2x2<Prec> PROJ_0_MATRIX() {
-    return {{{{1, 0}}, {{0, 0}}}};
+    return {{{{Complex<Prec>(1, 0), Complex<Prec>(0, 0)}},
+             {{Complex<Prec>(0, 0), Complex<Prec>(0, 0)}}}};
 }
 //! Projection to 1
 template <Precision Prec>
 KOKKOS_INLINE_FUNCTION Matrix2x2<Prec> PROJ_1_MATRIX() {
-    return {{{{0, 0}}, {{0, 1}}}};
+    return {{{{Complex<Prec>(0, 0), Complex<Prec>(0, 0)}},
+             {{Complex<Prec>(0, 0), Complex<Prec>(1, 0)}}}};
 }
 //! complex values for exp(j * i*pi/4 )
 template <Precision Prec>
 KOKKOS_INLINE_FUNCTION Kokkos::Array<Complex<Prec>, 4> PHASE_90ROT() {
-    return {1, Complex<Prec>(0, 1), -1, Complex<Prec>(0, -1)};
+    return {Complex<Prec>(1, 0), Complex<Prec>(0, 1), Complex<Prec>(-1, 0), Complex<Prec>(0, -1)};
 }
 //! complex values for exp(-j * i*pi/4 )
 template <Precision Prec>
 KOKKOS_INLINE_FUNCTION Kokkos::Array<Complex<Prec>, 4> PHASE_M90ROT() {
-    return {1, Complex<Prec>(0, -1), -1, Complex<Prec>(0, 1)};
+    return {Complex<Prec>(1, 0), Complex<Prec>(0, -1), Complex<Prec>(-1, 0), Complex<Prec>(0, 1)};
 }
 }  // namespace internal
 }  // namespace scaluq

--- a/include/scaluq/operator/pauli_operator.hpp
+++ b/include/scaluq/operator/pauli_operator.hpp
@@ -35,7 +35,7 @@ public:
         : _coef(coef), _bit_flip_mask(bit_flip_mask), _phase_flip_mask(phase_flip_mask) {}
 
     void set_coef(StdComplex c) { _coef = c; }
-    [[nodiscard]] StdComplex coef() const { return _coef; }
+    [[nodiscard]] StdComplex coef() const { return static_cast<StdComplex>(_coef); }
     [[nodiscard]] std::vector<std::uint64_t> target_qubit_list() const;
     [[nodiscard]] std::vector<std::uint64_t> pauli_id_list() const;
     [[nodiscard]] std::tuple<std::uint64_t, std::uint64_t> get_XZ_mask_representation() const {
@@ -93,12 +93,15 @@ public:
         extra_90rot_cnt -= Kokkos::popcount(z_left & y_right);  // ZY = -iX
         extra_90rot_cnt %= 4;
         if (extra_90rot_cnt < 0) extra_90rot_cnt += 4;
-        return PauliOperator(_bit_flip_mask ^ target._bit_flip_mask,
-                             _phase_flip_mask ^ target._phase_flip_mask,
-                             _coef * target._coef * internal::PHASE_90ROT<Prec>()[extra_90rot_cnt]);
+        return PauliOperator(
+            _bit_flip_mask ^ target._bit_flip_mask,
+            _phase_flip_mask ^ target._phase_flip_mask,
+            static_cast<StdComplex>(_coef * target._coef *
+                                    internal::PHASE_90ROT<Prec>()[extra_90rot_cnt]));
     }
     [[nodiscard]] KOKKOS_INLINE_FUNCTION PauliOperator operator*(StdComplex coef) const {
-        return PauliOperator(_bit_flip_mask, _phase_flip_mask, _coef * coef);
+        return PauliOperator(
+            _bit_flip_mask, _phase_flip_mask, static_cast<StdComplex>(_coef) * coef);
     }
     KOKKOS_INLINE_FUNCTION PauliOperator& operator*=(const PauliOperator& target) {
         *this = *this * target;

--- a/include/scaluq/state/state_vector.hpp
+++ b/include/scaluq/state/state_vector.hpp
@@ -15,21 +15,19 @@ namespace scaluq {
 
 template <Precision Prec, ExecutionSpace Space>
 class StateVector {
-    std::uint64_t _n_qubits;
-    std::uint64_t _dim;
+    std::uint64_t _n_qubits{};
+    std::uint64_t _dim{};
     using FloatType = internal::Float<Prec>;
     using ComplexType = internal::Complex<Prec>;
     using ExecutionSpaceType = internal::SpaceType<Space>;
 
 public:
     static constexpr std::uint64_t UNMEASURED = 2;
-    Kokkos::View<ComplexType*, ExecutionSpaceType> _raw;
+    Kokkos::View<ComplexType*, ExecutionSpaceType>
+        _raw;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
     StateVector() = default;
-    StateVector(std::uint64_t n_qubits);
-    StateVector(Kokkos::View<ComplexType*, ExecutionSpaceType> view);
-    StateVector(const StateVector& other) = default;
-
-    StateVector& operator=(const StateVector& other) = default;
+    explicit StateVector(std::uint64_t n_qubits);
+    explicit StateVector(Kokkos::View<ComplexType*, ExecutionSpaceType> view);
 
     /**
      * @attention Very slow. You should use load() instead if you can.

--- a/include/scaluq/state/state_vector_batched.hpp
+++ b/include/scaluq/state/state_vector_batched.hpp
@@ -7,20 +7,19 @@ namespace scaluq {
 
 template <Precision Prec, ExecutionSpace Space>
 class StateVectorBatched {
-    std::uint64_t _batch_size;
-    std::uint64_t _n_qubits;
-    std::uint64_t _dim;
+    std::uint64_t _batch_size{};
+    std::uint64_t _n_qubits{};
+    std::uint64_t _dim{};
     using FloatType = internal::Float<Prec>;
     using ComplexType = internal::Complex<Prec>;
     using ExecutionSpaceType = internal::SpaceType<Space>;
 
 public:
-    Kokkos::View<ComplexType**, Kokkos::LayoutRight, ExecutionSpaceType> _raw;
+    Kokkos::View<ComplexType**, Kokkos::LayoutRight, ExecutionSpaceType>
+        _raw;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+
     StateVectorBatched() = default;
     StateVectorBatched(std::uint64_t batch_size, std::uint64_t n_qubits);
-    StateVectorBatched(const StateVectorBatched& other) = default;
-
-    StateVectorBatched& operator=(const StateVectorBatched& other) = default;
 
     [[nodiscard]] std::uint64_t n_qubits() const { return this->_n_qubits; }
 

--- a/include/scaluq/type/complex.hpp
+++ b/include/scaluq/type/complex.hpp
@@ -13,42 +13,35 @@ class Complex {
 public:
     KOKKOS_INLINE_FUNCTION Complex() : _real{0}, _imag{0} {}
     template <typename Scalar>
-    requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
-        std::is_same_v<Scalar, int>
-            KOKKOS_INLINE_FUNCTION Complex(Scalar real)
+        requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
+                     std::is_same_v<Scalar, int>
+    KOKKOS_INLINE_FUNCTION explicit Complex(Scalar real)
         : _real(static_cast<FloatType>(real)), _imag{0} {}
     template <typename Scalar1, typename Scalar2>
-    requires(std::is_same_v<Scalar1, FloatType> || std::is_same_v<Scalar1, double> ||
-             std::is_same_v<Scalar1, int>) &&
-        (std::is_same_v<Scalar2, FloatType> || std::is_same_v<Scalar2, double> ||
-         std::is_same_v<Scalar2, int>)KOKKOS_INLINE_FUNCTION Complex(Scalar1 real, Scalar2 imag)
-        : _real(static_cast<FloatType>(real)),
-    _imag(static_cast<FloatType>(imag)) {}
-    KOKKOS_INLINE_FUNCTION Complex(const Complex& other)
-        : _real(other.real()), _imag(other.imag()) {}
-    KOKKOS_INLINE_FUNCTION Complex(const std::complex<double>& c)
+        requires(std::is_same_v<Scalar1, FloatType> || std::is_same_v<Scalar1, double> ||
+                 std::is_same_v<Scalar1, int>) &&
+                    (std::is_same_v<Scalar2, FloatType> || std::is_same_v<Scalar2, double> ||
+                     std::is_same_v<Scalar2, int>)
+    KOKKOS_INLINE_FUNCTION Complex(Scalar1 real, Scalar2 imag)
+        : _real(static_cast<FloatType>(real)), _imag(static_cast<FloatType>(imag)) {}
+    KOKKOS_INLINE_FUNCTION explicit Complex(const std::complex<double>& c)
         : _real(static_cast<FloatType>(c.real())), _imag(static_cast<FloatType>(c.imag())) {}
 
-    KOKKOS_INLINE_FUNCTION Complex& operator=(const Complex& other) {
-        _real = other._real;
-        _imag = other._imag;
-        return *this;
-    }
     KOKKOS_INLINE_FUNCTION Complex& operator=(const std::complex<double>& c) {
         _real = static_cast<FloatType>(c.real());
         _imag = static_cast<FloatType>(c.imag());
         return *this;
     }
     template <typename Scalar>
-    requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
-        std::is_same_v<Scalar, int>
-            KOKKOS_INLINE_FUNCTION Complex& operator=(Scalar real) {
+        requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
+                 std::is_same_v<Scalar, int>
+    KOKKOS_INLINE_FUNCTION Complex& operator=(Scalar real) {
         _real = static_cast<FloatType>(real);
         _imag = FloatType{0};
         return *this;
     }
 
-    KOKKOS_INLINE_FUNCTION operator std::complex<double>() const {
+    KOKKOS_INLINE_FUNCTION explicit operator std::complex<double>() const {
         return std::complex(static_cast<double>(_real), static_cast<double>(_imag));
     }
 
@@ -82,38 +75,38 @@ public:
     }
     KOKKOS_INLINE_FUNCTION Complex& operator*=(const Complex& rhs) { return *this = *this * rhs; }
     template <typename Scalar>
-    requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
-        std::is_same_v<Scalar, int>
-            KOKKOS_INLINE_FUNCTION Complex& operator*=(Scalar rhs) {
+        requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
+                 std::is_same_v<Scalar, int>
+    KOKKOS_INLINE_FUNCTION Complex& operator*=(Scalar rhs) {
         _real *= static_cast<FloatType>(rhs);
         _imag *= static_cast<FloatType>(rhs);
         return *this;
     }
     template <typename Scalar>
-    requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
-        std::is_same_v<Scalar, int>
-            KOKKOS_INLINE_FUNCTION Complex operator*(Scalar rhs) const {
+        requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
+                 std::is_same_v<Scalar, int>
+    KOKKOS_INLINE_FUNCTION Complex operator*(Scalar rhs) const {
         return Complex(*this) *= static_cast<FloatType>(rhs);
     }
     template <typename Scalar>
-    requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
-        std::is_same_v<Scalar, int>
-            KOKKOS_INLINE_FUNCTION friend Complex operator*(Scalar lhs, const Complex& rhs) {
+        requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
+                 std::is_same_v<Scalar, int>
+    KOKKOS_INLINE_FUNCTION friend Complex operator*(Scalar lhs, const Complex& rhs) {
         return Complex(static_cast<FloatType>(lhs) * rhs._real,
                        static_cast<FloatType>(lhs) * rhs._imag);
     }
     template <typename Scalar>
-    requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
-        std::is_same_v<Scalar, int>
-            KOKKOS_INLINE_FUNCTION Complex& operator/=(Scalar rhs) {
+        requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
+                 std::is_same_v<Scalar, int>
+    KOKKOS_INLINE_FUNCTION Complex& operator/=(Scalar rhs) {
         _real /= static_cast<FloatType>(rhs);
         _imag /= static_cast<FloatType>(rhs);
         return *this;
     }
     template <typename Scalar>
-    requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
-        std::is_same_v<Scalar, int>
-            KOKKOS_INLINE_FUNCTION Complex operator/(Scalar rhs) const {
+        requires std::is_same_v<Scalar, FloatType> || std::is_same_v<Scalar, double> ||
+                 std::is_same_v<Scalar, int>
+    KOKKOS_INLINE_FUNCTION Complex operator/(Scalar rhs) const {
         return Complex(*this) /= static_cast<FloatType>(rhs);
     }
 

--- a/include/scaluq/type/floating_point.hpp
+++ b/include/scaluq/type/floating_point.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <limits>
 #include <type_traits>
 
@@ -14,7 +15,7 @@
 #endif
 
 namespace scaluq {
-enum class Precision { F16, F32, F64, BF16 };
+enum class Precision : std::uint8_t { F16, F32, F64, BF16 };
 }  // namespace scaluq
 
 namespace scaluq::internal {
@@ -100,5 +101,5 @@ constexpr bool IsFloatingPointV = IsFloatingPoint<T>::value;
 template <typename T>
 concept FloatingPoint = IsFloatingPointV<T>;
 template <Precision Prec>
-using Float = FloatTypeImpl<Prec>::Type;
+using Float = typename FloatTypeImpl<Prec>::Type;
 };  // namespace scaluq::internal

--- a/include/scaluq/types.hpp
+++ b/include/scaluq/types.hpp
@@ -16,9 +16,9 @@ using StdComplex = std::complex<double>;
 using Json = nlohmann::json;
 
 #ifdef SCALUQ_USE_CUDA
-enum class ExecutionSpace { Host, HostSerial, Default };
+enum class ExecutionSpace : std::uint8_t { Host, HostSerial, Default };
 #else
-enum class ExecutionSpace { Host, HostSerial, Default = Host };
+enum class ExecutionSpace : std::uint8_t { Host, HostSerial, Default = Host };
 #endif
 
 using ComplexMatrix = Eigen::Matrix<StdComplex, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
@@ -75,7 +75,7 @@ public:
     Kokkos::View<std::uint32_t*, SpaceType<Space>> _col_idx, _row_ptr;
     std::uint64_t _rows, _cols;
 
-    SparseMatrix(const SparseComplexMatrix& sp);
+    explicit SparseMatrix(const SparseComplexMatrix& sp);
 };
 
 }  // namespace internal
@@ -107,8 +107,8 @@ struct adl_serializer<::scaluq::ComplexMatrix> {
         }
     }
     static void from_json(const json& j, ::scaluq::ComplexMatrix& value) {
-        int rows = j.size();
-        int cols = j[0].size();
+        int rows = static_cast<int>(j.size());
+        int cols = static_cast<int>(j[0].size());
         value.resize(rows, cols);
         int row_idx = 0;
         for (const auto& row : j) {
@@ -130,7 +130,7 @@ struct adl_serializer<::scaluq::SparseComplexMatrix> {
         json triplets = json::array();
         for (std::uint64_t row_idx = 0; row_idx < static_cast<std::uint64_t>(value.outerSize());
              ++row_idx) {
-            for (typename ::scaluq::SparseComplexMatrix::InnerIterator it(value, row_idx); it;
+            for (typename ::scaluq::SparseComplexMatrix::InnerIterator it(value, static_cast<Eigen::Index>(row_idx)); it;
                  ++it) {
                 triplets.push_back({{"row", it.row()}, {"col", it.col()}, {"val", it.value()}});
             }
@@ -140,7 +140,7 @@ struct adl_serializer<::scaluq::SparseComplexMatrix> {
     static void from_json(const json& j, ::scaluq::SparseComplexMatrix& value) {
         std::uint64_t rows = j["rows"].get<std::uint64_t>();
         std::uint64_t cols = j["cols"].get<std::uint64_t>();
-        value.resize(rows, cols);
+        value.resize(static_cast<Eigen::Index>(rows), static_cast<Eigen::Index>(cols));
         std::vector<Eigen::Triplet<::scaluq::StdComplex>> triplets;
         for (const auto& triplet : j["triplets"]) {
             triplets.emplace_back(triplet["row"].get<std::uint64_t>(),

--- a/include/scaluq/util/math.hpp
+++ b/include/scaluq/util/math.hpp
@@ -141,10 +141,10 @@ private:
 
 public:
     KOKKOS_INLINE_FUNCTION
-    Sum(value_type& value_) : value(&value_), references_scalar_v(true) {}
+    explicit Sum(value_type& value_) : value(&value_), references_scalar_v(true) {}
 
     KOKKOS_INLINE_FUNCTION
-    Sum(const result_view_type& value_) : value(value_), references_scalar_v(false) {}
+    explicit Sum(const result_view_type& value_) : value(value_), references_scalar_v(false) {}
 
     // Required
     KOKKOS_INLINE_FUNCTION

--- a/include/scaluq/util/random.hpp
+++ b/include/scaluq/util/random.hpp
@@ -12,7 +12,7 @@ class Random {
     std::normal_distribution<double> normal_dist;
 
 public:
-    Random(std::uint64_t seed = std::random_device()())
+    explicit Random(std::uint64_t seed = std::random_device()())
         : mt(seed), uniform_dist(0, 1), normal_dist(0, 1) {}
 
     [[nodiscard]] double uniform() { return this->uniform_dist(this->mt); }

--- a/include/scaluq/util/utility.hpp
+++ b/include/scaluq/util/utility.hpp
@@ -37,7 +37,7 @@ KOKKOS_INLINE_FUNCTION std::uint64_t insert_zero_at_mask_positions(std::uint64_t
          bit_mask &= (bit_mask - 1)) {  // loop through set bits
         std::uint64_t lower_mask = ~bit_mask & (bit_mask - 1);
         std::uint64_t upper_mask = ~lower_mask;
-        basis_index = ((basis_index & upper_mask) << 1) | (basis_index & lower_mask);
+        basis_index = ((basis_index & upper_mask) << 1U) | (basis_index & lower_mask);
     }
     return basis_index;
 }
@@ -51,7 +51,7 @@ inline std::uint64_t vector_to_mask(const std::vector<std::uint64_t>& indices) {
             if (x >= sizeof(std::uint64_t) * 8) [[unlikely]] {
                 throw std::runtime_error("The size of the qubit system must be less than 64.");
             }
-            if ((mask >> x) & 1) [[unlikely]] {
+            if ((mask >> x) & 1U) [[unlikely]] {
                 throw std::runtime_error("The specified qubit is duplicated.");
             }
         }
@@ -88,7 +88,7 @@ inline std::vector<std::uint64_t> mask_to_vector(std::uint64_t mask) {
 inline std::vector<std::uint64_t> mask_to_vector(std::uint64_t indices_mask, std::uint64_t mask) {
     std::vector<std::uint64_t> values;
     for (std::uint64_t sub_mask = indices_mask; sub_mask; sub_mask &= (sub_mask - 1)) {
-        values.push_back((mask >> std::countr_zero(sub_mask)) & 1);
+        values.push_back((mask >> static_cast<std::uint64_t>(std::countr_zero(sub_mask))) & 1U);
     }
     return values;
 }
@@ -214,7 +214,7 @@ inline ComplexMatrix transform_dense_matrix_by_order(const ComplexMatrix& mat,
         std::size_t row_src = transformed[i];
         for (std::size_t j = 0; j < matrix_size; j++) {
             std::size_t col_src = transformed[j];
-            ret(i, j) = mat(row_src, col_src);
+            ret(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j)) = mat(static_cast<Eigen::Index>(row_src), static_cast<Eigen::Index>(col_src));
         }
     }
     return ret;
@@ -230,14 +230,12 @@ inline SparseComplexMatrix transform_sparse_matrix_by_order(
 
 template <Precision Prec>
 constexpr double get_epsilon() {
-    if constexpr (Prec == Precision::F16)
+    if constexpr (Prec == Precision::F16 || Prec == Precision::BF16)
         return 1.;
     else if constexpr (Prec == Precision::F32)
         return 1e-4;
     else if constexpr (Prec == Precision::F64)
         return 1e-12;
-    else if constexpr (Prec == Precision::BF16)
-        return 1.;
     else
         static_assert(internal::lazy_false_v<internal::Float<Prec>>, "unknown Precision");
 }

--- a/src/gate/update_ops_dense_matrix.cpp
+++ b/src/gate/update_ops_dense_matrix.cpp
@@ -191,7 +191,7 @@ void multi_target_dense_matrix_gate(std::uint64_t target_mask,
             Kokkos::parallel_for(Kokkos::TeamThreadRange(team, matrix_dim), [&](std::uint64_t r) {
                 std::uint64_t dst_index =
                     internal::insert_zero_at_mask_positions(r, outer_mask) | basis;
-                Complex<Prec> sum = Float<Prec>{0};
+                Complex<Prec> sum(Float<Prec>{0});
                 Kokkos::parallel_reduce(
                     Kokkos::ThreadVectorRange(team, matrix_dim),
                     [&](std::uint64_t c, Complex<Prec>& inner_sum) {
@@ -245,7 +245,7 @@ void multi_target_dense_matrix_gate(std::uint64_t target_mask,
             Kokkos::parallel_for(Kokkos::TeamThreadRange(team, matrix_dim), [&](std::uint64_t r) {
                 std::uint64_t dst_index =
                     internal::insert_zero_at_mask_positions(r, outer_mask) | basis;
-                Complex<Prec> sum = Float<Prec>{0};
+                Complex<Prec> sum(Float<Prec>{0});
                 Kokkos::parallel_reduce(
                     Kokkos::ThreadVectorRange(team, matrix_dim),
                     [&](std::uint64_t c, Complex<Prec>& inner_sum) {

--- a/src/gate/update_ops_sparse_matrix.cpp
+++ b/src/gate/update_ops_sparse_matrix.cpp
@@ -34,7 +34,7 @@ void sparse_matrix_gate(std::uint64_t target_mask,
             Kokkos::parallel_for(Kokkos::TeamThreadRange(team, mat._rows), [&](std::uint64_t r) {
                 std::uint64_t dst_index =
                     internal::insert_zero_at_mask_positions(r, outer_mask) | basis;
-                Complex<Prec> sum = Float<Prec>{0};
+                Complex<Prec> sum(Float<Prec>{0});
                 Kokkos::parallel_reduce(
                     Kokkos::ThreadVectorRange(team, mat._row_ptr[r], mat._row_ptr[r + 1]),
                     [&](std::uint64_t idx, Complex<Prec>& inner_sum) {
@@ -87,7 +87,7 @@ void sparse_matrix_gate(std::uint64_t target_mask,
             Kokkos::parallel_for(Kokkos::TeamThreadRange(team, mat._rows), [&](std::uint64_t r) {
                 std::uint64_t dst_index =
                     internal::insert_zero_at_mask_positions(r, outer_mask) | basis;
-                Complex<Prec> sum = Float<Prec>{0};
+                Complex<Prec> sum(Float<Prec>{0});
                 Kokkos::parallel_reduce(
                     Kokkos::ThreadVectorRange(team, mat._row_ptr[r], mat._row_ptr[r + 1]),
                     [&](std::uint64_t idx, Complex<Prec>& inner_sum) {

--- a/src/gate/update_ops_standard.cpp
+++ b/src/gate/update_ops_standard.cpp
@@ -5,8 +5,8 @@ template <Precision Prec>
 Matrix2x2<Prec> get_IBMQ_matrix(Float<Prec> _theta, Float<Prec> _phi, Float<Prec> _lambda) {
     Complex<Prec> exp_val1 = internal::exp(Complex<Prec>(0, _phi));
     Complex<Prec> exp_val2 = internal::exp(Complex<Prec>(0, _lambda));
-    Complex<Prec> cos_val = internal::cos(_theta / Float<Prec>{2});
-    Complex<Prec> sin_val = internal::sin(_theta / Float<Prec>{2});
+    Complex<Prec> cos_val(internal::cos(_theta / Float<Prec>{2}));
+    Complex<Prec> sin_val(internal::sin(_theta / Float<Prec>{2}));
     return {
         {{{cos_val, -exp_val2 * sin_val}}, {{exp_val1 * sin_val, exp_val1 * exp_val2 * cos_val}}}};
 }
@@ -365,8 +365,8 @@ void rx_gate(std::uint64_t target_mask,
              StateVector<Prec, Space>& state) {
     const Float<Prec> cosval = internal::cos(angle / Float<Prec>{2});
     const Float<Prec> sinval = internal::sin(angle / Float<Prec>{2});
-    Matrix2x2<Prec> matrix = {
-        {{{cosval, Complex<Prec>(0, -sinval)}}, {{Complex<Prec>(0, -sinval), cosval}}}};
+    Matrix2x2<Prec> matrix = {{{{Complex<Prec>(cosval), Complex<Prec>(0, -sinval)}},
+                               {{Complex<Prec>(0, -sinval), Complex<Prec>(cosval)}}}};
     one_target_dense_matrix_gate(target_mask, control_mask, control_value_mask, matrix, state);
 }
 
@@ -378,8 +378,8 @@ void rx_gate(std::uint64_t target_mask,
              StateVectorBatched<Prec, Space>& states) {
     const Float<Prec> cosval = internal::cos(angle / Float<Prec>{2});
     const Float<Prec> sinval = internal::sin(angle / Float<Prec>{2});
-    Matrix2x2<Prec> matrix = {
-        {{{cosval, Complex<Prec>(0, -sinval)}}, {{Complex<Prec>(0, -sinval), cosval}}}};
+    Matrix2x2<Prec> matrix = {{{{Complex<Prec>(cosval), Complex<Prec>(0, -sinval)}},
+                               {{Complex<Prec>(0, -sinval), Complex<Prec>(cosval)}}}};
     one_target_dense_matrix_gate(target_mask, control_mask, control_value_mask, matrix, states);
 }
 
@@ -400,8 +400,8 @@ void rx_gate(std::uint64_t target_mask,
             const Float<Prec> angle = params(batch_id) * pcoef;
             const Float<Prec> cosval = internal::cos(angle / Float<Prec>{2});
             const Float<Prec> sinval = internal::sin(angle / Float<Prec>{2});
-            Matrix2x2<Prec> matrix = {
-                {{{cosval, Complex<Prec>(0, -sinval)}}, {{Complex<Prec>(0, -sinval), cosval}}}};
+            Matrix2x2<Prec> matrix = {{{{Complex<Prec>(cosval), Complex<Prec>(0, -sinval)}},
+                                       {{Complex<Prec>(0, -sinval), Complex<Prec>(cosval)}}}};
             Kokkos::parallel_for(
                 Kokkos::TeamThreadRange(team_member,
                                         states.dim() >> std::popcount(target_mask | control_mask)),
@@ -428,7 +428,8 @@ void ry_gate(std::uint64_t target_mask,
              StateVector<Prec, Space>& state) {
     const Float<Prec> cosval = internal::cos(angle / Float<Prec>{2});
     const Float<Prec> sinval = internal::sin(angle / Float<Prec>{2});
-    Matrix2x2<Prec> matrix = {{{{cosval, -sinval}}, {{sinval, cosval}}}};
+    Matrix2x2<Prec> matrix = {{{{Complex<Prec>(cosval), Complex<Prec>(-sinval)}},
+                               {{Complex<Prec>(sinval), Complex<Prec>(cosval)}}}};
     one_target_dense_matrix_gate(target_mask, control_mask, control_value_mask, matrix, state);
 }
 
@@ -440,7 +441,8 @@ void ry_gate(std::uint64_t target_mask,
              StateVectorBatched<Prec, Space>& states) {
     const Float<Prec> cosval = internal::cos(angle / Float<Prec>{2});
     const Float<Prec> sinval = internal::sin(angle / Float<Prec>{2});
-    Matrix2x2<Prec> matrix = {{{{cosval, -sinval}}, {{sinval, cosval}}}};
+    Matrix2x2<Prec> matrix = {{{{Complex<Prec>(cosval), Complex<Prec>(-sinval)}},
+                               {{Complex<Prec>(sinval), Complex<Prec>(cosval)}}}};
     one_target_dense_matrix_gate(target_mask, control_mask, control_value_mask, matrix, states);
 }
 
@@ -461,7 +463,8 @@ void ry_gate(std::uint64_t target_mask,
             const Float<Prec> angle = params(batch_id) * pcoef;
             const Float<Prec> cosval = internal::cos(angle / Float<Prec>{2});
             const Float<Prec> sinval = internal::sin(angle / Float<Prec>{2});
-            Matrix2x2<Prec> matrix = {{{{cosval, -sinval}}, {{sinval, cosval}}}};
+            Matrix2x2<Prec> matrix = {{{{Complex<Prec>(cosval), Complex<Prec>(-sinval)}},
+                                       {{Complex<Prec>(sinval), Complex<Prec>(cosval)}}}};
             Kokkos::parallel_for(
                 Kokkos::TeamThreadRange(team_member,
                                         states.dim() >> std::popcount(target_mask | control_mask)),

--- a/src/operator/operator.cpp
+++ b/src/operator/operator.cpp
@@ -64,7 +64,7 @@ void Operator<internal::Prec, internal::Space>::optimize() {
     std::map<std::tuple<std::uint64_t, std::uint64_t>, ComplexType> pauli_and_coef;
     auto terms_h = get_terms();
     for (const auto& pauli : terms_h) {
-        pauli_and_coef[pauli.get_XZ_mask_representation()] += pauli.coef();
+        pauli_and_coef[pauli.get_XZ_mask_representation()] += ComplexType(pauli.coef());
     }
     terms_h.clear();
     for (const auto& [mask, coef] : pauli_and_coef) {
@@ -249,7 +249,7 @@ std::vector<StdComplex> Operator<internal::Prec, internal::Space>::get_expectati
         KOKKOS_CLASS_LAMBDA(
             const typename Kokkos::TeamPolicy<internal::SpaceType<internal::Space>>::member_type&
                 team) {
-            ComplexType sum = 0;
+            ComplexType sum{};
             std::uint64_t batch_id = team.league_rank();
             Kokkos::parallel_reduce(
                 Kokkos::TeamThreadMDRange(team, nterms, dim >> 1),
@@ -373,7 +373,7 @@ std::vector<StdComplex> Operator<internal::Prec, internal::Space>::get_transitio
         KOKKOS_CLASS_LAMBDA(
             const typename Kokkos::TeamPolicy<internal::SpaceType<internal::Space>>::member_type&
                 team) {
-            ComplexType res = 0;
+            ComplexType res{};
             std::uint64_t batch_id = team.league_rank();
             Kokkos::parallel_reduce(
                 Kokkos::TeamThreadMDRange(team, nterms, (dim >> 1)),
@@ -516,7 +516,7 @@ Operator<internal::Prec, internal::Space>::solve_ground_state_by_arnoldi_method(
             auto coef = internal::inner_product<internal::Prec, internal::Space>(
                 krylov_space_basis[j]._raw, state._raw);
             hessenberg_matrix(j, i) = static_cast<StdComplex>(coef);
-            state.add_state_vector_with_coef(-coef, krylov_space_basis[j]);
+            state.add_state_vector_with_coef(static_cast<StdComplex>(-coef), krylov_space_basis[j]);
         }
         // normalize |state>
         double norm = std::sqrt(state.get_squared_norm());
@@ -557,10 +557,11 @@ Operator<internal::Prec, internal::Space>::solve_ground_state_by_arnoldi_method(
 template <>
 Operator<internal::Prec, internal::Space>& Operator<internal::Prec, internal::Space>::operator*=(
     StdComplex coef) {
+    ComplexType coef_internal(coef);
     Kokkos::parallel_for(
         "operator*=",
         Kokkos::RangePolicy<internal::SpaceType<internal::Space>>(0, _terms.size()),
-        KOKKOS_CLASS_LAMBDA(std::uint64_t i) { _terms(i)._coef *= coef; });
+        KOKKOS_CLASS_LAMBDA(std::uint64_t i) { _terms(i)._coef *= coef_internal; });
     _is_hermitian &= (coef.imag() == 0);
     return *this;
 }

--- a/src/operator/operator_batched.cpp
+++ b/src/operator/operator_batched.cpp
@@ -78,7 +78,7 @@ std::vector<StdComplex> OperatorBatched<internal::Prec, internal::Space>::get_ex
         Kokkos::TeamPolicy<ExecutionSpaceType>(_row_ptr.extent(0) - 1, Kokkos::AUTO),
         KOKKOS_CLASS_LAMBDA(const Kokkos::TeamPolicy<ExecutionSpaceType>::member_type& team) {
             std::uint64_t batch_id = team.league_rank();
-            ComplexType res_lcl = 0;
+            ComplexType res_lcl{};
             Kokkos::parallel_reduce(
                 Kokkos::TeamThreadMDRange(
                     team, _row_ptr[batch_id + 1] - _row_ptr[batch_id], dim >> 1),
@@ -143,7 +143,7 @@ std::vector<StdComplex> OperatorBatched<internal::Prec, internal::Space>::get_tr
         Kokkos::TeamPolicy<ExecutionSpaceType>(_row_ptr.extent(0) - 1, Kokkos::AUTO),
         KOKKOS_CLASS_LAMBDA(const Kokkos::TeamPolicy<ExecutionSpaceType>::member_type& team) {
             std::uint64_t batch_id = team.league_rank();
-            ComplexType res_lcl = 0;
+            ComplexType res_lcl{};
             Kokkos::parallel_reduce(
                 Kokkos::TeamThreadMDRange(
                     team, _row_ptr[batch_id + 1] - _row_ptr[batch_id], dim >> 1),
@@ -291,7 +291,9 @@ OperatorBatched<internal::Prec, internal::Space>::operator*(
     Kokkos::parallel_for(
         "operator*",
         Kokkos::RangePolicy<ExecutionSpaceType>(0, res._ops.extent(0)),
-        KOKKOS_CLASS_LAMBDA(std::uint64_t i) { res._ops[i] *= coef_view[i]; });
+        KOKKOS_CLASS_LAMBDA(std::uint64_t i) {
+            res._ops[i] *= static_cast<StdComplex>(coef_view[i]);
+        });
     return res;
 }
 
@@ -307,7 +309,7 @@ OperatorBatched<internal::Prec, internal::Space>::operator*=(const std::vector<S
     Kokkos::parallel_for(
         "operator*=",
         Kokkos::RangePolicy<ExecutionSpaceType>(0, _ops.extent(0)),
-        KOKKOS_CLASS_LAMBDA(std::uint64_t i) { _ops[i] *= coef_view[i]; });
+        KOKKOS_CLASS_LAMBDA(std::uint64_t i) { _ops[i] *= static_cast<StdComplex>(coef_view[i]); });
     return *this;
 }
 

--- a/src/operator/pauli_operator.cpp
+++ b/src/operator/pauli_operator.cpp
@@ -129,7 +129,8 @@ std::string PauliOperator<Prec>::get_pauli_string() const {
 
 template <Precision Prec>
 PauliOperator<Prec> PauliOperator<Prec>::get_dagger() const {
-    return PauliOperator(_bit_flip_mask, _phase_flip_mask, scaluq::internal::conj(_coef));
+    return PauliOperator(
+        _bit_flip_mask, _phase_flip_mask, static_cast<StdComplex>(scaluq::internal::conj(_coef)));
 }
 
 template <Precision Prec>
@@ -151,7 +152,7 @@ StdComplex PauliOperator<Prec>::get_expectation_value(
                 sum += tmp;
             },
             res);
-        return _coef * res;
+        return static_cast<StdComplex>(_coef * res);
     }
     std::uint64_t pivot = std::bit_width(bit_flip_mask) - 1;
     std::uint64_t global_phase_90rot_count = std::popcount(bit_flip_mask & phase_flip_mask);
@@ -262,7 +263,7 @@ StdComplex PauliOperator<Prec>::get_transition_amplitude(
                 sum += tmp;
             },
             internal::Sum<ComplexType, Space>(res));
-        return _coef * res;
+        return static_cast<StdComplex>(_coef * res);
     }
     std::uint64_t pivot = std::bit_width(bit_flip_mask) - 1;
     std::uint64_t global_phase_90rot_count = std::popcount(bit_flip_mask & phase_flip_mask);

--- a/src/state/state_vector.cpp
+++ b/src/state/state_vector.cpp
@@ -53,7 +53,7 @@ void StateVector<Prec, Space>::set_zero_state() {
 }
 template <Precision Prec, ExecutionSpace Space>
 void StateVector<Prec, Space>::set_zero_norm_state() {
-    Kokkos::deep_copy(_raw, 0);
+    Kokkos::deep_copy(_raw, ComplexType{});
 }
 template <Precision Prec, ExecutionSpace Space>
 void StateVector<Prec, Space>::set_computational_basis(std::uint64_t basis) {
@@ -135,7 +135,7 @@ double StateVector<Prec, Space>::get_zero_probability(std::uint64_t target_qubit
     FloatType sum = 0;
     Kokkos::parallel_reduce(
         "zero_prob",
-        Kokkos::RangePolicy<internal::SpaceType<Space>>(0, this->_dim >> 1),
+        Kokkos::RangePolicy<internal::SpaceType<Space>>(0, this->_dim >> 1U),
         KOKKOS_CLASS_LAMBDA(std::uint64_t i, FloatType & lsum) {
             std::uint64_t basis_0 = internal::insert_zero_to_basis_index(i, target_qubit_index);
             lsum += internal::squared_norm(this->_raw[basis_0]);
@@ -214,10 +214,11 @@ void StateVector<Prec, Space>::add_state_vector_with_coef(StdComplex coef,
 }
 template <Precision Prec, ExecutionSpace Space>
 void StateVector<Prec, Space>::multiply_coef(StdComplex coef) {
+    ComplexType complex_coef(coef);
     Kokkos::parallel_for(
         "multiply_coef",
         Kokkos::RangePolicy<internal::SpaceType<Space>>(0, this->_dim),
-        KOKKOS_CLASS_LAMBDA(std::uint64_t i) { this->_raw[i] *= coef; });
+        KOKKOS_CLASS_LAMBDA(std::uint64_t i) { this->_raw[i] *= complex_coef; });
 }
 template <Precision Prec, ExecutionSpace Space>
 std::vector<std::uint64_t> StateVector<Prec, Space>::sampling(std::uint64_t sampling_count,
@@ -246,8 +247,9 @@ std::vector<std::uint64_t> StateVector<Prec, Space>::sampling(std::uint64_t samp
             Kokkos::RangePolicy<internal::SpaceType<Space>>(0, todo_count),
             KOKKOS_LAMBDA(std::uint64_t i) {
                 auto rand_gen = rand_pool.get_state();
-                FloatType r = static_cast<FloatType>(rand_gen.drand(0., 1.));
-                std::uint64_t lo = 0, hi = stacked_prob.size();
+                auto r = static_cast<FloatType>(rand_gen.drand(0., 1.));
+                std::uint64_t lo = 0;
+                std::uint64_t hi = stacked_prob.size();
                 while (hi - lo > 1) {
                     std::uint64_t mid = (lo + hi) / 2;
                     if (stacked_prob[mid] > r) {
@@ -327,7 +329,7 @@ std::string StateVector<Prec, Space>::to_string() const {
             [](std::uint64_t n, std::uint64_t len) {
                 std::string tmp;
                 while (len--) {
-                    tmp += ((n >> len) & 1) + '0';
+                    tmp += static_cast<char>(((n >> len) & 1U) + '0');
                 }
                 return tmp;
             }(i, _n_qubits)

--- a/src/state/state_vector_batched.cpp
+++ b/src/state/state_vector_batched.cpp
@@ -91,7 +91,7 @@ void StateVectorBatched<Prec, Space>::set_computational_basis(std::uint64_t basi
 
 template <Precision Prec, ExecutionSpace Space>
 void StateVectorBatched<Prec, Space>::set_zero_norm_state() {
-    Kokkos::deep_copy(_raw, 0.);
+    Kokkos::deep_copy(_raw, ComplexType{});
 }
 
 template <Precision Prec, ExecutionSpace Space>
@@ -145,8 +145,9 @@ std::vector<std::vector<std::uint64_t>> StateVectorBatched<Prec, Space>::samplin
             KOKKOS_CLASS_LAMBDA(std::uint64_t idx) {
                 std::uint64_t batch_id = batch_ids[idx];
                 auto rand_gen = rand_pool.get_state();
-                FloatType r = static_cast<FloatType>(rand_gen.drand(0., 1.));
-                std::uint64_t lo = 0, hi = stacked_prob.extent(1);
+                auto r = static_cast<FloatType>(rand_gen.drand(0., 1.));
+                std::uint64_t lo = 0;
+                std::uint64_t hi = stacked_prob.extent(1);
                 while (hi - lo > 1) {
                     std::uint64_t mid = (lo + hi) / 2;
                     if (stacked_prob(batch_id, mid) > r) {
@@ -293,7 +294,7 @@ std::vector<double> StateVectorBatched<Prec, Space>::get_zero_probability(
             FloatType sum = 0;
             std::uint64_t batch_id = team.league_rank();
             Kokkos::parallel_reduce(
-                Kokkos::TeamThreadRange(team, _dim >> 1),
+                Kokkos::TeamThreadRange(team, _dim >> 1U),
                 [&](std::uint64_t i, FloatType& lsum) {
                     std::uint64_t basis_0 =
                         internal::insert_zero_to_basis_index(i, target_qubit_index);
@@ -371,7 +372,7 @@ std::vector<double> StateVectorBatched<Prec, Space>::get_marginal_probability(
 template <Precision Prec, ExecutionSpace Space>
 std::vector<double> StateVectorBatched<Prec, Space>::get_entropy() const {
     Kokkos::View<FloatType*, internal::SpaceType<Space>> ents("ents", _batch_size);
-    const FloatType eps = static_cast<FloatType>(1e-15);
+    const auto eps = static_cast<FloatType>(1e-15);
     Kokkos::parallel_for(
         "get_entropy",
         Kokkos::TeamPolicy<internal::SpaceType<Space>>(
@@ -504,7 +505,7 @@ StateVector<Prec, Space> StateVectorBatched<Prec, Space>::get_reduced_state() co
         KOKKOS_CLASS_LAMBDA(
             const Kokkos::TeamPolicy<internal::SpaceType<Space>>::member_type& team) {
             std::uint64_t i = team.league_rank();
-            ComplexType sum = 0;
+            ComplexType sum{};
             Kokkos::parallel_reduce(
                 Kokkos::TeamThreadRange(team, _batch_size),
                 [&](std::uint64_t b, ComplexType& lsum) { lsum += _raw(b, i); },
@@ -530,7 +531,7 @@ std::string StateVectorBatched<Prec, Space>::to_string() const {
                 [](std::uint64_t n, std::uint64_t len) {
                     std::string tmp;
                     while (len--) {
-                        tmp += ((n >> len) & 1) + '0';
+                        tmp += static_cast<char>(((n >> len) & 1U) + '0');
                     }
                     return tmp;
                 }(i, _n_qubits)

--- a/src/util/utility.cpp
+++ b/src/util/utility.cpp
@@ -74,7 +74,7 @@ ComplexMatrix convert_csr_to_external_matrix<Prec, Space>(SparseMatrix<Prec, Spa
     auto row_ptr = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), mat._row_ptr);
     for (std::uint32_t i = 0; i < mat._rows; ++i) {
         for (std::uint32_t idx = row_ptr[i]; idx < row_ptr[i + 1]; ++idx) {
-            eigen_matrix(i, col_idx[idx]) = vals[idx];
+            eigen_matrix(i, col_idx[idx]) = static_cast<StdComplex>(vals[idx]);
         }
     }
     return eigen_matrix;


### PR DESCRIPTION
clang-tidyを導入してみました。

ただ、ヘッダ部分まで含めたチェックをする (しかもclang-tidyはファイル単位でしか動作しないので各cppファイルごとに毎回同じヘッダが解析されている！) せいで相当時間がかかっており、F32のstate_vector_batchedだけでもローカルで2分半くらいかかっています…
このままCIに導入するとあまりに重いので検討中です。

現状、`--warnings-as-errors='*'` をつけていますが、あまりに変更が多い (このPRでは試しに今のところstate/に対してwarningが出た部分を修正してそれに関連する部分を修正していますが、見てのとおりです) ので、warningの分の修正は努力目標でもいいかもしれません。