### PR TITLE
Allow nesting of Circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,12 @@ int main() {
             scaluq::StateVector<Prec, Space>::Haar_random_state(n_qubits, 0);
         std::cout << state << std::endl;
 
-        scaluq::Circuit<Prec> circuit(n_qubits);
-        circuit.add_gate(scaluq::gate::X<Prec>(0));
-        circuit.add_gate(scaluq::gate::CNot<Prec>(0, 1));
-        circuit.add_gate(scaluq::gate::Y<Prec>(1));
-        circuit.add_gate(scaluq::gate::RX<Prec>(1, std::numbers::pi / 2));
+        scaluq::CircuitBuilder<Prec> builder;
+        builder.add_gate(scaluq::gate::X<Prec>(0));
+        builder.add_gate(scaluq::gate::CNot<Prec>(0, 1));
+        builder.add_gate(scaluq::gate::Y<Prec>(1));
+        builder.add_gate(scaluq::gate::RX<Prec>(1, std::numbers::pi / 2));
+        scaluq::Circuit<Prec> circuit = builder.build();
         circuit.update_quantum_state(state);
 
         std::vector<scaluq::PauliOperator<Prec>> terms;
@@ -169,11 +170,12 @@ int main() {
         StateVector state = StateVector::Haar_random_state(n_qubits, 0);
         std::cout << state << std::endl;
 
-        Circuit circuit;
-        circuit.add_gate(gate::X(0));
-        circuit.add_gate(gate::CNot(0, 1));
-        circuit.add_gate(gate::Y(1));
-        circuit.add_gate(gate::RX(1, std::numbers::pi / 2));
+        CircuitBuilder builder;
+        builder.add_gate(gate::X(0));
+        builder.add_gate(gate::CNot(0, 1));
+        builder.add_gate(gate::Y(1));
+        builder.add_gate(gate::RX(1, std::numbers::pi / 2));
+        Circuit circuit = builder.build();
         circuit.update_quantum_state(state);
 
         std::vector<PauliOperator> terms;
@@ -195,11 +197,12 @@ import math
 n_qubits = 3
 state = StateVector.Haar_random_state(n_qubits, 0)
 
-circuit = Circuit()
-circuit.add_gate(gate.X(0))
-circuit.add_gate(gate.CNot(0, 1))
-circuit.add_gate(gate.Y(1))
-circuit.add_gate(gate.RX(1, math.pi / 2))
+builder = CircuitBuilder()
+builder.add_gate(gate.X(0))
+builder.add_gate(gate.CNot(0, 1))
+builder.add_gate(gate.Y(1))
+builder.add_gate(gate.RX(1, math.pi / 2))
+circuit = builder.build()
 circuit.update_quantum_state(state)
 
 terms = []

--- a/README_ja.md
+++ b/README_ja.md
@@ -131,11 +131,12 @@ int main() {
             scaluq::StateVector<Prec, Space>::Haar_random_state(n_qubits, 0);
         std::cout << state << std::endl;
 
-        scaluq::Circuit<Prec> circuit(n_qubits);
-        circuit.add_gate(scaluq::gate::X<Prec>(0));
-        circuit.add_gate(scaluq::gate::CNot<Prec>(0, 1));
-        circuit.add_gate(scaluq::gate::Y<Prec>(1));
-        circuit.add_gate(scaluq::gate::RX<Prec>(1, std::numbers::pi / 2));
+        scaluq::CircuitBuilder<Prec> builder;
+        builder.add_gate(scaluq::gate::X<Prec>(0));
+        builder.add_gate(scaluq::gate::CNot<Prec>(0, 1));
+        builder.add_gate(scaluq::gate::Y<Prec>(1));
+        builder.add_gate(scaluq::gate::RX<Prec>(1, std::numbers::pi / 2));
+        scaluq::Circuit<Prec> circuit = builder.build();
         circuit.update_quantum_state(state);
 
         std::vector<scaluq::PauliOperator<Prec>> terms;
@@ -169,11 +170,12 @@ int main() {
         StateVector state = StateVector::Haar_random_state(n_qubits, 0);
         std::cout << state << std::endl;
 
-        Circuit circuit;
-        circuit.add_gate(gate::X(0));
-        circuit.add_gate(gate::CNot(0, 1));
-        circuit.add_gate(gate::Y(1));
-        circuit.add_gate(gate::RX(1, std::numbers::pi / 2));
+        CircuitBuilder builder;
+        builder.add_gate(gate::X(0));
+        builder.add_gate(gate::CNot(0, 1));
+        builder.add_gate(gate::Y(1));
+        builder.add_gate(gate::RX(1, std::numbers::pi / 2));
+        Circuit circuit = builder.build();
         circuit.update_quantum_state(state);
 
         std::vector<PauliOperator> terms;
@@ -195,11 +197,12 @@ import math
 n_qubits = 3
 state = StateVector.Haar_random_state(n_qubits, 0)
 
-circuit = Circuit()
-circuit.add_gate(gate.X(0))
-circuit.add_gate(gate.CNot(0, 1))
-circuit.add_gate(gate.Y(1))
-circuit.add_gate(gate.RX(1, math.pi / 2))
+builder = CircuitBuilder()
+builder.add_gate(gate.X(0))
+builder.add_gate(gate.CNot(0, 1))
+builder.add_gate(gate.Y(1))
+builder.add_gate(gate.RX(1, math.pi / 2))
+circuit = builder.build()
 circuit.update_quantum_state(state)
 
 terms = []

--- a/doc/source/tutorials/python/circuit.md
+++ b/doc/source/tutorials/python/circuit.md
@@ -1,7 +1,7 @@
 # Circuit
 
 Quantum circuit is expressed as {class}`Circuit <scaluq.default.f64.Circuit>`.
-This holds an array of instances of {class}`Gate <scaluq.default.f64.Gate>` or {class}`ParamGate <scaluq.default.f64.ParamGate>` to be applied. 
+This holds an array of instructions such as {class}`Gate <scaluq.default.f64.Gate>`, {class}`ParamGate <scaluq.default.f64.ParamGate>`, or nested `Circuit` instances.
 
 ```{note}
 In this section, we regard `Circuit` as an array of `Gate` instances. To learn about `ParamGate`, see [Using parametric gates and circuits](./param.md).
@@ -24,29 +24,31 @@ print(circuit.to_json())
 ```
 
 ## Add Gate to Circuit
-You can add `Gate` to `Circuit` by {func}`add_gate <scaluq.default.f64.Circuit.add_gate>`. `Gate` to be added is shallow-copied. Since all the `Gate`s in Scaluq are immutable, this is always safe!
+You can add `Gate` to `CircuitBuilder` by `add_gate`, and create a `Circuit` by calling `build`. `Gate` to be added is shallow-copied. Since all the `Gate`s in Scaluq are immutable, this is always safe!
 
 ```py
-from scaluq.default.f64 import Circuit
+from scaluq.default.f64 import CircuitBuilder
 from scaluq.default.f64.gate import H, X
 
 nqubits = 2
-circuit = Circuit()
-circuit.add_gate(H(0))
-circuit.add_gate(X(1, controls=[0]))
+builder = CircuitBuilder()
+builder.add_gate(H(0))
+builder.add_gate(X(1, controls=[0]))
+circuit = builder.build()
 ```
 
 ## Apply Circuit to StateVector
 You can run Circuit by applying {func}`update_quantum_state <scaluq.default.f64.Circuit.update_quantum_state>` to {class}`StateVector <scaluq.default.f64.StateVector>`.
 
 ```py
-from scaluq.default.f64 import Circuit, StateVector
+from scaluq.default.f64 import CircuitBuilder, StateVector
 from scaluq.default.f64.gate import H, X
 
 nqubits = 2
-circuit = Circuit()
-circuit.add_gate(H(0))
-circuit.add_gate(X(1, controls=[0]))
+builder = CircuitBuilder()
+builder.add_gate(H(0))
+builder.add_gate(X(1, controls=[0]))
+circuit = builder.build()
 
 state = StateVector(nqubits)
 circuit.update_quantum_state(state)
@@ -59,16 +61,17 @@ print(state.get_amplitudes())
 ## Get properties of Circuit
 You can get some properties of `Circuit`.
 ```py
-from scaluq.default.f64 import Circuit
+from scaluq.default.f64 import CircuitBuilder
 from scaluq.default.f64.gate import H, X
 
 nqubits = 2
-circuit = Circuit()
-circuit.add_gate(H(0))
-circuit.add_gate(X(1))
-circuit.add_gate(X(1, controls=[0]))
+builder = CircuitBuilder()
+builder.add_gate(H(0))
+builder.add_gate(X(1))
+builder.add_gate(X(1, controls=[0]))
+circuit = builder.build()
 
-print(circuit.gate_list()) # [H, X, CX]
-print(circuit.n_gates()) # 3
+print(circuit.instructions()) # [H, X, CX]
+print(circuit.n_instructions()) # 3
 print(circuit.calculate_depth()) # 2
 ```

--- a/doc/source/tutorials/python/gate.md
+++ b/doc/source/tutorials/python/gate.md
@@ -109,14 +109,15 @@ print(rx.angle())
 Since this inheritance relation is not shown in language layer, explicit upcast is required when you pass the Gate as {class}`Gate <scaluq.default.f64.Gate>` type.
 
 ```py
-from scaluq.default.f64 import Gate, RXGate, Circuit
+from scaluq.default.f64 import Gate, RXGate, CircuitBuilder
 from scaluq.default.f64.gate import RX
 import math
 
 rx = RXGate(RX(0, math.pi/4))
-circuit = Circuit()
+builder = CircuitBuilder()
 rx = Gate(rx) # omitting this downcast causes error on next line
-circuit.add_gate(rx)
+builder.add_gate(rx)
+circuit = builder.build()
 ```
 
 ## Apply to StateVector

--- a/doc/source/tutorials/python/param.md
+++ b/doc/source/tutorials/python/param.md
@@ -14,21 +14,22 @@ p_ry = ParamRY(1) # Parametric RY gate with target 1 and coef 1.0 (default)
 ```
 
 ## Add parametric gates to Circuit
-You can add {class}`ParamGate <scaluq.default.f64.ParamGate>` to {class}`Circuit <scaluq.default.f64.Circuit>` using {func}`add_param_gate <scaluq.default.f64.Circuit.add_param_gate>`. This method requires a key (string) to identify the parameter. Multiple gates can share the same key.
+You can add {class}`ParamGate <scaluq.default.f64.ParamGate>` to `CircuitBuilder` using `add_param_gate`, and create a {class}`Circuit <scaluq.default.f64.Circuit>` by calling `build`. This method requires a key (string) to identify the parameter. Multiple gates can share the same key.
 
 You can also retrieve information about parameter keys from the circuit.
 ```
 from scaluq.default.f64.gate import ParamRX, ParamRY, H
-from scaluq.default.f64 import Circuit
+from scaluq.default.f64 import CircuitBuilder
 import math
 
 nqubits = 2
-circuit = Circuit()
+builder = CircuitBuilder()
 
-circuit.add_gate(H(0))
-circuit.add_param_gate(ParamRX(0), "p_rx")
-circuit.add_param_gate(ParamRX(1), "p_rx") # Same key can be used
-circuit.add_param_gate(ParamRY(1), "p_ry")
+builder.add_gate(H(0))
+builder.add_param_gate(ParamRX(0), "p_rx")
+builder.add_param_gate(ParamRX(1), "p_rx") # Same key can be used
+builder.add_param_gate(ParamRY(1), "p_ry")
+circuit = builder.build()
 
 # Get parameter key at specific gate index
 print(circuit.get_param_key_at(0)) # None (H gate is not parametric)
@@ -45,15 +46,16 @@ When executing the circuit, you must provide values for each parameter key. The 
 
 ```
 from scaluq.default.f64.gate import H, ParamRX, ParamRY
-from scaluq.default.f64 import Circuit, StateVector
+from scaluq.default.f64 import CircuitBuilder, StateVector
 import math
 
 n_qubits = 2
-circuit = Circuit()
+builder = CircuitBuilder()
 state = StateVector(n_qubits) # Initial state |00>
 
-circuit.add_param_gate(ParamRX(0,0.5), "angle_x") # coef 0.5
-circuit.add_param_gate(ParamRY(1), "angle_y")
+builder.add_param_gate(ParamRX(0,0.5), "angle_x") # coef 0.5
+builder.add_param_gate(ParamRY(1), "angle_y")
+circuit = builder.build()
 params_1 = {
     "angle_x": math.pi,
     "angle_y": math.pi/2

--- a/exe/main.py
+++ b/exe/main.py
@@ -1,17 +1,18 @@
-from scaluq.default.f64 import Circuit
+from scaluq.default.f64 import CircuitBuilder
 from scaluq.default.f64.gate import H, X
 from scaluq.host_serial.f64 import StateVector
 
 nqubits = 2
-circuit = Circuit()
-circuit.add_gate(H(0))
-circuit.add_gate(X(1))
-circuit.add_gate(X(1, controls=[0]))
+builder = CircuitBuilder()
+builder.add_gate(H(0))
+builder.add_gate(X(1))
+builder.add_gate(X(1, controls=[0]))
+circuit = builder.build()
 
-print(circuit.gate_list()[0]) # [H, X, CX]
-print(circuit.gate_list()[1]) # [H, X, CX]
-print(circuit.gate_list()[2]) # [H, X, CX]
-print(circuit.n_gates()) # 3
+print(circuit.instructions()[0]) # H
+print(circuit.instructions()[1]) # X
+print(circuit.instructions()[2]) # CX
+print(circuit.n_instructions()) # 3
 print(circuit.calculate_depth()) # 2
 
 state = StateVector(nqubits)

--- a/include/scaluq/all.hpp
+++ b/include/scaluq/all.hpp
@@ -29,6 +29,7 @@
     using ClassicalRegisterBatched = ::scaluq::ClassicalRegisterBatched;                       \
     using PauliOperator = ::scaluq::PauliOperator<Prec>;                                       \
     using Operator = ::scaluq::Operator<Prec, Space>;                                          \
+    using CircuitBuilder = ::scaluq::CircuitBuilder<Prec>;                                     \
     using Gate = ::scaluq::Gate<Prec>;                                                         \
     using IGate = ::scaluq::IGate<Prec>;                                                       \
     using GlobalPhaseGate = ::scaluq::GlobalPhaseGate<Prec>;                                   \

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -4,6 +4,7 @@
 #include <bit>
 #include <functional>
 #include <map>
+#include <memory>
 #include <optional>
 #include <random>
 #include <set>
@@ -24,80 +25,80 @@ namespace scaluq {
 using ClassicalCondition = std::function<bool(const ClassicalRegister&)>;
 
 template <Precision Prec>
+class Circuit;
+
+template <Precision Prec>
+struct CircuitStorage;
+
+template <Precision Prec>
+using CircuitInstruction = std::variant<Gate<Prec>, ParamGateWithTag, Circuit<Prec>>;
+
+template <Precision Prec>
+[[nodiscard]] bool is_gate(const CircuitInstruction<Prec>& instruction) {
+    return instruction.index() == 0;
+}
+template <Precision Prec>
+[[nodiscard]] bool is_param_gate(const CircuitInstruction<Prec>& instruction) {
+    return instruction.index() == 1;
+}
+template <Precision Prec>
+[[nodiscard]] bool is_circuit(const CircuitInstruction<Prec>& instruction) {
+    return instruction.index() == 2;
+}
+template <Precision Prec>
+[[nodiscard]] const Gate<Prec>& get_gate(const CircuitInstruction<Prec>& instruction) {
+    return std::get<0>(instruction);
+}
+template <Precision Prec>
+[[nodiscard]] const std::pair<ParamGate<Prec>, std::string>& get_param_gate_with_key(
+    const CircuitInstruction<Prec>& instruction) {
+    return std::get<1>(instruction);
+}
+template <Precision Prec>
+[[nodiscard]] const Circuit<Prec>& get_circuit(const CircuitInstruction<Prec>& instruction) {
+    return std::get<2>(instruction);
+}
+
+template <Precision Prec>
 class Circuit {
 public:
     using GateWithKey = std::variant<Gate<Prec>, std::pair<ParamGate<Prec>, std::string>>;
-    Circuit() = default;
+    using Instruction = CircuitInstruction<Prec>;
+    Circuit();
 
-    [[nodiscard]] inline const std::vector<GateWithKey>& gate_list() const { return _gate_list; }
-    [[nodiscard]] inline std::uint64_t n_gates() const { return _gate_list.size(); }
+    [[nodiscard]] inline const std::vector<Instruction>& instructions() const {
+        return _storage->instructions;
+    }
+    [[nodiscard]] inline std::uint64_t n_instructions() const {
+        return _storage->instructions.size();
+    }
     [[nodiscard]] std::set<std::string> key_set() const;
-    [[nodiscard]] inline const GateWithKey& get_gate_at(std::uint64_t idx) const {
-        if (idx >= _gate_list.size()) {
-            throw std::runtime_error("Circuit::get_gate_at(std::uint64_t): index out of bounds");
+    [[nodiscard]] inline const Instruction& get_instruction_at(std::uint64_t idx) const {
+        if (idx >= _storage->instructions.size()) {
+            throw std::runtime_error(
+                "Circuit::get_instruction_at(std::uint64_t): index out of bounds");
         }
-        return _gate_list[idx];
+        return _storage->instructions[idx];
     }
     [[nodiscard]] inline std::optional<std::string> get_param_key_at(std::uint64_t idx) const {
-        if (idx >= _gate_list.size()) {
+        if (idx >= _storage->instructions.size()) {
             throw std::runtime_error(
                 "Circuit::get_parameter_key(std::uint64_t): index out of bounds");
         }
-        const auto& gate = _gate_list[idx];
-        if (gate.index() == 0) return std::nullopt;
-        return std::get<1>(gate).second;
+        const auto& instruction = _storage->instructions[idx];
+        if (!is_param_gate(instruction)) return std::nullopt;
+        return get_param_gate_with_key(instruction).second;
     }
     [[nodiscard]] inline std::optional<ClassicalCondition> get_classical_condition_at(
         std::uint64_t idx) const {
-        if (idx >= _gate_list.size()) {
+        if (idx >= _storage->instructions.size()) {
             throw std::runtime_error(
                 "Circuit::get_classical_condition_at(std::uint64_t): index out of bounds");
         }
-        return _classical_conditions[idx];
+        return _storage->classical_conditions[idx];
     }
 
     [[nodiscard]] std::uint64_t calculate_depth() const;
-
-    void add_gate(const Gate<Prec>& gate) {
-        _gate_list.push_back(gate);
-        _classical_conditions.push_back(std::nullopt);
-    }
-    void add_param_gate(const ParamGate<Prec>& param_gate, std::string_view parameter_key) {
-        _gate_list.push_back(std::make_pair(param_gate, std::string(parameter_key)));
-        _classical_conditions.push_back(std::nullopt);
-    }
-    void add_conditional_gate(const Gate<Prec>& gate, ClassicalCondition condition) {
-        add_gate(gate);
-        _classical_conditions.back() = std::move(condition);
-    }
-    void add_conditional_gate(const Gate<Prec>& gate,
-                              std::uint64_t classical_bit_index,
-                              bool expected_value) {
-        add_conditional_gate(gate,
-                             [classical_bit_index, expected_value](const ClassicalRegister& reg) {
-                                 return reg[classical_bit_index] == expected_value;
-                             });
-    }
-    void add_conditional_param_gate(const ParamGate<Prec>& param_gate,
-                                    std::string_view parameter_key,
-                                    ClassicalCondition condition) {
-        add_param_gate(param_gate, parameter_key);
-        _classical_conditions.back() = std::move(condition);
-    }
-    void add_conditional_param_gate(const ParamGate<Prec>& param_gate,
-                                    std::string_view parameter_key,
-                                    std::uint64_t classical_bit_index,
-                                    bool expected_value) {
-        add_conditional_param_gate(
-            param_gate,
-            parameter_key,
-            [classical_bit_index, expected_value](const ClassicalRegister& reg) {
-                return reg[classical_bit_index] == expected_value;
-            });
-    }
-
-    void add_circuit(const Circuit<Prec>& circuit);
-    void add_circuit(Circuit<Prec>&& circuit);
 
     template <ExecutionSpace Space>
     void update_quantum_state(StateVector<Prec, Space>& state,
@@ -123,35 +124,43 @@ public:
     Circuit get_inverse() const;
 
     template <ExecutionSpace Space>
-    void optimize(std::uint64_t max_block_size = 3);
+    [[nodiscard]] Circuit optimize(std::uint64_t max_block_size = 3) const;
 
     friend void to_json(Json& j, const Circuit& circuit) {
         j = Json{{"gate_list", Json::array()}};
-        for (std::uint64_t idx = 0; idx < circuit.gate_list().size(); ++idx) {
-            if (circuit._classical_conditions[idx].has_value()) {
+        for (std::uint64_t idx = 0; idx < circuit.instructions().size(); ++idx) {
+            if (circuit._storage->classical_conditions[idx].has_value()) {
                 throw std::runtime_error(
                     "Circuit::to_json: classically controlled instructions cannot be serialized.");
             }
-            const auto& gate = circuit.gate_list()[idx];
-            if (gate.index() == 0)
-                j["gate_list"].emplace_back(Json{{"gate", std::get<0>(gate)}});
-            else
-                j["gate_list"].emplace_back(
-                    Json{{"gate", std::get<1>(gate).first}, {"key", std::get<1>(gate).second}});
+            const auto& instruction = circuit.instructions()[idx];
+            if (is_gate(instruction)) {
+                j["gate_list"].emplace_back(Json{{"gate", get_gate(instruction)}});
+            } else if (is_param_gate(instruction)) {
+                const auto& [param_gate, key] = get_param_gate_with_key(instruction);
+                j["gate_list"].emplace_back(Json{{"gate", param_gate}, {"key", key}});
+            } else {
+                j["gate_list"].emplace_back(Json{{"circuit", get_circuit(instruction)}});
+            }
         }
     }
 
     friend void from_json(const Json& j, Circuit& circuit) {
-        circuit = Circuit();
+        auto storage = std::make_shared<CircuitStorage<Prec>>();
         const Json& tmp_list = j.at("gate_list");
-        for (const Json& gate_with_key : tmp_list) {
-            if (gate_with_key.contains("key")) {
-                circuit.add_param_gate(gate_with_key.at("gate").get<ParamGate<Prec>>(),
-                                       gate_with_key.at("key").get<std::string>());
+        for (const Json& instruction : tmp_list) {
+            if (instruction.contains("circuit")) {
+                storage->instructions.push_back(instruction.at("circuit").get<Circuit<Prec>>());
+            } else if (instruction.contains("key")) {
+                storage->instructions.push_back(
+                    std::make_pair(instruction.at("gate").get<ParamGate<Prec>>(),
+                                   instruction.at("key").get<std::string>()));
             } else {
-                circuit.add_gate(gate_with_key.at("gate").get<Gate<Prec>>());
+                storage->instructions.push_back(instruction.at("gate").get<Gate<Prec>>());
             }
+            storage->classical_conditions.push_back(std::nullopt);
         }
+        circuit = Circuit(std::move(storage));
     }
 
     /**
@@ -175,12 +184,118 @@ public:
         const Operator<Prec, Space>& observable, const std::map<std::string, double>& parameters);
 
 private:
-    std::vector<GateWithKey> _gate_list;
-    std::vector<std::optional<ClassicalCondition>> _classical_conditions;
+    template <Precision>
+    friend class CircuitBuilder;
 
+    explicit Circuit(std::shared_ptr<const CircuitStorage<Prec>> storage)
+        : _storage(std::move(storage)) {}
+
+    std::shared_ptr<const CircuitStorage<Prec>> _storage;
+
+    [[nodiscard]] std::uint64_t required_operand_qubit_mask() const;
     [[nodiscard]] std::uint64_t required_n_qubits() const;
     [[nodiscard]] bool has_classical_instructions() const;
     void check_state_vector_n_qubits(std::uint64_t n_qubits) const;
+
+    template <ExecutionSpace Space>
+    void update_quantum_state_internal(internal::ExecutionContext<Prec, Space> context,
+                                       const std::map<std::string, double>& parameters) const;
+    template <ExecutionSpace Space>
+    void update_quantum_state_internal(
+        internal::ExecutionContextBatched<Prec, Space> context,
+        const std::map<std::string, std::vector<double>>& parameters) const;
+};
+
+template <Precision Prec>
+struct CircuitStorage {
+    std::vector<CircuitInstruction<Prec>> instructions;
+    std::vector<std::optional<ClassicalCondition>> classical_conditions;
+};
+
+template <Precision Prec>
+Circuit<Prec>::Circuit() : _storage(std::make_shared<CircuitStorage<Prec>>()) {}
+
+template <Precision Prec>
+class CircuitBuilder {
+public:
+    using Instruction = typename Circuit<Prec>::Instruction;
+
+    CircuitBuilder() = default;
+
+    [[nodiscard]] std::uint64_t n_instructions() const { return _instructions.size(); }
+
+    void add_gate(const Gate<Prec>& gate) {
+        _instructions.push_back(gate);
+        _classical_conditions.push_back(std::nullopt);
+    }
+    void add_param_gate(const ParamGate<Prec>& param_gate, std::string_view parameter_key) {
+        _instructions.push_back(std::make_pair(param_gate, std::string(parameter_key)));
+        _classical_conditions.push_back(std::nullopt);
+    }
+    void add_conditional_gate(const Gate<Prec>& gate, ClassicalCondition condition) {
+        _instructions.push_back(gate);
+        _classical_conditions.push_back(std::move(condition));
+    }
+    void add_conditional_gate(const Gate<Prec>& gate,
+                              std::uint64_t classical_bit_index,
+                              bool expected_value) {
+        add_conditional_gate(gate,
+                             [classical_bit_index, expected_value](const ClassicalRegister& reg) {
+                                 return reg[classical_bit_index] == expected_value;
+                             });
+    }
+    void add_conditional_param_gate(const ParamGate<Prec>& param_gate,
+                                    std::string_view parameter_key,
+                                    ClassicalCondition condition) {
+        _instructions.push_back(std::make_pair(param_gate, std::string(parameter_key)));
+        _classical_conditions.push_back(std::move(condition));
+    }
+    void add_conditional_param_gate(const ParamGate<Prec>& param_gate,
+                                    std::string_view parameter_key,
+                                    std::uint64_t classical_bit_index,
+                                    bool expected_value) {
+        add_conditional_param_gate(
+            param_gate,
+            parameter_key,
+            [classical_bit_index, expected_value](const ClassicalRegister& reg) {
+                return reg[classical_bit_index] == expected_value;
+            });
+    }
+    void extend_circuit(const Circuit<Prec>& circuit) {
+        _instructions.insert(_instructions.end(),
+                             circuit._storage->instructions.begin(),
+                             circuit._storage->instructions.end());
+        _classical_conditions.insert(_classical_conditions.end(),
+                                     circuit._storage->classical_conditions.begin(),
+                                     circuit._storage->classical_conditions.end());
+    }
+    void add_circuit(const Circuit<Prec>& circuit) {
+        _instructions.push_back(circuit);
+        _classical_conditions.push_back(std::nullopt);
+    }
+    void add_conditional_circuit(const Circuit<Prec>& circuit, ClassicalCondition condition) {
+        _instructions.push_back(circuit);
+        _classical_conditions.push_back(std::move(condition));
+    }
+    void add_conditional_circuit(const Circuit<Prec>& circuit,
+                                 std::uint64_t classical_bit_index,
+                                 bool expected_value) {
+        add_conditional_circuit(
+            circuit, [classical_bit_index, expected_value](const ClassicalRegister& reg) {
+                return reg[classical_bit_index] == expected_value;
+            });
+    }
+
+    [[nodiscard]] Circuit<Prec> build() const {
+        auto storage = std::make_shared<CircuitStorage<Prec>>();
+        storage->instructions = _instructions;
+        storage->classical_conditions = _classical_conditions;
+        return Circuit<Prec>(std::move(storage));
+    }
+
+private:
+    std::vector<Instruction> _instructions;
+    std::vector<std::optional<ClassicalCondition>> _classical_conditions;
 };
 
 #ifdef SCALUQ_USE_NANOBIND
@@ -314,11 +429,14 @@ void register_circuit_space_bindings(nb::class_<Circuit<Prec>>& c) {
             "Apply gate to the StateVectorBatched with classical register. If the circuit "
             "contains parametric gate, give parameter values as "
             "\"name=[value1, value2, ...]\" in kwargs.")
-        .def("optimize",
-             nb::overload_cast<std::uint64_t>(&Circuit<Prec>::template optimize<Space>),
-             "max_block_size"_a = 3,
-             "Optimize circuit. Create qubit dependency tree and merge neighboring gates if the "
-             "new gate has less than or equal to `max_block_size` or the new gate is Pauli.")
+        .def(
+            "optimize",
+            [](const Circuit<Prec>& circuit, std::uint64_t max_block_size) {
+                return circuit.template optimize<Space>(max_block_size);
+            },
+            "max_block_size"_a = 3,
+            "Optimize circuit. Create qubit dependency tree and merge neighboring gates if the "
+            "new gate has less than or equal to `max_block_size` or the new gate is Pauli.")
         .def(
             "simulate_noise",
             [](const Circuit<Prec>& circuit,
@@ -367,64 +485,25 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
             .c_str());
 
     c.def(nb::init<>(), "Initialize empty circuit.")
-        .def("gate_list",
-             &Circuit<Prec>::gate_list,
-             "Get property of `gate_list`.",
+        .def("instructions",
+             &Circuit<Prec>::instructions,
+             "Get property of `instructions`.",
              nb::rv_policy::reference)
-        .def("n_gates", &Circuit<Prec>::n_gates, "Get property of `n_gates`.")
+        .def("n_instructions", &Circuit<Prec>::n_instructions, "Get property of `n_instructions`.")
         .def("key_set", &Circuit<Prec>::key_set, "Get set of keys of parameters.")
-        .def("get_gate_at", &Circuit<Prec>::get_gate_at, "index"_a, "Get reference of i-th gate.")
+        .def("get_instruction_at",
+             &Circuit<Prec>::get_instruction_at,
+             "index"_a,
+             "Get reference of i-th instruction.")
         .def("get_param_key_at",
              &Circuit<Prec>::get_param_key_at,
              "index"_a,
-             "Get parameter key of i-th gate. If it is not parametric, return None.")
+             "Get parameter key of i-th instruction. If it is not parametric, return None.")
         .def("get_classical_condition_at",
              &Circuit<Prec>::get_classical_condition_at,
              "index"_a,
-             "Get classical condition of i-th gate. If it is not conditional, return None.")
+             "Get classical condition of i-th instruction. If it is not conditional, return None.")
         .def("calculate_depth", &Circuit<Prec>::calculate_depth, "Get depth of circuit.")
-        .def("add_gate",
-             nb::overload_cast<const Gate<Prec>&>(&Circuit<Prec>::add_gate),
-             "gate"_a,
-             "Add gate. Given gate is copied.")
-        .def("add_conditional_gate",
-             nb::overload_cast<const Gate<Prec>&, ClassicalCondition>(
-                 &Circuit<Prec>::add_conditional_gate),
-             "gate"_a,
-             "condition"_a,
-             "Add gate with a user-defined classical condition.")
-        .def("add_conditional_gate",
-             nb::overload_cast<const Gate<Prec>&, std::uint64_t, bool>(
-                 &Circuit<Prec>::add_conditional_gate),
-             "gate"_a,
-             "classical_bit_index"_a,
-             "expected_value"_a,
-             "Add gate with a condition on a classical bit.")
-        .def("add_param_gate",
-             nb::overload_cast<const ParamGate<Prec>&, std::string_view>(
-                 &Circuit<Prec>::add_param_gate),
-             "param_gate"_a,
-             "param_key"_a,
-             "Add parametric gate with specifying key. Given param_gate is copied.")
-        .def("add_conditional_param_gate",
-             nb::overload_cast<const ParamGate<Prec>&, std::string_view, ClassicalCondition>(
-                 &Circuit<Prec>::add_conditional_param_gate),
-             "param_gate"_a,
-             "param_key"_a,
-             "condition"_a,
-             "Add parametric gate with a user-defined classical condition.")
-        .def("add_conditional_param_gate",
-             nb::overload_cast<const ParamGate<Prec>&, std::string_view, std::uint64_t, bool>(
-                 &Circuit<Prec>::add_conditional_param_gate),
-             "param_gate"_a,
-             "param_key"_a,
-             "classical_bit_index"_a,
-             "expected_value"_a,
-             "Add parametric gate with a condition on a classical bit.")
-        .def("add_circuit",
-             nb::overload_cast<const Circuit<Prec>&>(&Circuit<Prec>::add_circuit),
-             "other"_a,
-             "Add all gates in specified circuit. Given gates are copied.")
         .def("copy",
              &Circuit<Prec>::copy,
              "Copy circuit. Returns a new circuit instance with all gates copied by reference.")
@@ -435,13 +514,79 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
             "to_json",
             [](const Circuit<Prec>& circuit) { return Json(circuit).dump(); },
             "Information as json style.")
-        .def(
-            "load_json",
-            [](Circuit<Prec>& circuit, const std::string& str) {
-                circuit = nlohmann::json::parse(str);
+        .def_static(
+            "from_json",
+            [](const std::string& str) {
+                return nlohmann::json::parse(str).template get<Circuit<Prec>>();
             },
             "json_str"_a,
-            "Read an object from the JSON representation of the circuit.");
+            "Create an object from the JSON representation of the circuit.");
+
+    nb::class_<CircuitBuilder<Prec>>(m, "CircuitBuilder", "Mutable builder for Circuit.")
+        .def(nb::init<>(), "Initialize empty circuit builder.")
+        .def("n_instructions",
+             &CircuitBuilder<Prec>::n_instructions,
+             "Get property of `n_instructions`.")
+        .def("add_gate",
+             nb::overload_cast<const Gate<Prec>&>(&CircuitBuilder<Prec>::add_gate),
+             "gate"_a,
+             "Add gate. Given gate is copied.")
+        .def("add_conditional_gate",
+             nb::overload_cast<const Gate<Prec>&, ClassicalCondition>(
+                 &CircuitBuilder<Prec>::add_conditional_gate),
+             "gate"_a,
+             "condition"_a,
+             "Add gate with a user-defined classical condition.")
+        .def("add_conditional_gate",
+             nb::overload_cast<const Gate<Prec>&, std::uint64_t, bool>(
+                 &CircuitBuilder<Prec>::add_conditional_gate),
+             "gate"_a,
+             "classical_bit_index"_a,
+             "expected_value"_a,
+             "Add gate with a condition on a classical bit.")
+        .def("add_param_gate",
+             nb::overload_cast<const ParamGate<Prec>&, std::string_view>(
+                 &CircuitBuilder<Prec>::add_param_gate),
+             "param_gate"_a,
+             "param_key"_a,
+             "Add parametric gate with specifying key. Given param_gate is copied.")
+        .def("add_conditional_param_gate",
+             nb::overload_cast<const ParamGate<Prec>&, std::string_view, ClassicalCondition>(
+                 &CircuitBuilder<Prec>::add_conditional_param_gate),
+             "param_gate"_a,
+             "param_key"_a,
+             "condition"_a,
+             "Add parametric gate with a user-defined classical condition.")
+        .def("add_conditional_param_gate",
+             nb::overload_cast<const ParamGate<Prec>&, std::string_view, std::uint64_t, bool>(
+                 &CircuitBuilder<Prec>::add_conditional_param_gate),
+             "param_gate"_a,
+             "param_key"_a,
+             "classical_bit_index"_a,
+             "expected_value"_a,
+             "Add parametric gate with a condition on a classical bit.")
+        .def("extend_circuit",
+             nb::overload_cast<const Circuit<Prec>&>(&CircuitBuilder<Prec>::extend_circuit),
+             "other"_a,
+             "Add all gates in specified circuit. Given gates are copied.")
+        .def("add_circuit",
+             &CircuitBuilder<Prec>::add_circuit,
+             "other"_a,
+             "Add specified circuit as a nested subcircuit.")
+        .def("add_conditional_circuit",
+             nb::overload_cast<const Circuit<Prec>&, ClassicalCondition>(
+                 &CircuitBuilder<Prec>::add_conditional_circuit),
+             "other"_a,
+             "condition"_a,
+             "Add subcircuit with a user-defined classical condition.")
+        .def("add_conditional_circuit",
+             nb::overload_cast<const Circuit<Prec>&, std::uint64_t, bool>(
+                 &CircuitBuilder<Prec>::add_conditional_circuit),
+             "other"_a,
+             "classical_bit_index"_a,
+             "expected_value"_a,
+             "Add subcircuit with a condition on a classical bit.")
+        .def("build", &CircuitBuilder<Prec>::build, "Build an immutable Circuit.");
 
     register_circuit_space_bindings<Prec, ExecutionSpace::Host>(c);
     register_circuit_space_bindings<Prec, ExecutionSpace::HostSerial>(c);

--- a/src/circuit/circuit.cpp
+++ b/src/circuit/circuit.cpp
@@ -8,8 +8,13 @@ namespace scaluq {
 template <Precision Prec>
 std::set<std::string> Circuit<Prec>::key_set() const {
     std::set<std::string> key_set;
-    for (auto&& gate : _gate_list) {
-        if (gate.index() == 1) key_set.insert(std::get<1>(gate).second);
+    for (const auto& instruction : instructions()) {
+        if (is_param_gate(instruction)) {
+            key_set.insert(get_param_gate_with_key(instruction).second);
+        } else if (is_circuit(instruction)) {
+            auto child_key_set = get_circuit(instruction).key_set();
+            key_set.insert(child_key_set.begin(), child_key_set.end());
+        }
     }
     return key_set;
 }
@@ -19,13 +24,27 @@ std::uint64_t Circuit<Prec>::calculate_depth() const {
     const std::uint64_t n_qubits = required_n_qubits();
     if (n_qubits == 0) return 0;
     std::vector<std::uint64_t> filled_step(n_qubits, 0ULL);
-    for (const auto& gate : _gate_list) {
+    for (const auto& instruction : instructions()) {
+        if (is_circuit(instruction)) {
+            const auto& subcircuit = get_circuit(instruction);
+            std::vector<std::uint64_t> operand_qubits =
+                internal::mask_to_vector(subcircuit.required_operand_qubit_mask());
+            std::uint64_t max_step = 0;
+            for (std::uint64_t operand : operand_qubits) {
+                if (max_step < filled_step[operand]) max_step = filled_step[operand];
+            }
+            const std::uint64_t subcircuit_depth = subcircuit.calculate_depth();
+            for (std::uint64_t operand : operand_qubits) {
+                filled_step[operand] = max_step + subcircuit_depth;
+            }
+            continue;
+        }
         std::vector<std::uint64_t> control_qubits =
-            gate.index() == 0 ? std::get<0>(gate)->control_qubit_list()
-                              : std::get<1>(gate).first->control_qubit_list();
+            is_gate(instruction) ? get_gate(instruction)->control_qubit_list()
+                                 : get_param_gate_with_key(instruction).first->control_qubit_list();
         std::vector<std::uint64_t> target_qubits =
-            gate.index() == 0 ? std::get<0>(gate)->target_qubit_list()
-                              : std::get<1>(gate).first->target_qubit_list();
+            is_gate(instruction) ? get_gate(instruction)->target_qubit_list()
+                                 : get_param_gate_with_key(instruction).first->target_qubit_list();
         std::uint64_t max_step_amount_target_qubits = 0;
         for (std::uint64_t control : control_qubits) {
             if (max_step_amount_target_qubits < filled_step[control]) {
@@ -48,27 +67,24 @@ std::uint64_t Circuit<Prec>::calculate_depth() const {
 }
 
 template <Precision Prec>
-void Circuit<Prec>::add_circuit(const Circuit<Prec>& circuit) {
-    _gate_list.reserve(_gate_list.size() + circuit._gate_list.size());
-    _classical_conditions.reserve(_classical_conditions.size() +
-                                  circuit._classical_conditions.size());
-    for (const auto& gate : circuit._gate_list) {
-        _gate_list.push_back(gate);
-    }
-    for (const auto& condition : circuit._classical_conditions) {
-        _classical_conditions.push_back(condition);
-    }
-}
-template <Precision Prec>
-void Circuit<Prec>::add_circuit(Circuit<Prec>&& circuit) {
-    _gate_list.reserve(_gate_list.size() + circuit._gate_list.size());
-    _classical_conditions.reserve(_classical_conditions.size() +
-                                  circuit._classical_conditions.size());
-    for (auto&& gate : circuit._gate_list) {
-        _gate_list.push_back(std::move(gate));
-    }
-    for (auto&& condition : circuit._classical_conditions) {
-        _classical_conditions.push_back(std::move(condition));
+template <ExecutionSpace Space>
+void Circuit<Prec>::update_quantum_state_internal(
+    internal::ExecutionContext<Prec, Space> context,
+    const std::map<std::string, double>& parameters) const {
+    for (std::uint64_t idx = 0; idx < instructions().size(); ++idx) {
+        if (_storage->classical_conditions[idx].has_value() &&
+            !_storage->classical_conditions[idx].value()(context.classical_register)) {
+            continue;
+        }
+        auto&& instruction = instructions()[idx];
+        if (is_gate(instruction)) {
+            get_gate(instruction)->update_quantum_state(context);
+        } else if (is_param_gate(instruction)) {
+            const auto& [param_gate, key] = get_param_gate_with_key(instruction);
+            param_gate->update_quantum_state(context, parameters.at(key));
+        } else {
+            get_circuit(instruction).update_quantum_state_internal(context, parameters);
+        }
     }
 }
 
@@ -93,9 +109,7 @@ void Circuit<Prec>::update_quantum_state(StateVector<Prec, Space>& state,
                                          const std::map<std::string, double>& parameters,
                                          std::uint64_t seed) const {
     check_state_vector_n_qubits(state.n_qubits());
-    for (auto&& gate : _gate_list) {
-        if (gate.index() == 0) continue;
-        const auto& key = std::get<1>(gate).second;
+    for (const auto& key : key_set()) {
         if (!parameters.contains(key)) {
             using namespace std::string_literals;
             throw std::runtime_error(
@@ -105,17 +119,48 @@ void Circuit<Prec>::update_quantum_state(StateVector<Prec, Space>& state,
     }
     std::mt19937_64 random_engine(seed);
     internal::ExecutionContext<Prec, Space> context{state, classical_register, random_engine};
-    for (std::uint64_t idx = 0; idx < _gate_list.size(); ++idx) {
-        if (_classical_conditions[idx].has_value() &&
-            !_classical_conditions[idx].value()(classical_register)) {
+    update_quantum_state_internal(context, parameters);
+}
+
+template <Precision Prec>
+template <ExecutionSpace Space>
+void Circuit<Prec>::update_quantum_state_internal(
+    internal::ExecutionContextBatched<Prec, Space> context,
+    const std::map<std::string, std::vector<double>>& parameters) const {
+    for (std::uint64_t idx = 0; idx < instructions().size(); ++idx) {
+        auto&& instruction = instructions()[idx];
+        if (_storage->classical_conditions[idx].has_value()) {
+            for (std::uint64_t batch_index = 0; batch_index < context.states.batch_size();
+                 ++batch_index) {
+                auto& reg = context.classical_register[batch_index];
+                if (!_storage->classical_conditions[idx].value()(reg)) continue;
+                auto state = context.states.view_state_vector_at(batch_index);
+                internal::ExecutionContext<Prec, Space> state_context{
+                    state, reg, context.random_engine};
+                if (is_gate(instruction)) {
+                    get_gate(instruction)->update_quantum_state(state_context);
+                } else if (is_param_gate(instruction)) {
+                    const auto& [param_gate, key] = get_param_gate_with_key(instruction);
+                    param_gate->update_quantum_state(state_context,
+                                                     parameters.at(key)[batch_index]);
+                } else {
+                    std::map<std::string, double> scalar_parameters;
+                    for (const auto& [key, values] : parameters) {
+                        scalar_parameters.emplace(key, values[batch_index]);
+                    }
+                    get_circuit(instruction)
+                        .update_quantum_state_internal(state_context, scalar_parameters);
+                }
+            }
             continue;
         }
-        auto&& gate = _gate_list[idx];
-        if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(context);
-        } else {
-            const auto& [param_gate, key] = std::get<1>(gate);
+        if (is_gate(instruction)) {
+            get_gate(instruction)->update_quantum_state(context);
+        } else if (is_param_gate(instruction)) {
+            const auto& [param_gate, key] = get_param_gate_with_key(instruction);
             param_gate->update_quantum_state(context, parameters.at(key));
+        } else {
+            get_circuit(instruction).update_quantum_state_internal(context, parameters);
         }
     }
 }
@@ -149,9 +194,7 @@ void Circuit<Prec>::update_quantum_state(
             "Circuit::update_quantum_state(StateVectorBatched&, ClassicalRegisterBatched&, ...): "
             "batch size mismatch.");
     }
-    for (auto&& gate : _gate_list) {
-        if (gate.index() == 0) continue;
-        const auto& key = std::get<1>(gate).second;
+    for (const auto& key : key_set()) {
         if (!parameters.contains(key)) {
             using namespace std::string_literals;
             throw std::runtime_error(
@@ -167,31 +210,7 @@ void Circuit<Prec>::update_quantum_state(
     std::mt19937_64 random_engine(seed);
     internal::ExecutionContextBatched<Prec, Space> context{
         states, classical_register, random_engine};
-    for (std::uint64_t idx = 0; idx < _gate_list.size(); ++idx) {
-        auto&& gate = _gate_list[idx];
-        if (_classical_conditions[idx].has_value()) {
-            for (std::uint64_t batch_index = 0; batch_index < states.batch_size(); ++batch_index) {
-                auto& reg = classical_register[batch_index];
-                if (!_classical_conditions[idx].value()(reg)) continue;
-                auto state = states.view_state_vector_at(batch_index);
-                internal::ExecutionContext<Prec, Space> state_context{state, reg, random_engine};
-                if (gate.index() == 0) {
-                    std::get<0>(gate)->update_quantum_state(state_context);
-                } else {
-                    const auto& [param_gate, key] = std::get<1>(gate);
-                    param_gate->update_quantum_state(state_context,
-                                                     parameters.at(key)[batch_index]);
-                }
-            }
-            continue;
-        }
-        if (gate.index() == 0) {
-            std::get<0>(gate)->update_quantum_state(context);
-        } else {
-            const auto& [param_gate, key] = std::get<1>(gate);
-            param_gate->update_quantum_state(context, parameters.at(key));
-        }
-    }
+    update_quantum_state_internal(context, parameters);
 }
 
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Host>(
@@ -255,43 +274,34 @@ template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Defa
 
 template <Precision Prec>
 Circuit<Prec> Circuit<Prec>::copy() const {
-    Circuit<Prec> ccircuit;
-    ccircuit._gate_list.reserve(_gate_list.size());
-    for (auto&& gate : _gate_list) {
-        if (gate.index() == 0)
-            ccircuit._gate_list.push_back(std::get<0>(gate));
-        else {
-            const auto& [param_gate, key] = std::get<1>(gate);
-            ccircuit._gate_list.push_back(std::make_pair(param_gate, key));
-        }
-    }
-    ccircuit._classical_conditions = _classical_conditions;
-    return ccircuit;
+    return *this;
 }
 
 template <Precision Prec>
 Circuit<Prec> Circuit<Prec>::get_inverse() const {
-    Circuit<Prec> icircuit;
-    icircuit._gate_list.reserve(_gate_list.size());
-    icircuit._classical_conditions.reserve(_classical_conditions.size());
-    for (std::uint64_t idx = 0; idx < _gate_list.size(); ++idx) {
-        auto&& gate = _gate_list[_gate_list.size() - 1 - idx];
-        if (gate.index() == 0)
-            icircuit._gate_list.push_back(std::get<0>(gate)->get_inverse());
-        else {
-            const auto& [param_gate, key] = std::get<1>(gate);
-            icircuit._gate_list.push_back(std::make_pair(param_gate->get_inverse(), key));
+    auto storage = std::make_shared<CircuitStorage<Prec>>();
+    storage->instructions.reserve(instructions().size());
+    storage->classical_conditions.reserve(_storage->classical_conditions.size());
+    for (std::uint64_t idx = 0; idx < instructions().size(); ++idx) {
+        auto&& instruction = instructions()[instructions().size() - 1 - idx];
+        if (is_gate(instruction)) {
+            storage->instructions.push_back(get_gate(instruction)->get_inverse());
+        } else if (is_param_gate(instruction)) {
+            const auto& [param_gate, key] = get_param_gate_with_key(instruction);
+            storage->instructions.push_back(std::make_pair(param_gate->get_inverse(), key));
+        } else {
+            storage->instructions.push_back(get_circuit(instruction).get_inverse());
         }
-        icircuit._classical_conditions.push_back(
-            _classical_conditions[_classical_conditions.size() - 1 - idx]);
+        storage->classical_conditions.push_back(
+            _storage->classical_conditions[_storage->classical_conditions.size() - 1 - idx]);
     }
-    return icircuit;
+    return Circuit(std::move(storage));
 }
 
 template <Precision Prec>
 template <ExecutionSpace Space>
-void Circuit<Prec>::optimize(std::uint64_t max_block_size) {
-    std::vector<GateWithKey> new_gate_list;  // result
+Circuit<Prec> Circuit<Prec>::optimize(std::uint64_t max_block_size) const {
+    std::vector<Instruction> new_instructions;  // result
     std::vector<std::optional<ClassicalCondition>> new_classical_conditions;
     double global_phase = 0.;
     std::vector<Gate<Prec>> gate_pool;  // waitlist for merge or push
@@ -300,19 +310,21 @@ void Circuit<Prec>::optimize(std::uint64_t max_block_size) {
     std::vector<std::uint64_t> waiting_gate_idx_at_qubit(
         n_qubits,
         NO_GATES);  // which gate is waiting in the qubit (by index of gate_pool)
-    auto get_operand_list = [&](const GateWithKey& gate_with_key) {
-        if (gate_with_key.index() == 0)
-            return std::get<0>(gate_with_key)->operand_qubit_list();
+    auto get_operand_list = [&](const Instruction& instruction) {
+        if (is_gate(instruction))
+            return get_gate(instruction)->operand_qubit_list();
+        else if (is_param_gate(instruction))
+            return get_param_gate_with_key(instruction).first->operand_qubit_list();
         else
-            return std::get<1>(gate_with_key).first->operand_qubit_list();
+            return internal::mask_to_vector(get_circuit(instruction).required_operand_qubit_mask());
     };
-    auto push = [&](const GateWithKey& gate_with_key,
+    auto push = [&](const Instruction& instruction,
                     std::optional<ClassicalCondition> condition = std::nullopt) {
         // clear waitlist and push gate to result
-        for (std::uint64_t operand : get_operand_list(gate_with_key)) {
+        for (std::uint64_t operand : get_operand_list(instruction)) {
             waiting_gate_idx_at_qubit[operand] = NO_GATES;
         }
-        new_gate_list.push_back(gate_with_key);
+        new_instructions.push_back(instruction);
         new_classical_conditions.push_back(std::move(condition));
     };
     auto wait = [&](const Gate<Prec>& gate) {
@@ -323,9 +335,9 @@ void Circuit<Prec>::optimize(std::uint64_t max_block_size) {
         }
         gate_pool.push_back(gate);
     };
-    auto get_waiting_gate_indices = [&](const GateWithKey& gate_with_key) {
+    auto get_waiting_gate_indices = [&](const Instruction& instruction) {
         std::vector<std::uint64_t> waiting_gate_indices;
-        for (std::uint64_t operand : get_operand_list(gate_with_key)) {
+        for (std::uint64_t operand : get_operand_list(instruction)) {
             if (waiting_gate_idx_at_qubit[operand] != NO_GATES)
                 waiting_gate_indices.push_back(waiting_gate_idx_at_qubit[operand]);
         }
@@ -334,46 +346,51 @@ void Circuit<Prec>::optimize(std::uint64_t max_block_size) {
                                    waiting_gate_indices.end());
         return waiting_gate_indices;
     };
-    auto push_waiting_gates = [&](const GateWithKey& gate_with_key) {
-        for (std::uint64_t idx : get_waiting_gate_indices(gate_with_key)) {
+    auto push_waiting_gates = [&](const Instruction& instruction) {
+        for (std::uint64_t idx : get_waiting_gate_indices(instruction)) {
             push(gate_pool[idx]);
         }
     };
-    auto get_newly_applied_qubits = [&](const GateWithKey& gate_with_key) {
+    auto clear_waiting_gate = [&](const Gate<Prec>& gate) {
+        for (std::uint64_t operand : gate->operand_qubit_list()) {
+            waiting_gate_idx_at_qubit[operand] = NO_GATES;
+        }
+    };
+    auto get_newly_applied_qubits = [&](const Instruction& instruction) {
         std::vector<std::uint64_t> newly_applied_qubits;
-        for (std::uint64_t operand : get_operand_list(gate_with_key)) {
+        for (std::uint64_t operand : get_operand_list(instruction)) {
             if (waiting_gate_idx_at_qubit[operand] == NO_GATES)
                 newly_applied_qubits.push_back(operand);
         }
         return newly_applied_qubits;
     };
 
-    for (std::uint64_t idx = 0; idx < _gate_list.size(); ++idx) {
-        const GateWithKey& gate_with_key = _gate_list[idx];
-        const auto& classical_condition = _classical_conditions[idx];
-        if (classical_condition.has_value() || gate_with_key.index() == 1 ||
-            std::get<0>(gate_with_key).gate_type() == GateType::Probabilistic ||
-            std::get<0>(gate_with_key).gate_type() == GateType::Measurement) {
+    for (std::uint64_t idx = 0; idx < instructions().size(); ++idx) {
+        const Instruction& instruction = instructions()[idx];
+        const auto& classical_condition = _storage->classical_conditions[idx];
+        if (classical_condition.has_value() || !is_gate(instruction) ||
+            get_gate(instruction).gate_type() == GateType::Probabilistic ||
+            get_gate(instruction).gate_type() == GateType::Measurement) {
             // ParamGate, Probabilistic, Gate with classical branches, and Measurement cannot be
             // merged with others
-            push_waiting_gates(gate_with_key);
-            push(gate_with_key, classical_condition);
+            push_waiting_gates(instruction);
+            push(instruction, classical_condition);
             continue;
         }
-        const Gate<Prec>& gate = std::get<0>(gate_with_key);
+        const Gate<Prec>& gate = get_gate(instruction);
         if (gate.gate_type() == GateType::I) continue;  // IGate is ignored
         if (gate.gate_type() == GateType::GlobalPhase && gate->control_qubit_mask() == 0ULL) {
             // non-controlled GlobalPhase is ignored
             global_phase += GlobalPhaseGate<Prec>(gate)->phase();
             continue;
         }
-        std::vector<std::uint64_t> waiting_gate_indices = get_waiting_gate_indices(gate_with_key);
+        std::vector<std::uint64_t> waiting_gate_indices = get_waiting_gate_indices(instruction);
         if (waiting_gate_indices.empty()) {
             // just wait
             wait(gate);
             continue;
         }
-        std::vector<std::uint64_t> newly_applied_qubits = get_newly_applied_qubits(gate_with_key);
+        std::vector<std::uint64_t> newly_applied_qubits = get_newly_applied_qubits(instruction);
         std::uint64_t new_gate_size =
             std::accumulate(waiting_gate_indices.begin(),
                             waiting_gate_indices.end(),
@@ -420,6 +437,13 @@ void Circuit<Prec>::optimize(std::uint64_t max_block_size) {
             }
 
             // wait
+            if (merged_gate.gate_type() == GateType::I) {
+                clear_waiting_gate(gate);
+                for (std::uint64_t idx : waiting_gate_indices) {
+                    clear_waiting_gate(gate_pool[idx]);
+                }
+                continue;
+            }
             wait(merged_gate);
         } else {
             // not merge
@@ -440,19 +464,22 @@ void Circuit<Prec>::optimize(std::uint64_t max_block_size) {
     finally_waiting_gate_indices.erase(std::ranges::unique(finally_waiting_gate_indices).begin(),
                                        finally_waiting_gate_indices.end());
     for (std::uint64_t idx : finally_waiting_gate_indices) {
-        new_gate_list.push_back(gate_pool[idx]);
+        new_instructions.push_back(gate_pool[idx]);
         new_classical_conditions.push_back(std::nullopt);
     }
     if (std::abs(global_phase) > 1e-12) push(gate::GlobalPhase<Prec>(global_phase));
-    _gate_list.swap(new_gate_list);
-    _classical_conditions.swap(new_classical_conditions);
+    auto storage = std::make_shared<CircuitStorage<Prec>>();
+    storage->instructions = std::move(new_instructions);
+    storage->classical_conditions = std::move(new_classical_conditions);
+    return Circuit(std::move(storage));
 }
-template void Circuit<internal::Prec>::optimize<ExecutionSpace::Host>(std::uint64_t max_block_size);
-template void Circuit<internal::Prec>::optimize<ExecutionSpace::HostSerial>(
-    std::uint64_t max_block_size);
+template Circuit<internal::Prec> Circuit<internal::Prec>::optimize<ExecutionSpace::Host>(
+    std::uint64_t max_block_size) const;
+template Circuit<internal::Prec> Circuit<internal::Prec>::optimize<ExecutionSpace::HostSerial>(
+    std::uint64_t max_block_size) const;
 #ifdef SCALUQ_USE_CUDA
-template void Circuit<internal::Prec>::optimize<ExecutionSpace::Default>(
-    std::uint64_t max_block_size);
+template Circuit<internal::Prec> Circuit<internal::Prec>::optimize<ExecutionSpace::Default>(
+    std::uint64_t max_block_size) const;
 #endif  // SCALUQ_USE_CUDA
 
 // サンプリング回数について，下図のような木をBFSする
@@ -474,15 +501,18 @@ std::vector<std::pair<StateVector<Prec, Space>, std::int64_t>> Circuit<Prec>::si
     states.set_state_vector_at(0, initial_state);
     std::vector<std::uint64_t> scounts{sampling_count}, new_scounts;
 
-    for (auto& g : _gate_list) {
+    for (auto& g : instructions()) {
+        if (is_circuit(g)) {
+            throw std::runtime_error("Circuit::simulate_noise: nested circuits are not supported.");
+        }
         std::vector<double> probs;
         std::vector<GateWithKey> gates;
-        if (g.index() == 0) {
-            const auto& gate = std::get<0>(g);
+        if (is_gate(g)) {
+            const auto& gate = get_gate(g);
             if (gate.gate_type() == GateType::Probabilistic) {
                 probs = ProbabilisticGate<Prec>(gate)->distribution();
-                const auto& gate_list = ProbabilisticGate<Prec>(gate)->gate_list();
-                for (const auto& tmp : gate_list) {
+                const auto& probabilistic_gate_list = ProbabilisticGate<Prec>(gate)->gate_list();
+                for (const auto& tmp : probabilistic_gate_list) {
                     gates.push_back(tmp);
                 }
             } else {
@@ -490,7 +520,7 @@ std::vector<std::pair<StateVector<Prec, Space>, std::int64_t>> Circuit<Prec>::si
                 gates.push_back(gate);
             }
         } else {
-            const auto& [gate, key] = std::get<1>(g);
+            const auto& [gate, key] = get_param_gate_with_key(g);
             if (gate.param_gate_type() == ParamGateType::ParamProbabilistic) {
                 probs = ParamProbabilisticGate<Prec>(gate)->distribution();
                 auto prob_gate_list = ParamProbabilisticGate<Prec>(gate)->gate_list();
@@ -504,7 +534,7 @@ std::vector<std::pair<StateVector<Prec, Space>, std::int64_t>> Circuit<Prec>::si
                 }
             } else {
                 probs = std::vector<double>{1.0};
-                gates.push_back(g);
+                gates.push_back(get_param_gate_with_key(g));
             }
         }
 
@@ -584,12 +614,23 @@ Circuit<internal::Prec>::simulate_noise<ExecutionSpace::Default>(
 #endif  // SCALUQ_USE_CUDA
 
 template <Precision Prec>
-std::uint64_t Circuit<Prec>::required_n_qubits() const {
+std::uint64_t Circuit<Prec>::required_operand_qubit_mask() const {
     std::uint64_t operand_mask = 0;
-    for (const auto& gate : _gate_list) {
-        operand_mask |= gate.index() == 0 ? std::get<0>(gate)->operand_qubit_mask()
-                                          : std::get<1>(gate).first->operand_qubit_mask();
+    for (const auto& instruction : instructions()) {
+        if (is_gate(instruction)) {
+            operand_mask |= get_gate(instruction)->operand_qubit_mask();
+        } else if (is_param_gate(instruction)) {
+            operand_mask |= get_param_gate_with_key(instruction).first->operand_qubit_mask();
+        } else {
+            operand_mask |= get_circuit(instruction).required_operand_qubit_mask();
+        }
     }
+    return operand_mask;
+}
+
+template <Precision Prec>
+std::uint64_t Circuit<Prec>::required_n_qubits() const {
+    const std::uint64_t operand_mask = required_operand_qubit_mask();
     return std::bit_width(operand_mask);
 }
 
@@ -603,12 +644,18 @@ void Circuit<Prec>::check_state_vector_n_qubits(std::uint64_t n_qubits) const {
 
 template <Precision Prec>
 bool Circuit<Prec>::has_classical_instructions() const {
-    if (std::ranges::any_of(_classical_conditions,
+    if (std::ranges::any_of(_storage->classical_conditions,
                             [](const auto& condition) { return condition.has_value(); })) {
         return true;
     }
-    return std::ranges::any_of(_gate_list, [](const GateWithKey& gate) {
-        return gate.index() == 0 && std::get<0>(gate).gate_type() == GateType::Measurement;
+    return std::ranges::any_of(instructions(), [](const Instruction& instruction) {
+        if (is_gate(instruction)) {
+            return get_gate(instruction).gate_type() == GateType::Measurement;
+        }
+        if (is_circuit(instruction)) {
+            return get_circuit(instruction).has_classical_instructions();
+        }
+        return false;
     });
 }
 
@@ -622,8 +669,6 @@ std::unordered_map<std::string, double> Circuit<Prec>::compute_expectation_gradi
     StateVector<Prec, Space>& bistate,
     const std::map<std::string, double>& parameters) {
     const auto eps = internal::get_epsilon<Prec>();
-    const std::uint64_t n_gates = this->n_gates();
-
     std::unordered_map<std::string, double> gradient;
     const auto& key_set = this->key_set();
     gradient.reserve(key_set.size());
@@ -633,11 +678,18 @@ std::unordered_map<std::string, double> Circuit<Prec>::compute_expectation_gradi
 
     StateVector<Prec, Space> Astate(state.n_qubits());
 
-    for (std::int64_t i = static_cast<std::int64_t>(n_gates) - 1; i >= 0; i--) {
-        const auto& cur_gate = this->get_gate_at(static_cast<std::uint64_t>(i));
+    for (const auto& instruction : instructions()) {
+        if (is_circuit(instruction)) {
+            throw std::runtime_error(
+                "compute_expectation_gradient_backprop: nested circuits are not supported.");
+        }
+    }
 
-        if (cur_gate.index() == 1) {
-            const auto& [pgate, key] = std::get<1>(cur_gate);
+    for (std::int64_t i = static_cast<std::int64_t>(n_instructions()) - 1; i >= 0; i--) {
+        const auto& cur_gate = get_instruction_at(static_cast<std::uint64_t>(i));
+
+        if (is_param_gate(cur_gate)) {
+            const auto& [pgate, key] = get_param_gate_with_key(cur_gate);
 
             Astate = state.copy();
             double pauli_coef = 1.0;
@@ -669,14 +721,14 @@ std::unordered_map<std::string, double> Circuit<Prec>::compute_expectation_gradi
             gradient[key] += contrib;
         }
 
-        if (cur_gate.index() == 0) {
-            const auto& g = std::get<0>(cur_gate);
+        if (is_gate(cur_gate)) {
+            const auto& g = get_gate(cur_gate);
 
             auto inv = g->get_inverse();
             inv->update_quantum_state(bistate);
             inv->update_quantum_state(state);
         } else {
-            const auto& [pgate, key] = std::get<1>(cur_gate);
+            const auto& [pgate, key] = get_param_gate_with_key(cur_gate);
 
             auto inv = pgate->get_inverse();
             const auto it = parameters.find(key);

--- a/src/gate/gate_probabilistic.cpp
+++ b/src/gate/gate_probabilistic.cpp
@@ -20,6 +20,9 @@ void flatten_probabilistic_gate(double prob_prefix,
                                 const Gate<Prec>& gate,
                                 std::vector<double>& accumulated_distribution,
                                 std::vector<Gate<Prec>>& accumulated_gate_list) {
+    if (gate.gate_type() == GateType::Measurement) {
+        throw std::runtime_error("MeasurementGate cannot be added to ProbabilisticGate.");
+    }
     if (gate.gate_type() != GateType::Probabilistic) {
         accumulated_distribution.push_back(prob_prefix);
         accumulated_gate_list.push_back(gate);
@@ -95,10 +98,8 @@ std::string ProbabilisticGateImpl<Prec>::to_string(const std::string& indent) co
         ExecutionContextBatched<Prec, Space> context) const {                                     \
         for (std::size_t i = 0; i < context.states.batch_size(); ++i) {                           \
             auto state_vector = context.states.view_state_vector_at(i);                           \
-            this->update_quantum_state(                                                           \
-                ExecutionContext<Prec, Space>{state_vector,                                       \
-                                              context.classical_register[i],                      \
-                                              context.random_engine});                            \
+            this->update_quantum_state(ExecutionContext<Prec, Space>{                             \
+                state_vector, context.classical_register[i], context.random_engine});             \
         }                                                                                         \
     }
 DEFINE_PROBABILISTIC_GATE_CONTEXT_UPDATE(ExecutionSpace::Host)

--- a/src/gate/param_gate_probabilistic.cpp
+++ b/src/gate/param_gate_probabilistic.cpp
@@ -25,6 +25,9 @@ void flatten_param_probabilistic_gate(double prob_prefix,
                                       std::vector<EitherGate<Prec>>& accumulated_gate_list) {
     if (gate.index() == 0) {
         const auto& gate_non_param = std::get<0>(gate);
+        if (gate_non_param.gate_type() == GateType::Measurement) {
+            throw std::runtime_error("MeasurementGate cannot be added to ParamProbabilisticGate.");
+        }
         if (gate_non_param.gate_type() == GateType::Probabilistic) {
             auto probabilistic_gate = ProbabilisticGate<Prec>(gate_non_param);
             const auto& distribution = probabilistic_gate->distribution();
@@ -125,9 +128,8 @@ void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
     for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
         auto state_vector = context.states.view_state_vector_at(i);
         this->update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::Host>{state_vector,
-                                                         context.classical_register[i],
-                                                         context.random_engine},
+            ExecutionContext<Prec, ExecutionSpace::Host>{
+                state_vector, context.classical_register[i], context.random_engine},
             params[i]);
     }
 }
@@ -149,9 +151,8 @@ void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
     for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
         auto state_vector = context.states.view_state_vector_at(i);
         this->update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::HostSerial>{state_vector,
-                                                               context.classical_register[i],
-                                                               context.random_engine},
+            ExecutionContext<Prec, ExecutionSpace::HostSerial>{
+                state_vector, context.classical_register[i], context.random_engine},
             params[i]);
     }
 }
@@ -174,9 +175,8 @@ void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
     for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
         auto state_vector = context.states.view_state_vector_at(i);
         this->update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::Default>{state_vector,
-                                                            context.classical_register[i],
-                                                            context.random_engine},
+            ExecutionContext<Prec, ExecutionSpace::Default>{
+                state_vector, context.classical_register[i], context.random_engine},
             params[i]);
     }
 }

--- a/tests/circuit/circuit_test.cpp
+++ b/tests/circuit/circuit_test.cpp
@@ -3,6 +3,7 @@
 #include <scaluq/circuit/circuit.hpp>
 #include <scaluq/gate/gate_factory.hpp>
 #include <scaluq/gate/param_gate_factory.hpp>
+#include <scaluq/operator/operator.hpp>
 
 #include "../test_environment.hpp"
 #include "../util/util.hpp"
@@ -12,6 +13,149 @@ using namespace scaluq;
 template <typename T>
 class CircuitTest : public FixtureBase<T> {};
 TYPED_TEST_SUITE(CircuitTest, TestTypes, NameGenerator);
+
+TYPED_TEST(CircuitTest, CircuitBuilderBuildsCircuit) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    CircuitBuilder<Prec> builder;
+    builder.add_gate(gate::X<Prec>(0));
+    builder.add_gate(gate::Y<Prec>(1));
+
+    Circuit<Prec> circuit = builder.build();
+    StateVector<Prec, Space> state(2);
+    circuit.update_quantum_state(state, {}, 0);
+
+    const auto amplitudes = state.get_amplitudes();
+    check_near<Prec>(amplitudes[0], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[1], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[2], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[3], StdComplex{0.0, 1.0});
+}
+
+TYPED_TEST(CircuitTest, CircuitBuilderAddsSubcircuitAsSingleInstruction) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    CircuitBuilder<Prec> sub_builder;
+    sub_builder.add_gate(gate::X<Prec>(0));
+    Circuit<Prec> subcircuit = sub_builder.build();
+
+    CircuitBuilder<Prec> builder;
+    builder.add_circuit(subcircuit);
+    builder.add_gate(gate::X<Prec>(1));
+
+    Circuit<Prec> circuit = builder.build();
+    ASSERT_EQ(circuit.n_instructions(), 2);
+    EXPECT_TRUE(is_circuit(circuit.get_instruction_at(0)));
+
+    StateVector<Prec, Space> state(2);
+    circuit.update_quantum_state(state, {}, 0);
+
+    const auto amplitudes = state.get_amplitudes();
+    check_near<Prec>(amplitudes[0], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[1], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[2], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[3], StdComplex{1.0, 0.0});
+}
+
+TYPED_TEST(CircuitTest, CalculateDepthUsesSubcircuitOperands) {
+    constexpr Precision Prec = TestFixture::Prec;
+
+    CircuitBuilder<Prec> sub_builder;
+    sub_builder.add_gate(gate::X<Prec>(2));
+    Circuit<Prec> subcircuit = sub_builder.build();
+
+    CircuitBuilder<Prec> builder;
+    builder.add_circuit(subcircuit);
+    builder.add_gate(gate::X<Prec>(0));
+
+    Circuit<Prec> circuit = builder.build();
+    EXPECT_EQ(circuit.calculate_depth(), 1);
+}
+
+TYPED_TEST(CircuitTest, AddConditionalSubcircuit) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    CircuitBuilder<Prec> sub_builder;
+    sub_builder.add_gate(gate::X<Prec>(0));
+    Circuit<Prec> subcircuit = sub_builder.build();
+
+    CircuitBuilder<Prec> builder;
+    builder.add_gate(gate::Measurement<Prec>(0, 0, true));
+    builder.add_conditional_circuit(subcircuit, 0, false);
+    builder.add_conditional_gate(gate::X<Prec>(1), 0, true);
+
+    Circuit<Prec> circuit = builder.build();
+    StateVector<Prec, Space> state(2);
+    ClassicalRegister classical_register(1);
+    circuit.update_quantum_state(state, classical_register, {}, 0);
+    EXPECT_FALSE(classical_register[0]);
+
+    const auto amplitudes = state.get_amplitudes();
+    check_near<Prec>(amplitudes[0], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[1], StdComplex{1.0, 0.0});
+    check_near<Prec>(amplitudes[2], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[3], StdComplex{0.0, 0.0});
+}
+
+TYPED_TEST(CircuitTest, SubcircuitJsonRoundTrip) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    CircuitBuilder<Prec> sub_builder;
+    sub_builder.add_gate(gate::X<Prec>(0));
+    Circuit<Prec> subcircuit = sub_builder.build();
+
+    CircuitBuilder<Prec> builder;
+    builder.add_circuit(subcircuit);
+    Circuit<Prec> circuit = builder.build();
+
+    Circuit<Prec> restored = Json(circuit).get<Circuit<Prec>>();
+    ASSERT_EQ(restored.n_instructions(), 1);
+    EXPECT_TRUE(is_circuit(restored.get_instruction_at(0)));
+
+    StateVector<Prec, Space> state(1);
+    restored.update_quantum_state(state, {}, 0);
+
+    const auto amplitudes = state.get_amplitudes();
+    check_near<Prec>(amplitudes[0], StdComplex{0.0, 0.0});
+    check_near<Prec>(amplitudes[1], StdComplex{1.0, 0.0});
+}
+
+TYPED_TEST(CircuitTest, SimulateNoiseRejectsNestedCircuit) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    CircuitBuilder<Prec> sub_builder;
+    sub_builder.add_gate(gate::X<Prec>(0));
+    Circuit<Prec> subcircuit = sub_builder.build();
+
+    CircuitBuilder<Prec> builder;
+    builder.add_circuit(subcircuit);
+    Circuit<Prec> circuit = builder.build();
+
+    StateVector<Prec, Space> state(1);
+    EXPECT_THROW(circuit.template simulate_noise<Space>(state, 10), std::runtime_error);
+}
+
+TYPED_TEST(CircuitTest, ComputeExpectationGradientRejectsNestedCircuit) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    CircuitBuilder<Prec> sub_builder;
+    sub_builder.add_gate(gate::X<Prec>(0));
+    Circuit<Prec> subcircuit = sub_builder.build();
+
+    CircuitBuilder<Prec> builder;
+    builder.add_circuit(subcircuit);
+    Circuit<Prec> circuit = builder.build();
+
+    Operator<Prec, Space> observable({PauliOperator<Prec>("Z 0", 1.0)});
+    EXPECT_THROW(circuit.template compute_expectation_gradient<Space>(observable, {}),
+                 std::runtime_error);
+}
 
 template <Precision Prec, ExecutionSpace Space>
 void circuit_test() {
@@ -26,117 +170,118 @@ void circuit_test() {
     auto state_cp = state.get_amplitudes();
     for (std::uint64_t i = 0; i < dim; ++i) state_eigen[i] = state_cp[i];
 
-    Circuit<Prec> circuit;
+    CircuitBuilder<Prec> builder;
     std::uint64_t target, target_sub;
     double angle;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::X<Prec>(target));
+    builder.add_gate(gate::X<Prec>(target));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_X(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::Y<Prec>(target));
+    builder.add_gate(gate::Y<Prec>(target));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_Y(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::Z<Prec>(target));
+    builder.add_gate(gate::Z<Prec>(target));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_Z(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::H<Prec>(target));
+    builder.add_gate(gate::H<Prec>(target));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_H(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::S<Prec>(target));
+    builder.add_gate(gate::S<Prec>(target));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_S(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::Sdag<Prec>(target));
+    builder.add_gate(gate::Sdag<Prec>(target));
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target, make_S().adjoint(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::T<Prec>(target));
+    builder.add_gate(gate::T<Prec>(target));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_T(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::Tdag<Prec>(target));
+    builder.add_gate(gate::Tdag<Prec>(target));
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target, make_T().adjoint(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::SqrtX<Prec>(target));
+    builder.add_gate(gate::SqrtX<Prec>(target));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_SqrtX(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::SqrtXdag<Prec>(target));
+    builder.add_gate(gate::SqrtXdag<Prec>(target));
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target, make_SqrtX().adjoint(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::SqrtY<Prec>(target));
+    builder.add_gate(gate::SqrtY<Prec>(target));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_SqrtY(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::SqrtYdag<Prec>(target));
+    builder.add_gate(gate::SqrtYdag<Prec>(target));
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target, make_SqrtY().adjoint(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::P0<Prec>(target));
+    builder.add_gate(gate::P0<Prec>(target));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_P0(), n) * state_eigen;
 
     target = (target + 1) % n;
-    circuit.add_gate(gate::P1<Prec>(target));
+    builder.add_gate(gate::P1<Prec>(target));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_P1(), n) * state_eigen;
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
-    circuit.add_gate(gate::RX<Prec>(target, angle));
+    builder.add_gate(gate::RX<Prec>(target, angle));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_RX(angle), n) * state_eigen;
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
-    circuit.add_gate(gate::RY<Prec>(target, angle));
+    builder.add_gate(gate::RY<Prec>(target, angle));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_RY(angle), n) * state_eigen;
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
-    circuit.add_gate(gate::RZ<Prec>(target, angle));
+    builder.add_gate(gate::RZ<Prec>(target, angle));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_RZ(angle), n) * state_eigen;
 
     target = random.int32() % n;
     target_sub = random.int32() % (n - 1);
     if (target_sub >= target) target_sub++;
-    circuit.add_gate(gate::CX<Prec>(target, target_sub));
+    builder.add_gate(gate::CX<Prec>(target, target_sub));
     state_eigen = get_eigen_matrix_full_qubit_CX(target, target_sub, n) * state_eigen;
 
     target = random.int32() % n;
     target_sub = random.int32() % (n - 1);
     if (target_sub >= target) target_sub++;
-    circuit.add_gate(gate::CZ<Prec>(target, target_sub));
+    builder.add_gate(gate::CZ<Prec>(target, target_sub));
     state_eigen = get_eigen_matrix_full_qubit_CZ(target, target_sub, n) * state_eigen;
 
     target = random.int32() % n;
     target_sub = random.int32() % (n - 1);
     if (target_sub >= target) target_sub++;
-    circuit.add_gate(gate::Swap<Prec>(target, target_sub));
+    builder.add_gate(gate::Swap<Prec>(target, target_sub));
     state_eigen = get_eigen_matrix_full_qubit_Swap(target, target_sub, n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::U1<Prec>(target, std::numbers::pi));
+    builder.add_gate(gate::U1<Prec>(target, std::numbers::pi));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_Z(), n) * state_eigen;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::U2<Prec>(target, 0, std::numbers::pi));
+    builder.add_gate(gate::U2<Prec>(target, 0, std::numbers::pi));
     state_eigen = get_expanded_eigen_matrix_with_identity(target, make_H(), n) * state_eigen;
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
-    circuit.add_gate(gate::U3<Prec>(target, -angle, 0, 0));
+    builder.add_gate(gate::U3<Prec>(target, -angle, 0, 0));
     state_eigen =
         get_expanded_eigen_matrix_with_identity(target, make_U(-angle, 0, 0), n) * state_eigen;
 
+    Circuit<Prec> circuit = builder.build();
     circuit.update_quantum_state(state);
 
     state_cp = state.get_amplitudes();
@@ -163,73 +308,74 @@ void circuit_rev_test() {
     ComplexVector state_eigen(dim);
     for (std::uint64_t i = 0; i < dim; ++i) state_eigen[i] = state_cp[i];
 
-    Circuit<Prec> circuit;
+    CircuitBuilder<Prec> builder;
     std::uint64_t target, target_sub;
     double angle;
 
     target = random.int32() % n;
-    circuit.add_gate(gate::X<Prec>(target));
+    builder.add_gate(gate::X<Prec>(target));
 
     target = random.int32() % n;
-    circuit.add_gate(gate::Y<Prec>(target));
+    builder.add_gate(gate::Y<Prec>(target));
 
     target = random.int32() % n;
-    circuit.add_gate(gate::Z<Prec>(target));
+    builder.add_gate(gate::Z<Prec>(target));
 
     target = random.int32() % n;
-    circuit.add_gate(gate::H<Prec>(target));
+    builder.add_gate(gate::H<Prec>(target));
 
     target = random.int32() % n;
-    circuit.add_gate(gate::S<Prec>(target));
+    builder.add_gate(gate::S<Prec>(target));
 
     target = random.int32() % n;
-    circuit.add_gate(gate::Sdag<Prec>(target));
+    builder.add_gate(gate::Sdag<Prec>(target));
 
     target = random.int32() % n;
-    circuit.add_gate(gate::T<Prec>(target));
+    builder.add_gate(gate::T<Prec>(target));
 
     target = random.int32() % n;
-    circuit.add_gate(gate::Tdag<Prec>(target));
+    builder.add_gate(gate::Tdag<Prec>(target));
 
     target = random.int32() % n;
-    circuit.add_gate(gate::SqrtX<Prec>(target));
+    builder.add_gate(gate::SqrtX<Prec>(target));
 
     target = random.int32() % n;
-    circuit.add_gate(gate::SqrtXdag<Prec>(target));
+    builder.add_gate(gate::SqrtXdag<Prec>(target));
 
     target = random.int32() % n;
-    circuit.add_gate(gate::SqrtY<Prec>(target));
+    builder.add_gate(gate::SqrtY<Prec>(target));
 
     target = random.int32() % n;
-    circuit.add_gate(gate::SqrtYdag<Prec>(target));
-
-    target = random.int32() % n;
-    angle = random.uniform() * 3.14159;
-    circuit.add_gate(gate::RX<Prec>(target, angle));
+    builder.add_gate(gate::SqrtYdag<Prec>(target));
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
-    circuit.add_gate(gate::RY<Prec>(target, angle));
+    builder.add_gate(gate::RX<Prec>(target, angle));
 
     target = random.int32() % n;
     angle = random.uniform() * 3.14159;
-    circuit.add_gate(gate::RZ<Prec>(target, angle));
+    builder.add_gate(gate::RY<Prec>(target, angle));
+
+    target = random.int32() % n;
+    angle = random.uniform() * 3.14159;
+    builder.add_gate(gate::RZ<Prec>(target, angle));
 
     target = random.int32() % n;
     target_sub = random.int32() % (n - 1);
     if (target_sub >= target) target_sub++;
-    circuit.add_gate(gate::CX<Prec>(target, target_sub));
+    builder.add_gate(gate::CX<Prec>(target, target_sub));
 
     target = random.int32() % n;
     target_sub = random.int32() % (n - 1);
     if (target_sub >= target) target_sub++;
-    circuit.add_gate(gate::CZ<Prec>(target, target_sub));
+    builder.add_gate(gate::CZ<Prec>(target, target_sub));
 
     target = random.int32() % n;
     target_sub = random.int32() % (n - 1);
     if (target_sub >= target) target_sub++;
-    circuit.add_gate(gate::Swap<Prec>(target, target_sub));
+    builder.add_gate(gate::Swap<Prec>(target, target_sub));
 
+    Circuit<Prec> circuit = builder.build();
     circuit.update_quantum_state(state);
 
     auto revcircuit = circuit.get_inverse();
@@ -251,9 +397,10 @@ TYPED_TEST(CircuitTest, ThrowsWhenStateHasTooFewQubits) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
 
-    Circuit<Prec> circuit;
-    circuit.add_gate(gate::X<Prec>(1));
+    CircuitBuilder<Prec> builder;
+    builder.add_gate(gate::X<Prec>(1));
 
+    Circuit<Prec> circuit = builder.build();
     StateVector<Prec, Space> state(1);
     ASSERT_THROW(circuit.update_quantum_state(state), std::runtime_error);
 }
@@ -262,10 +409,11 @@ TYPED_TEST(CircuitTest, UpdateQuantumStateStoresMeasurementInClassicalRegister) 
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
 
-    Circuit<Prec> circuit;
-    circuit.add_gate(gate::X<Prec>(0));
-    circuit.add_gate(gate::Measurement<Prec>(0, 3));
+    CircuitBuilder<Prec> builder;
+    builder.add_gate(gate::X<Prec>(0));
+    builder.add_gate(gate::Measurement<Prec>(0, 3));
 
+    Circuit<Prec> circuit = builder.build();
     StateVector<Prec, Space> state(1);
     ClassicalRegister classical_register(4);
     circuit.update_quantum_state(state, classical_register, {}, 0);
@@ -281,11 +429,12 @@ TYPED_TEST(CircuitTest, AddConditionalGate) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
 
-    Circuit<Prec> circuit;
-    circuit.add_gate(gate::Measurement<Prec>(0, 0, true));  // must be reg[0]=0
-    circuit.add_conditional_gate(gate::X<Prec>(0), 0, 0);   // must be |01>
-    circuit.add_conditional_gate(gate::X<Prec>(1), 0, 1);   // must not be |10>
+    CircuitBuilder<Prec> builder;
+    builder.add_gate(gate::Measurement<Prec>(0, 0, true));  // must be reg[0]=0
+    builder.add_conditional_gate(gate::X<Prec>(0), 0, 0);   // must be |01>
+    builder.add_conditional_gate(gate::X<Prec>(1), 0, 1);   // must not be |10>
 
+    Circuit<Prec> circuit = builder.build();
     StateVector<Prec, Space> state(2);
     ClassicalRegister classical_register(1);
     circuit.update_quantum_state(state, classical_register, {}, 0);
@@ -302,11 +451,12 @@ TYPED_TEST(CircuitTest, AddConditionalGateBatched) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
 
-    Circuit<Prec> circuit;
-    circuit.add_gate(gate::Measurement<Prec>(0, 0, true));
-    circuit.add_conditional_gate(gate::X<Prec>(0), 0, 0);
-    circuit.add_conditional_gate(gate::X<Prec>(1), 0, 1);
+    CircuitBuilder<Prec> builder;
+    builder.add_gate(gate::Measurement<Prec>(0, 0, true));
+    builder.add_conditional_gate(gate::X<Prec>(0), 0, 0);
+    builder.add_conditional_gate(gate::X<Prec>(1), 0, 1);
 
+    Circuit<Prec> circuit = builder.build();
     StateVectorBatched<Prec, Space> states(2, 2);
     states.load({
         {1.0, 0.0, 0.0, 0.0},
@@ -333,9 +483,10 @@ TYPED_TEST(CircuitTest, ThrowsWhenMeasurementRequiresClassicalRegister) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
 
-    Circuit<Prec> circuit;
-    circuit.add_gate(gate::Measurement<Prec>(0, 0));
+    CircuitBuilder<Prec> builder;
+    builder.add_gate(gate::Measurement<Prec>(0, 0));
 
+    Circuit<Prec> circuit = builder.build();
     StateVector<Prec, Space> state(1);
     EXPECT_THROW(circuit.update_quantum_state(state, {}, 0), std::runtime_error);
 
@@ -347,9 +498,10 @@ TYPED_TEST(CircuitTest, ThrowsWhenConditionalGateRequiresClassicalRegister) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
 
-    Circuit<Prec> circuit;
-    circuit.add_conditional_gate(gate::X<Prec>(0), 0, true);
+    CircuitBuilder<Prec> builder;
+    builder.add_conditional_gate(gate::X<Prec>(0), 0, true);
 
+    Circuit<Prec> circuit = builder.build();
     StateVector<Prec, Space> state(1);
     EXPECT_THROW(circuit.update_quantum_state(state, {}, 0), std::runtime_error);
 
@@ -361,10 +513,11 @@ TYPED_TEST(CircuitTest, UpdateQuantumStateBatchedStoresMeasurementInClassicalReg
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
 
-    Circuit<Prec> circuit;
-    circuit.add_gate(gate::X<Prec>(0));
-    circuit.add_gate(gate::Measurement<Prec>(0, 1));
+    CircuitBuilder<Prec> builder;
+    builder.add_gate(gate::X<Prec>(0));
+    builder.add_gate(gate::Measurement<Prec>(0, 1));
 
+    Circuit<Prec> circuit = builder.build();
     StateVectorBatched<Prec, Space> states(2, 1);
     ClassicalRegisterBatched classical_register(2, 2);
 
@@ -377,13 +530,15 @@ TYPED_TEST(CircuitTest, OptimizeDoesNotMergeMeasurementGate) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
 
-    Circuit<Prec> circuit;
-    circuit.add_gate(gate::X<Prec>(0));
-    circuit.add_gate(gate::Measurement<Prec>(0, 0));
+    CircuitBuilder<Prec> builder;
+    builder.add_gate(gate::X<Prec>(0));
+    builder.add_gate(gate::Measurement<Prec>(0, 0));
 
-    circuit.template optimize<Space>();
+    Circuit<Prec> circuit = builder.build();
+    auto optimized = circuit.template optimize<Space>();
 
-    ASSERT_EQ(circuit.n_gates(), 2);
-    EXPECT_EQ(std::get<0>(circuit.get_gate_at(0)).gate_type(), GateType::X);
-    EXPECT_EQ(std::get<0>(circuit.get_gate_at(1)).gate_type(), GateType::Measurement);
+    ASSERT_EQ(optimized.n_instructions(), 2);
+    EXPECT_EQ(get_gate(optimized.get_instruction_at(0)).gate_type(), GateType::X);
+    EXPECT_EQ(get_gate(optimized.get_instruction_at(1)).gate_type(), GateType::Measurement);
+    ASSERT_EQ(circuit.n_instructions(), 2);
 }

--- a/tests/circuit/param_circuit_test.cpp
+++ b/tests/circuit/param_circuit_test.cpp
@@ -18,8 +18,8 @@ void param_circuit_test() {
     std::uint64_t n_qubits = 5;
     Random random;
     for ([[maybe_unused]] std::uint64_t repeat : std::views::iota(0, 10)) {
-        Circuit<Prec> circuit;
-        Circuit<Prec> pcircuit;
+        CircuitBuilder<Prec> builder;
+        CircuitBuilder<Prec> pbuilder;
         constexpr std::uint64_t nparams = 5;
         std::array<std::string, nparams> pkeys = {};
         for (std::uint64_t pidx : std::views::iota(std::uint64_t{0}, nparams))
@@ -37,16 +37,16 @@ void param_circuit_test() {
                 std::uint64_t pidx = random.int32() % nparams;
                 if (param_gate_kind == 0) {
                     std::uint64_t target = random.int32() % n_qubits;
-                    circuit.add_gate(gate::RX<Prec>(target, coef * params[pidx]));
-                    pcircuit.add_param_gate(gate::ParamRX<Prec>(target, coef), pkeys[pidx]);
+                    builder.add_gate(gate::RX<Prec>(target, coef * params[pidx]));
+                    pbuilder.add_param_gate(gate::ParamRX<Prec>(target, coef), pkeys[pidx]);
                 } else if (param_gate_kind == 1) {
                     std::uint64_t target = random.int32() % n_qubits;
-                    circuit.add_gate(gate::RY<Prec>(target, coef * params[pidx]));
-                    pcircuit.add_param_gate(gate::ParamRY<Prec>(target, coef), pkeys[pidx]);
+                    builder.add_gate(gate::RY<Prec>(target, coef * params[pidx]));
+                    pbuilder.add_param_gate(gate::ParamRY<Prec>(target, coef), pkeys[pidx]);
                 } else if (param_gate_kind == 2) {
                     std::uint64_t target = random.int32() % n_qubits;
-                    circuit.add_gate(gate::RZ<Prec>(target, coef * params[pidx]));
-                    pcircuit.add_param_gate(gate::ParamRZ<Prec>(target, coef), pkeys[pidx]);
+                    builder.add_gate(gate::RZ<Prec>(target, coef * params[pidx]));
+                    pbuilder.add_param_gate(gate::ParamRZ<Prec>(target, coef), pkeys[pidx]);
                 } else {
                     std::vector<std::uint64_t> target_vec, pauli_id_vec;
                     for (std::uint64_t target = 0; target < n_qubits; target++) {
@@ -54,21 +54,23 @@ void param_circuit_test() {
                         pauli_id_vec.emplace_back(random.int64() % 4);
                     }
                     PauliOperator<Prec> pauli(target_vec, pauli_id_vec, 1.0);
-                    circuit.add_gate(gate::PauliRotation<Prec>(pauli, coef * params[pidx]));
-                    pcircuit.add_param_gate(gate::ParamPauliRotation<Prec>(pauli, coef),
+                    builder.add_gate(gate::PauliRotation<Prec>(pauli, coef * params[pidx]));
+                    pbuilder.add_param_gate(gate::ParamPauliRotation<Prec>(pauli, coef),
                                             pkeys[pidx]);
                 }
             } else {
                 std::uint64_t control = random.int32() % n_qubits;
                 std::uint64_t target = random.int32() % (n_qubits - 1);
                 if (target == control) target = n_qubits - 1;
-                circuit.add_gate(gate::CX<Prec>(control, target));
-                pcircuit.add_gate(gate::CX<Prec>(control, target));
+                builder.add_gate(gate::CX<Prec>(control, target));
+                pbuilder.add_gate(gate::CX<Prec>(control, target));
             }
         };
         for ([[maybe_unused]] std::uint64_t _ : std::views::iota(0ULL, 20ULL)) {
             add_random_rotation_or_cnot();
         }
+        Circuit<Prec> circuit = builder.build();
+        Circuit<Prec> pcircuit = pbuilder.build();
         StateVector state = StateVector<Prec, Space>::Haar_random_state(n_qubits);
         StateVector state_cp = state.copy();
         auto amplitudes_base = state.get_amplitudes();
@@ -102,10 +104,11 @@ TYPED_TEST(ParamCircuitTest, InsufficientParameterGiven) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
     {
-        Circuit<Prec> circuit;
-        circuit.add_param_gate(gate::ParamRX<Prec>(0), "0");
-        circuit.add_param_gate(gate::ParamRX<Prec>(0), "1");
-        circuit.add_param_gate(gate::ParamRX<Prec>(0), "0");
+        CircuitBuilder<Prec> builder;
+        builder.add_param_gate(gate::ParamRX<Prec>(0), "0");
+        builder.add_param_gate(gate::ParamRX<Prec>(0), "1");
+        builder.add_param_gate(gate::ParamRX<Prec>(0), "0");
+        Circuit<Prec> circuit = builder.build();
         StateVector<Prec, Space> state(1);
         ASSERT_NO_THROW(circuit.update_quantum_state(state, {{"0", 0}, {"1", 0}}));
         ASSERT_NO_THROW(circuit.update_quantum_state(state, {{"0", 0}, {"1", 0}, {"2", 0}}));
@@ -120,11 +123,12 @@ TYPED_TEST(ParamCircuitTest, AddConditionalParamGate) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
 
-    Circuit<Prec> circuit;
-    circuit.add_gate(gate::Measurement<Prec>(0, 0, true));                      // must be reg[0]=0
-    circuit.add_conditional_param_gate(gate::ParamRX<Prec>(0), "theta", 0, 0);  // must be |01>
-    circuit.add_conditional_param_gate(gate::ParamRX<Prec>(1), "theta", 0, 1);  // must not be |10>
+    CircuitBuilder<Prec> builder;
+    builder.add_gate(gate::Measurement<Prec>(0, 0, true));                      // must be reg[0]=0
+    builder.add_conditional_param_gate(gate::ParamRX<Prec>(0), "theta", 0, 0);  // must be |01>
+    builder.add_conditional_param_gate(gate::ParamRX<Prec>(1), "theta", 0, 1);  // must not be |10>
 
+    Circuit<Prec> circuit = builder.build();
     StateVector<Prec, Space> state(2);
     ClassicalRegister classical_register(1);
     circuit.update_quantum_state(state, classical_register, {{"theta", std::numbers::pi}}, 0);
@@ -141,11 +145,12 @@ TYPED_TEST(ParamCircuitTest, UpdateQuantumStateExecutesConditionalParametricGate
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
 
-    Circuit<Prec> circuit;
-    circuit.add_gate(gate::X<Prec>(0));
-    circuit.add_gate(gate::Measurement<Prec>(0, 0));
-    circuit.add_conditional_param_gate(gate::ParamRX<Prec>(1), "theta", 0, true);
+    CircuitBuilder<Prec> builder;
+    builder.add_gate(gate::X<Prec>(0));
+    builder.add_gate(gate::Measurement<Prec>(0, 0));
+    builder.add_conditional_param_gate(gate::ParamRX<Prec>(1), "theta", 0, true);
 
+    Circuit<Prec> circuit = builder.build();
     StateVector<Prec, Space> state(2);
     ClassicalRegister classical_register(1);
     circuit.update_quantum_state(state, classical_register, {{"theta", std::numbers::pi}}, 0);

--- a/tests/circuit/test_compute_expectation_gradient.cpp
+++ b/tests/circuit/test_compute_expectation_gradient.cpp
@@ -22,7 +22,7 @@ void compute_expectation_gradient_test_parametric_rc() {
     std::uniform_int_distribution<std::uint64_t> dist_target(0, n - 1);
     std::uniform_real_distribution<double> dist_param(-M_PI, M_PI);
 
-    Circuit<Prec> circuit;
+    CircuitBuilder<Prec> builder;
 
     const double pcoef1 = 0.7;
     const double pcoef2 = 0.2;
@@ -55,14 +55,15 @@ void compute_expectation_gradient_test_parametric_rc() {
         gate_coefs.push_back(dist_param(engine));
         gate_coefs.push_back(dist_param(engine));
 
-        circuit.add_param_gate(gate::ParamRX<Prec>(gate_targets[idx_first], gate_coefs[idx_first]),
+        builder.add_param_gate(gate::ParamRX<Prec>(gate_targets[idx_first], gate_coefs[idx_first]),
                                std::to_string(idx_first));
-        circuit.add_param_gate(
+        builder.add_param_gate(
             gate::ParamRY<Prec>(gate_targets[idx_second], gate_coefs[idx_second]),
             std::to_string(idx_second));
-        circuit.add_param_gate(gate::ParamRZ<Prec>(gate_targets[idx_third], gate_coefs[idx_third]),
+        builder.add_param_gate(gate::ParamRZ<Prec>(gate_targets[idx_third], gate_coefs[idx_third]),
                                std::to_string(idx_third));
     }
+    Circuit<Prec> circuit = builder.build();
     auto gradient = circuit.compute_expectation_gradient(op, parameters);
 
     // make gradient by eigen matrix calculation
@@ -133,7 +134,7 @@ void compute_expectation_gradient_test_parametric_pauli_rotation() {
     std::uniform_int_distribution<std::uint64_t> dist_target(0, n - 1);
     std::uniform_real_distribution<double> dist_param(-M_PI, M_PI);
 
-    Circuit<Prec> circuit;
+    CircuitBuilder<Prec> builder;
 
     const double pcoef1 = 0.7;
     const double pcoef2 = 0.2;
@@ -170,25 +171,26 @@ void compute_expectation_gradient_test_parametric_pauli_rotation() {
         pauli_op_coefs.push_back(dist_param(engine));
         pauli_op_coefs.push_back(dist_param(engine));
 
-        circuit.add_param_gate(
+        builder.add_param_gate(
             gate::ParamPauliRotation<Prec>(
                 PauliOperator<Prec>("X " + std::to_string(gate_targets[idx_first]),
                                     pauli_op_coefs[idx_first]),
                 pauli_rotation_coefs[idx_first]),
             std::to_string(idx_first));
-        circuit.add_param_gate(
+        builder.add_param_gate(
             gate::ParamPauliRotation<Prec>(
                 PauliOperator<Prec>("Y " + std::to_string(gate_targets[idx_second]),
                                     pauli_op_coefs[idx_second]),
                 pauli_rotation_coefs[idx_second]),
             std::to_string(idx_second));
-        circuit.add_param_gate(
+        builder.add_param_gate(
             gate::ParamPauliRotation<Prec>(
                 PauliOperator<Prec>("Z " + std::to_string(gate_targets[idx_third]),
                                     pauli_op_coefs[idx_third]),
                 pauli_rotation_coefs[idx_third]),
             std::to_string(idx_third));
     }
+    Circuit<Prec> circuit = builder.build();
     auto gradient = circuit.compute_expectation_gradient(op, parameters);
 
     // make gradient by eigen matrix calculation
@@ -269,8 +271,9 @@ TYPED_TEST(CircuitExpectationGradientTest, RejectsNonHermitianObservable) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
 
-    Circuit<Prec> circuit;
-    circuit.add_param_gate(gate::ParamRX<Prec>(0, 1.0), "theta");
+    CircuitBuilder<Prec> builder;
+    builder.add_param_gate(gate::ParamRX<Prec>(0, 1.0), "theta");
+    Circuit<Prec> circuit = builder.build();
 
     const Operator<Prec, Space> op({PauliOperator<Prec>("X 0", StdComplex(0.0, 1.0))});
     const std::map<std::string, double> parameters{{"theta", 0.1}};


### PR DESCRIPTION
</details>

## Summary
Circuit単位での古典分岐を可能にしたいという理由から，Circuitをネストできるような設計を採用しました．
`Circuit`を他クラス同様immutableな設計にし，ポインタによる管理をさせることでコピーコストを下げます．