### PR TITLE
Try to reduce cuda build time

### DIFF
--- a/.github/workflows/install_pr.yml
+++ b/.github/workflows/install_pr.yml
@@ -2,7 +2,6 @@ name: Install to System (PR)
 
 on:
   pull_request:
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -143,7 +142,7 @@ jobs:
 
       - name: Install to system (CUDA)
         if: ${{ matrix.device == 'cuda' }}
-        run: sudo -E env "PATH=$PATH" ninja -j 2 -C build install
+        run: sudo -E env "PATH=$PATH" ninja -j 4 -C build install
 
       - name: Install to system (CPU)
         if: ${{ matrix.device == 'cpu' }}

--- a/.github/workflows/install_pr.yml
+++ b/.github/workflows/install_pr.yml
@@ -130,7 +130,8 @@ jobs:
       - name: Configure
         run: ./script/configure
 
-      - name: Inspect Runner Hardware
+      - name: Inspect Runner Hardware (Linux only)
+        if: ${{ matrix.os-arch == 'linux-x86_64' }}
         run: |
           echo "=== CPU Info ==="
           nproc

--- a/.github/workflows/install_pr.yml
+++ b/.github/workflows/install_pr.yml
@@ -33,7 +33,7 @@ jobs:
   library:
     name: Install Library
     needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.any_changed == 'true' }}
+    # if: ${{ needs.check-changed.outputs.any_changed == 'true' }}
     strategy:
       matrix:
         os-arch: ["linux-x86_64", "macos-arm64"]

--- a/.github/workflows/install_pr.yml
+++ b/.github/workflows/install_pr.yml
@@ -2,6 +2,7 @@ name: Install to System (PR)
 
 on:
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -129,7 +130,22 @@ jobs:
       - name: Configure
         run: ./script/configure
 
-      - name: Install to system
+      - name: Inspect Runner Hardware
+        run: |
+          echo "=== CPU Info ==="
+          nproc
+          lscpu | grep -E "Model name|CPU\(s\):|Thread\(s\) per core"
+          echo "=== Memory Info ==="
+          free -h
+          echo "=== Disk Info ==="
+          df -h /
+
+      - name: Install to system (CUDA)
+        if: ${{ matrix.device == 'cuda' }}
+        run: sudo -E env "PATH=$PATH" ninja -j 2 -C build install
+
+      - name: Install to system (CPU)
+        if: ${{ matrix.device == 'cpu' }}
         run: sudo -E env "PATH=$PATH" ninja -C build install
 
       - name: Build and Run other project


### PR DESCRIPTION
## Summary
Briefly describe the changes in this PR.  

cuda利用時のビルド時間がCIのクリアを律速するものの一つであるので、改善を試みる。

時間測定実験のため他のファイルへのninja並列数の変更は未完了。

## What was changed? (変更点)
- cuda利用時だけnvccによるメモリスワッピングの可能性があるのでninjaの並列数で実験する。

## Why was this change needed? (変更理由)
- CIの時間を削減したい。

## Additional context (optional)
- 並列数をいくつか試してみるが、cuda環境のビルドだけが遅い理由がメモリスワッピングのため低速かは不明。
- ninjaはデフォルトで `並列数=(プロセッサ数+2) or (プロセッサ)`　のようなので`-j は1,2,4`あたりを試す予定。
