### PR TITLE
u1、u2ゲートのjsonパラメータ名の修正

### DIFF
--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -941,7 +941,7 @@ std::shared_ptr<const U1GateImpl<Prec>> GetGateFromJson<U1GateImpl<Prec>>::get(c
         vector_to_mask(j.at("target").get<std::vector<std::uint64_t>>()),
         vector_to_mask(control_qubits),
         vector_to_mask(control_qubits, control_values),
-        static_cast<Float<Prec>>(j.at("theta").get<double>()));
+        static_cast<Float<Prec>>(j.at("lambda").get<double>()));
 }
 template <Precision Prec>
 std::shared_ptr<const U2GateImpl<Prec>> GetGateFromJson<U2GateImpl<Prec>>::get(const Json& j) {
@@ -951,8 +951,8 @@ std::shared_ptr<const U2GateImpl<Prec>> GetGateFromJson<U2GateImpl<Prec>>::get(c
         vector_to_mask(j.at("target").get<std::vector<std::uint64_t>>()),
         vector_to_mask(control_qubits),
         vector_to_mask(control_qubits, control_values),
-        static_cast<Float<Prec>>(j.at("theta").get<double>()),
-        static_cast<Float<Prec>>(j.at("phi").get<double>()));
+        static_cast<Float<Prec>>(j.at("phi").get<double>()),
+        static_cast<Float<Prec>>(j.at("lambda").get<double>()));
 }
 template <Precision Prec>
 std::shared_ptr<const U3GateImpl<Prec>> GetGateFromJson<U3GateImpl<Prec>>::get(const Json& j) {

--- a/src/gate/param_gate_standard.cpp
+++ b/src/gate/param_gate_standard.cpp
@@ -333,7 +333,7 @@ template class ParamRZGateImpl<Prec>;
         return std::make_shared<const Impl<Prec>>(                                           \
             vector_to_mask(j.at("target").get<std::vector<std::uint64_t>>()),                \
             vector_to_mask(controls),                                                        \
-            vector_to_mask(control_values),                                                  \
+            vector_to_mask(controls, control_values),                                        \
             static_cast<Float<Prec>>(j.at("param_coef").get<double>()));                     \
     }                                                                                        \
     template struct GetParamGateFromJson<Impl<Prec>>;

--- a/tests/gate/gate_test.cpp
+++ b/tests/gate/gate_test.cpp
@@ -796,6 +796,69 @@ TYPED_TEST(GateTest, MeasurementGateJsonRoundTrip) {
     EXPECT_EQ(MeasurementGate<Prec>(loaded)->classical_bit_index(), 3);
 }
 
