### PR TITLE
Update download-artifact version

### DIFF
--- a/.github/workflows/wheel_merge.yml
+++ b/.github/workflows/wheel_merge.yml
@@ -118,23 +118,23 @@ jobs:
       - name: Install Python dependencies
         run: python -m pip install twine
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: cp310-${{ matrix.cibw-os-arch }}
           path: ./cp310
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: cp311-${{ matrix.cibw-os-arch }}
           path: ./cp311
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: cp312-${{ matrix.cibw-os-arch }}
           path: ./cp312
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: cp313-${{ matrix.cibw-os-arch }}
           path: ./cp313
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: cp314-${{ matrix.cibw-os-arch }}
           path: ./cp314


### PR DESCRIPTION
## Summary
Briefly describe the changes in this PR.  

#368 の続き

## What was changed? (変更点)
- `actions/download-artifact@v7` <- `actions/download-artifact@v4`

## Why was this change needed? (変更理由)
- Github ActionsのNode.js 24以降に伴うactionsバージョンの更新
