### PR TITLE
ParamGate の JSON 復元で control_value が壊れる不具合を修正

### DIFF
--- a/src/gate/param_gate_standard.cpp
+++ b/src/gate/param_gate_standard.cpp
@@ -333,7 +333,7 @@ template class ParamRZGateImpl<Prec>;
         return std::make_shared<const Impl<Prec>>(                                           \
             vector_to_mask(j.at("target").get<std::vector<std::uint64_t>>()),                \
             vector_to_mask(controls),                                                        \
-            vector_to_mask(control_values),                                                  \
+            vector_to_mask(controls, control_values),                                        \
             static_cast<Float<Prec>>(j.at("param_coef").get<double>()));                     \
     }                                                                                        \
     template struct GetParamGateFromJson<Impl<Prec>>;

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -109,6 +109,53 @@ TYPED_TEST(ParamGateTest, ApplyParamRZGate) {
     test_apply_parametric_single_pauli_rotation<Prec, Space>(
         5, &gate::RZ<Prec>, &gate::ParamRZ<Prec>);
 }
+
+template <Precision Prec, ExecutionSpace Space, typename Factory>
+void test_param_gate_json_roundtrip_preserves_control_value(Factory factory) {
+    using ParamGateT = ParamGate<Prec>;
+    using StateVectorT = StateVector<Prec, Space>;
+
+    const ParamGateT original =
+        factory(0, 1.0, std::vector<std::uint64_t>{5}, std::vector<std::uint64_t>{1});
+    const ParamGateT restored = Json(original).template get<ParamGateT>();
+
+    ASSERT_EQ(restored->control_qubit_list(), (std::vector<std::uint64_t>{5}));
+    ASSERT_EQ(restored->control_value_list(), (std::vector<std::uint64_t>{1}));
+
+    StateVectorT state_original(6);
+    StateVectorT state_restored(6);
+    state_original.set_computational_basis(1ULL << 5);
+    state_restored.set_computational_basis(1ULL << 5);
+
+    original->update_quantum_state(state_original, std::numbers::pi);
+    restored->update_quantum_state(state_restored, std::numbers::pi);
+
+    const auto amps_original = state_original.get_amplitudes();
+    const auto amps_restored = state_restored.get_amplitudes();
+    ASSERT_EQ(amps_original.size(), amps_restored.size());
+    for (std::size_t i = 0; i < amps_original.size(); ++i) {
+        check_near<Prec>(amps_original[i], amps_restored[i]);
+    }
+}
+
+TYPED_TEST(ParamGateTest, ParamRXJsonRoundtripPreservesControlValue) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRX<Prec>);
+}
+
+TYPED_TEST(ParamGateTest, ParamRYJsonRoundtripPreservesControlValue) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRY<Prec>);
+}
+
+TYPED_TEST(ParamGateTest, ParamRZJsonRoundtripPreservesControlValue) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRZ<Prec>);
+}
+
 TYPED_TEST(ParamGateTest, ApplyParamPauliRotationGate) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -91,21 +91,13 @@ void test_apply_parametric_multi_pauli_rotation(std::uint64_t n_qubits) {
     }
 }
 
-TYPED_TEST(ParamGateTest, ApplyParamRXGate) {
+TYPED_TEST(ParamGateTest, ApplyParamRotationGates) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
     test_apply_parametric_single_pauli_rotation<Prec, Space>(
         5, &gate::RX<Prec>, &gate::ParamRX<Prec>);
-}
-TYPED_TEST(ParamGateTest, ApplyParamRYGate) {
-    constexpr Precision Prec = TestFixture::Prec;
-    constexpr ExecutionSpace Space = TestFixture::Space;
     test_apply_parametric_single_pauli_rotation<Prec, Space>(
         5, &gate::RY<Prec>, &gate::ParamRY<Prec>);
-}
-TYPED_TEST(ParamGateTest, ApplyParamRZGate) {
-    constexpr Precision Prec = TestFixture::Prec;
-    constexpr ExecutionSpace Space = TestFixture::Space;
     test_apply_parametric_single_pauli_rotation<Prec, Space>(
         5, &gate::RZ<Prec>, &gate::ParamRZ<Prec>);
 }