+TYPED_TEST(GateTest, UGateJsonRoundTrip) {
+    constexpr Precision Prec = TestFixture::Prec;
+
+    {
+        Gate<Prec> gate = gate::U1<Prec>(0, 0.75, {2}, {1});
+        ASSERT_NO_THROW({
+            Gate<Prec> loaded = Json(gate).template get<Gate<Prec>>();
+            ASSERT_EQ(loaded.gate_type(), GateType::U1);
+            EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{2}));
+            EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
+            EXPECT_NEAR(U1Gate<Prec>(loaded)->lambda(), 0.75, 1e-12);
+            const auto original_matrix = gate->get_matrix();
+            const auto loaded_matrix = loaded->get_matrix();
+            ASSERT_EQ(original_matrix.rows(), loaded_matrix.rows());
+            ASSERT_EQ(original_matrix.cols(), loaded_matrix.cols());
+            for (Eigen::Index r = 0; r < original_matrix.rows(); ++r) {
+                for (Eigen::Index c = 0; c < original_matrix.cols(); ++c) {
+                    check_near<Prec>(original_matrix(r, c), loaded_matrix(r, c));
+                }
+            }
+        });
+    }
+
+    {
+        Gate<Prec> gate = gate::U2<Prec>(1, 0.25, 0.75, {3}, {1});
+        Gate<Prec> loaded = Json(gate).template get<Gate<Prec>>();
+        ASSERT_EQ(loaded.gate_type(), GateType::U2);
+        EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{3}));
+        EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
+        EXPECT_NEAR(U2Gate<Prec>(loaded)->phi(), 0.25, 1e-12);
+        EXPECT_NEAR(U2Gate<Prec>(loaded)->lambda(), 0.75, 1e-12);
+        const auto original_matrix = gate->get_matrix();
+        const auto loaded_matrix = loaded->get_matrix();
+        ASSERT_EQ(original_matrix.rows(), loaded_matrix.rows());
+        ASSERT_EQ(original_matrix.cols(), loaded_matrix.cols());
+        for (Eigen::Index r = 0; r < original_matrix.rows(); ++r) {
+            for (Eigen::Index c = 0; c < original_matrix.cols(); ++c) {
+                check_near<Prec>(original_matrix(r, c), loaded_matrix(r, c));
+            }
+        }
+    }
+
+    {
+        Gate<Prec> gate = gate::U3<Prec>(2, 0.5, 0.25, 0.75, {4}, {1});
+        Gate<Prec> loaded = Json(gate).template get<Gate<Prec>>();
+        ASSERT_EQ(loaded.gate_type(), GateType::U3);
+        EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{4}));
+        EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
+        EXPECT_NEAR(U3Gate<Prec>(loaded)->theta(), 0.5, 1e-12);
+        EXPECT_NEAR(U3Gate<Prec>(loaded)->phi(), 0.25, 1e-12);
+        EXPECT_NEAR(U3Gate<Prec>(loaded)->lambda(), 0.75, 1e-12);
+        const auto original_matrix = gate->get_matrix();
+        const auto loaded_matrix = loaded->get_matrix();
+        ASSERT_EQ(original_matrix.rows(), loaded_matrix.rows());
+        ASSERT_EQ(original_matrix.cols(), loaded_matrix.cols());
+        for (Eigen::Index r = 0; r < original_matrix.rows(); ++r) {
+            for (Eigen::Index c = 0; c < original_matrix.cols(); ++c) {
+                check_near<Prec>(original_matrix(r, c), loaded_matrix(r, c));
+            }
+        }
+    }
+}
+
 TYPED_TEST(GateTest, FlattenNestedProbabilisticGate) {
     constexpr Precision Prec = TestFixture::Prec;
     Gate<Prec> nested_gate = gate::Probabilistic<Prec>(

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -109,6 +109,53 @@ TYPED_TEST(ParamGateTest, ApplyParamRZGate) {
     test_apply_parametric_single_pauli_rotation<Prec, Space>(
         5, &gate::RZ<Prec>, &gate::ParamRZ<Prec>);
 }
+
+template <Precision Prec, ExecutionSpace Space, typename Factory>
+void test_param_gate_json_roundtrip_preserves_control_value(Factory factory) {
+    using ParamGateT = ParamGate<Prec>;
+    using StateVectorT = StateVector<Prec, Space>;
+
+    const ParamGateT original =
+        factory(0, 1.0, std::vector<std::uint64_t>{5}, std::vector<std::uint64_t>{1});
+    const ParamGateT restored = Json(original).template get<ParamGateT>();
+
+    ASSERT_EQ(restored->control_qubit_list(), (std::vector<std::uint64_t>{5}));
+    ASSERT_EQ(restored->control_value_list(), (std::vector<std::uint64_t>{1}));
+
+    StateVectorT state_original(6);
+    StateVectorT state_restored(6);
+    state_original.set_computational_basis(1ULL << 5);
+    state_restored.set_computational_basis(1ULL << 5);
+
+    original->update_quantum_state(state_original, std::numbers::pi);
+    restored->update_quantum_state(state_restored, std::numbers::pi);
+
+    const auto amps_original = state_original.get_amplitudes();
+    const auto amps_restored = state_restored.get_amplitudes();
+    ASSERT_EQ(amps_original.size(), amps_restored.size());
+    for (std::size_t i = 0; i < amps_original.size(); ++i) {
+        check_near<Prec>(amps_original[i], amps_restored[i]);
+    }
+}
+
+TYPED_TEST(ParamGateTest, ParamRXJsonRoundtripPreservesControlValue) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRX<Prec>);
+}
+
+TYPED_TEST(ParamGateTest, ParamRYJsonRoundtripPreservesControlValue) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRY<Prec>);
+}
+
+TYPED_TEST(ParamGateTest, ParamRZJsonRoundtripPreservesControlValue) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRZ<Prec>);
+}
+
 TYPED_TEST(ParamGateTest, ApplyParamPauliRotationGate) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -91,21 +91,13 @@ void test_apply_parametric_multi_pauli_rotation(std::uint64_t n_qubits) {
     }
 }
 
