### PR TITLE
Add concurrency control for PR trigger

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check-changed:
     name: Check Changed Files

--- a/.github/workflows/install_pr.yml
+++ b/.github/workflows/install_pr.yml
@@ -3,6 +3,10 @@ name: Install to System (PR)
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-changed:
     name: Check Changed Files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - ".github/**/*.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Check YAML

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -10,6 +10,10 @@ on:
       - ".github/workflows/lint.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sdist-build:
     name: Source distribution

--- a/.github/workflows/test_changed.yml
+++ b/.github/workflows/test_changed.yml
@@ -3,6 +3,10 @@ name: Test Changed Files
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: C++ Build and Test

--- a/.github/workflows/wheel_pr.yml
+++ b/.github/workflows/wheel_pr.yml
@@ -3,6 +3,10 @@ name: Wheel build (PR)
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-changed:
     name: Check Changed Files


### PR DESCRIPTION
## Summary
Briefly describe the changes in this PR.  

`pull_request`のトリガーに対して`concurrency`制御を導入する。

マージキューを採用しているので、`pull_request`トリガーの古いジョブのみがキャンセルされるようにしている。
短時間で修正をpushする際、古いテストを手動キャンセルする必要がなくなる。

## What was changed? (変更点)
- ymlファイルに`concurrency`を追加

## Why was this change needed? (変更理由)
- PRへの古いpushによるテストが最新pushのCIテストに律速されないようにするため。

## Additional context (optional)
-