@@ -138,21 +130,11 @@ void test_param_gate_json_roundtrip_preserves_control_value(Factory factory) {
     }
 }
 
-TYPED_TEST(ParamGateTest, ParamRXJsonRoundtripPreservesControlValue) {
+TYPED_TEST(ParamGateTest, ParamGateJsonRoundtripPreservesControlValue) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
     test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRX<Prec>);
-}
-
-TYPED_TEST(ParamGateTest, ParamRYJsonRoundtripPreservesControlValue) {
-    constexpr Precision Prec = TestFixture::Prec;
-    constexpr ExecutionSpace Space = TestFixture::Space;
     test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRY<Prec>);
-}
-
-TYPED_TEST(ParamGateTest, ParamRZJsonRoundtripPreservesControlValue) {
-    constexpr Precision Prec = TestFixture::Prec;
-    constexpr ExecutionSpace Space = TestFixture::Space;
     test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRZ<Prec>);
 }
 
@@ -219,14 +201,12 @@ TYPED_TEST(ParamGateTest, ParamProbabilisticGateRejectsInvalidDistributionValues
     EXPECT_THROW(
         gate::ParamProbabilistic<Prec>({-0.2, 1.2}, {gate::ParamRX<Prec>(0), gate::I<Prec>()}),
         std::runtime_error);
-    EXPECT_THROW(
-        gate::ParamProbabilistic<Prec>({std::numeric_limits<double>::quiet_NaN(), 1.0},
-                                       {gate::ParamRX<Prec>(0), gate::I<Prec>()}),
-        std::runtime_error);
-    EXPECT_THROW(
-        gate::ParamProbabilistic<Prec>({std::numeric_limits<double>::infinity(), 0.0},
-                                       {gate::ParamRX<Prec>(0), gate::I<Prec>()}),
-        std::runtime_error);
+    EXPECT_THROW(gate::ParamProbabilistic<Prec>({std::numeric_limits<double>::quiet_NaN(), 1.0},
+                                                {gate::ParamRX<Prec>(0), gate::I<Prec>()}),
+                 std::runtime_error);
+    EXPECT_THROW(gate::ParamProbabilistic<Prec>({std::numeric_limits<double>::infinity(), 0.0},
+                                                {gate::ParamRX<Prec>(0), gate::I<Prec>()}),
+                 std::runtime_error);
 }
 
 template <Precision Prec, ExecutionSpace Space>


### PR DESCRIPTION
## Summary
`ParamRX`、`ParamRY`、`ParamRZ` の JSON 復元処理において、制御条件の復元方法が誤っていたため、`to_json()` / `from_json()` の往復後に元の gate と異なる条件で動作してしまう不具合を修正しました。

## What was changed? (変更点)
- `src/gate/param_gate_standard.cpp` の `GetParamGateFromJson` を修正
- `control_value_mask` の復元処理を、誤っていた `vector_to_mask(control_values)` から、正しい `vector_to_mask(controls, control_values)` に変更
- `ParamRX`、`ParamRY`、`ParamRZ` について、JSON 往復後も制御 qubit と制御値が正しく保持されることを確認するテストを追加
- 復元後の gate で `control_qubit_list()` と `control_value_list()` が期待どおりであることを確認
- 復元後の gate が元の gate と同じ入力状態に対して同じ量子状態更新結果を返すことを確認

## Why was this change needed? (変更理由)
- JSON 復元時に `control_value_mask` の構築方法が誤っており、`control_value` が「各制御 qubit に対応する 0/1 条件」ではなく、「qubit index の配列」のように扱われていたため
- その結果、たとえば `control = [5]`、`control_value = [1]` は本来「5番 qubit が 1 のときに gate を適用する」という意味ですが、復元時には `control_value = [1]` が「条件値 1」ではなく「1番 qubit」という index のように解釈され、5番 qubit に対する制御条件が正しく再現されていなかったため