### PR TITLE
add SCALUQ_CPU_NATIVE: OFF to test_changed

### DIFF
--- a/.github/workflows/test_changed.yml
+++ b/.github/workflows/test_changed.yml
@@ -44,6 +44,7 @@ jobs:
       CMAKE_BUILD_TYPE: ${{ matrix.device == 'cuda' && 'Release' || 'Debug' }}
       SCALUQ_USE_TEST: "ON"
       SCALUQ_USE_CUDA: ${{ matrix.device == 'cuda' && 'ON' || 'OFF' }}
+      SCALUQ_CPU_NATIVE: "OFF"
       SCALUQ_CUDA_ARCH: "TURING75"
       SCALUQ_FLOAT16: ${{ matrix.compiler == 'clang' && 'OFF' || 'ON' }}
       SCALUQ_FLOAT32: "ON"


### PR DESCRIPTION
## Summary
test_changedのCIで`SCALUQ_CPU_NATIVE: OFF` が抜けていたので、異なるアーキテクチャのccacheによってIllegal Instructionが発生していました( https://github.com/qulacs/scaluq/actions/runs/25532703419/job/75472006325?pr=348 )
これを修正します。