-TYPED_TEST(ParamGateTest, ApplyParamRXGate) {
+TYPED_TEST(ParamGateTest, ApplyParamRotationGates) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
     test_apply_parametric_single_pauli_rotation<Prec, Space>(
         5, &gate::RX<Prec>, &gate::ParamRX<Prec>);
-}
-TYPED_TEST(ParamGateTest, ApplyParamRYGate) {
-    constexpr Precision Prec = TestFixture::Prec;
-    constexpr ExecutionSpace Space = TestFixture::Space;
     test_apply_parametric_single_pauli_rotation<Prec, Space>(
         5, &gate::RY<Prec>, &gate::ParamRY<Prec>);
-}
-TYPED_TEST(ParamGateTest, ApplyParamRZGate) {
-    constexpr Precision Prec = TestFixture::Prec;
-    constexpr ExecutionSpace Space = TestFixture::Space;
     test_apply_parametric_single_pauli_rotation<Prec, Space>(
         5, &gate::RZ<Prec>, &gate::ParamRZ<Prec>);
 }
@@ -138,21 +130,11 @@ void test_param_gate_json_roundtrip_preserves_control_value(Factory factory) {
     }
 }
 
-TYPED_TEST(ParamGateTest, ParamRXJsonRoundtripPreservesControlValue) {
+TYPED_TEST(ParamGateTest, ParamGateJsonRoundtripPreservesControlValue) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
     test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRX<Prec>);
-}
-
-TYPED_TEST(ParamGateTest, ParamRYJsonRoundtripPreservesControlValue) {
-    constexpr Precision Prec = TestFixture::Prec;
-    constexpr ExecutionSpace Space = TestFixture::Space;
     test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRY<Prec>);
-}
-
-TYPED_TEST(ParamGateTest, ParamRZJsonRoundtripPreservesControlValue) {
-    constexpr Precision Prec = TestFixture::Prec;
-    constexpr ExecutionSpace Space = TestFixture::Space;
     test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRZ<Prec>);
 }
 
@@ -219,14 +201,12 @@ TYPED_TEST(ParamGateTest, ParamProbabilisticGateRejectsInvalidDistributionValues
     EXPECT_THROW(
         gate::ParamProbabilistic<Prec>({-0.2, 1.2}, {gate::ParamRX<Prec>(0), gate::I<Prec>()}),
         std::runtime_error);
-    EXPECT_THROW(
-        gate::ParamProbabilistic<Prec>({std::numeric_limits<double>::quiet_NaN(), 1.0},
-                                       {gate::ParamRX<Prec>(0), gate::I<Prec>()}),
-        std::runtime_error);
-    EXPECT_THROW(
-        gate::ParamProbabilistic<Prec>({std::numeric_limits<double>::infinity(), 0.0},
-                                       {gate::ParamRX<Prec>(0), gate::I<Prec>()}),
-        std::runtime_error);
+    EXPECT_THROW(gate::ParamProbabilistic<Prec>({std::numeric_limits<double>::quiet_NaN(), 1.0},
+                                                {gate::ParamRX<Prec>(0), gate::I<Prec>()}),
+                 std::runtime_error);
+    EXPECT_THROW(gate::ParamProbabilistic<Prec>({std::numeric_limits<double>::infinity(), 0.0},
+                                                {gate::ParamRX<Prec>(0), gate::I<Prec>()}),
+                 std::runtime_error);
 }
 
 template <Precision Prec, ExecutionSpace Space>


### PR DESCRIPTION
## Summary
`U1` / `U2` の JSON 復元処理の不整合を修正し、JSON round-trip が正しく行えるようにしました。

## What was changed? (変更点)
- `src/gate/gate_standard.cpp` の `U1` / `U2` の JSON 復元処理を修正
- `U1` は `lambda`、`U2` は `phi` / `lambda` を正しく読むように変更
- `U1` / `U2` / `U3` の JSON round-trip テストを追加


## Why was this change needed? (変更理由)
- `U1` の復元時に `lambda` ではなく `theta` を読んでいたため、JSON round-trip が例外になっていたため
- `U2` の復元時に `phi` / `lambda` ではなく `theta` / `phi` を読んでいたため、入力によっては本来と異なる gate が生成される可能性があったため
- 保存時と復元時でパラメータ名の対応が一致しておらず、JSON round-trip の整合性が壊れていたため