### PR TITLE
ExecutionContext を参照渡しにする

### DIFF
--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -282,21 +282,24 @@ public:
     void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector) const {
         ClassicalRegister classical_register(0);
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::Host>{state_vector, classical_register, random_engine});
+        ExecutionContext<Prec, ExecutionSpace::Host> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context);
     }
     void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
                               ClassicalRegister& classical_register,
                               std::uint64_t seed = std::random_device{}()) const {
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>{
-            state_vector, classical_register, random_engine});
+        ExecutionContext<Prec, ExecutionSpace::Host> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states) const {
         ClassicalRegisterBatched classical_register(0, states.batch_size());
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::Host>{
-            states, classical_register, random_engine});
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
                               ClassicalRegisterBatched& classical_register,
@@ -307,27 +310,31 @@ public:
                 "...): batch size mismatch.");
         }
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(
-            ExecutionContextBatched<Prec, ExecutionSpace::Host>{states, classical_register, random_engine});
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context);
     }
     void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector) const {
         ClassicalRegister classical_register(0);
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial>{
-            state_vector, classical_register, random_engine});
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context);
     }
     void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
                               ClassicalRegister& classical_register,
                               std::uint64_t seed = std::random_device{}()) const {
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial>{
-            state_vector, classical_register, random_engine});
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states) const {
         ClassicalRegisterBatched classical_register(0, states.batch_size());
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>{
-            states, classical_register, random_engine});
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
                               ClassicalRegisterBatched& classical_register,
@@ -338,28 +345,32 @@ public:
                 "...): batch size mismatch.");
         }
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>{
-            states, classical_register, random_engine});
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context);
     }
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector) const {
         ClassicalRegister classical_register(0);
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::Default>{state_vector, classical_register, random_engine});
+        ExecutionContext<Prec, ExecutionSpace::Default> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context);
     }
     void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
                               ClassicalRegister& classical_register,
                               std::uint64_t seed = std::random_device{}()) const {
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default>{
-            state_vector, classical_register, random_engine});
+        ExecutionContext<Prec, ExecutionSpace::Default> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states) const {
         ClassicalRegisterBatched classical_register(0, states.batch_size());
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::Default>{
-            states, classical_register, random_engine});
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
                               ClassicalRegisterBatched& classical_register,
@@ -370,23 +381,24 @@ public:
                 "...): batch size mismatch.");
         }
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(
-            ExecutionContextBatched<Prec, ExecutionSpace::Default>{states, classical_register, random_engine});
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context);
     }
 #endif  // SCALUQ_USE_CUDA
     virtual void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host> context) const = 0;
+        ExecutionContext<Prec, ExecutionSpace::Host>& context) const = 0;
     virtual void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const = 0;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const = 0;
     virtual void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const = 0;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const = 0;
     virtual void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const = 0;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const = 0;
 #ifdef SCALUQ_USE_CUDA
     virtual void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const = 0;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const = 0;
     virtual void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const = 0;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const = 0;
 #endif
 
     [[nodiscard]] virtual std::string to_string(const std::string& indent = "") const = 0;

--- a/include/scaluq/gate/gate_matrix.hpp
+++ b/include/scaluq/gate/gate_matrix.hpp
@@ -31,18 +31,18 @@ public:
     ComplexMatrix get_matrix() const override;
 
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -78,18 +78,18 @@ public:
     SparseComplexMatrix get_sparse_matrix() const { return get_matrix().sparseView(); }
 
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/gate_measurement.hpp
+++ b/include/scaluq/gate/gate_measurement.hpp
@@ -27,18 +27,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/gate_pauli.hpp
+++ b/include/scaluq/gate/gate_pauli.hpp
@@ -32,18 +32,18 @@ public:
     ComplexMatrix get_matrix() const override { return this->_pauli.get_matrix(); }
 
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -85,18 +85,18 @@ public:
     ComplexMatrix get_matrix() const override;
 
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/gate_probabilistic.hpp
+++ b/include/scaluq/gate/gate_probabilistic.hpp
@@ -66,18 +66,18 @@ public:
     }
 
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -19,18 +19,18 @@ public:
     ComplexMatrix get_matrix() const override;
 
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -60,18 +60,18 @@ public:
     ComplexMatrix get_matrix() const override;
 
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -111,18 +111,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -146,18 +146,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -181,18 +181,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -216,18 +216,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -269,18 +269,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -305,18 +305,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -341,18 +341,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -377,18 +377,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -414,18 +414,18 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -450,18 +450,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -487,18 +487,18 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -523,18 +523,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -558,18 +558,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -593,18 +593,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -629,18 +629,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -666,18 +666,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -703,18 +703,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -749,18 +749,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -802,18 +802,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -860,18 +860,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -898,18 +898,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;
@@ -954,18 +954,18 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/param_gate.hpp
+++ b/include/scaluq/gate/param_gate.hpp
@@ -117,27 +117,26 @@ public:
                               double param) const {
         ClassicalRegister classical_register(0);
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::Host>{state_vector, classical_register, random_engine},
-            param);
+        ExecutionContext<Prec, ExecutionSpace::Host> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context, param);
     }
     void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
                               ClassicalRegister& classical_register,
                               double param,
                               std::uint64_t seed = std::random_device{}()) const {
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::Host>{
-                state_vector, classical_register, random_engine},
-            param);
+        ExecutionContext<Prec, ExecutionSpace::Host> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context, param);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
                               const std::vector<double>& params) const {
         ClassicalRegisterBatched classical_register(0, states.batch_size());
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(
-            ExecutionContextBatched<Prec, ExecutionSpace::Host>{states, classical_register, random_engine},
-            params);
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context, params);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
                               ClassicalRegisterBatched& classical_register,
@@ -154,37 +153,34 @@ public:
                 "ClassicalRegisterBatched&, ...): parameter size mismatch.");
         }
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(
-            ExecutionContextBatched<Prec, ExecutionSpace::Host>{states, classical_register, random_engine},
-            params);
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context, params);
     }
     void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
                               double param) const {
         ClassicalRegister classical_register(0);
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::HostSerial>{
-                state_vector, classical_register, random_engine},
-            param);
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context, param);
     }
     void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
                               ClassicalRegister& classical_register,
                               double param,
                               std::uint64_t seed = std::random_device{}()) const {
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::HostSerial>{
-                state_vector, classical_register, random_engine},
-            param);
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context, param);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
                               const std::vector<double>& params) const {
         ClassicalRegisterBatched classical_register(0, states.batch_size());
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(
-            ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>{
-                states, classical_register, random_engine},
-            params);
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context, params);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
                               ClassicalRegisterBatched& classical_register,
@@ -201,37 +197,35 @@ public:
                 "ClassicalRegisterBatched&, ...): parameter size mismatch.");
         }
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>{
-                                 states, classical_register, random_engine},
-                             params);
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context, params);
     }
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
                               double param) const {
         ClassicalRegister classical_register(0);
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::Default>{state_vector, classical_register, random_engine},
-            param);
+        ExecutionContext<Prec, ExecutionSpace::Default> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context, param);
     }
     void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
                               ClassicalRegister& classical_register,
                               double param,
                               std::uint64_t seed = std::random_device{}()) const {
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::Default>{
-                state_vector, classical_register, random_engine},
-            param);
+        ExecutionContext<Prec, ExecutionSpace::Default> context{
+            state_vector, classical_register, random_engine};
+        update_quantum_state(context, param);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
                               const std::vector<double>& params) const {
         ClassicalRegisterBatched classical_register(0, states.batch_size());
         std::mt19937_64 random_engine(std::random_device{}());
-        update_quantum_state(
-            ExecutionContextBatched<Prec, ExecutionSpace::Default>{
-                states, classical_register, random_engine},
-            params);
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context, params);
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
                               ClassicalRegisterBatched& classical_register,
@@ -248,26 +242,26 @@ public:
                 "ClassicalRegisterBatched&, ...): parameter size mismatch.");
         }
         std::mt19937_64 random_engine(seed);
-        update_quantum_state(
-            ExecutionContextBatched<Prec, ExecutionSpace::Default>{states, classical_register, random_engine},
-            params);
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context{
+            states, classical_register, random_engine};
+        update_quantum_state(context, params);
     }
 #endif  // SCALUQ_USE_CUDA
 
-    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
+    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context,
                                       double param) const = 0;
-    virtual void update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+    virtual void update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
                                       const std::vector<double>& params) const = 0;
-    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
+    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial>& context,
                                       double param) const = 0;
     virtual void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
         const std::vector<double>& params) const = 0;
 #ifdef SCALUQ_USE_CUDA
-    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
+    virtual void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default>& context,
                                       double param) const = 0;
     virtual void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
         const std::vector<double>& params) const = 0;
 #endif
 

--- a/include/scaluq/gate/param_gate_pauli.hpp
+++ b/include/scaluq/gate/param_gate_pauli.hpp
@@ -33,22 +33,22 @@ public:
             this->_control_mask, this->_control_value_mask, _pauli, -this->_pcoef);
     }
     ComplexMatrix get_matrix(double param) const override;
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
                               const std::vector<double>& params) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
                               const std::vector<double>& params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
                               const std::vector<double>& params) const override;
 #endif  // SCALUQ_USE_CUDA
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/param_gate_probabilistic.hpp
+++ b/include/scaluq/gate/param_gate_probabilistic.hpp
@@ -71,22 +71,22 @@ public:
             "ParamProbabilisticGateImpl.");
     }
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
                               const std::vector<double>& params) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
                               const std::vector<double>& params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
                               const std::vector<double>& params) const override;
 #endif  // SCALUQ_USE_CUDA
 

--- a/include/scaluq/gate/param_gate_standard.hpp
+++ b/include/scaluq/gate/param_gate_standard.hpp
@@ -19,22 +19,22 @@ public:
     }
     ComplexMatrix get_matrix(double param) const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
                               const std::vector<double>& params) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
                               const std::vector<double>& params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
                               const std::vector<double>& params) const override;
 #endif  // SCALUQ_USE_CUDA
 
@@ -61,22 +61,22 @@ public:
     }
     ComplexMatrix get_matrix(double param) const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
                               const std::vector<double>& params) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
                               const std::vector<double>& params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
                               const std::vector<double>& params) const override;
 #endif  // SCALUQ_USE_CUDA
 
@@ -103,22 +103,22 @@ public:
     }
     ComplexMatrix get_matrix(double param) const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
                               const std::vector<double>& params) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context,
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
                               const std::vector<double>& params) const override;
 #ifdef SCALUQ_USE_CUDA
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default> context,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default>& context,
                               double param) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
                               const std::vector<double>& params) const override;
 #endif  // SCALUQ_USE_CUDA
 

--- a/src/gate/gate_matrix.cpp
+++ b/src/gate/gate_matrix.cpp
@@ -45,7 +45,7 @@ std::string DenseMatrixGateImpl<Prec, Space>::to_string(const std::string& inden
 #define DEFINE_DENSE_MATRIX_GATE_UPDATE(ContextClass, state_member, TargetSpace)            \
     template <Precision Prec, ExecutionSpace GateSpace>                                     \
     void DenseMatrixGateImpl<Prec, GateSpace>::update_quantum_state(                        \
-        ContextClass<Prec, TargetSpace> context) const {                                    \
+        ContextClass<Prec, TargetSpace>& context) const {                                    \
         if constexpr (GateSpace == TargetSpace) {                                           \
             this->check_qubit_mask_within_bounds(context.state_member);                     \
             dense_matrix_gate(this->_target_mask,                                           \
@@ -114,7 +114,7 @@ std::string SparseMatrixGateImpl<Prec, Space>::to_string(const std::string& inde
 #define DEFINE_SPARSE_MATRIX_GATE_UPDATE(ContextClass, state_member, TargetSpace)           \
     template <Precision Prec, ExecutionSpace GateSpace>                                     \
     void SparseMatrixGateImpl<Prec, GateSpace>::update_quantum_state(                       \
-        ContextClass<Prec, TargetSpace> context) const {                                    \
+        ContextClass<Prec, TargetSpace>& context) const {                                    \
         if constexpr (GateSpace == TargetSpace) {                                           \
             this->check_qubit_mask_within_bounds(context.state_member);                     \
             sparse_matrix_gate(this->_target_mask,                                          \

--- a/src/gate/gate_measurement.cpp
+++ b/src/gate/gate_measurement.cpp
@@ -44,7 +44,7 @@ bool apply_measurement_update(StateVector<Prec, Space>& state,
 
 #define DEFINE_MEASUREMENT_GATE_UPDATE(Space)                                                   \
     template <Precision Prec>                                                                   \
-    void MeasurementGateImpl<Prec>::update_quantum_state(ExecutionContext<Prec, Space> context) \
+    void MeasurementGateImpl<Prec>::update_quantum_state(ExecutionContext<Prec, Space>& context) \
         const {                                                                                 \
         this->check_qubit_mask_within_bounds(context.state);                                    \
         if (context.classical_register.register_size() <= _classical_bit_index) {               \
@@ -58,7 +58,7 @@ bool apply_measurement_update(StateVector<Prec, Space>& state,
     }                                                                                           \
     template <Precision Prec>                                                                   \
     void MeasurementGateImpl<Prec>::update_quantum_state(                                       \
-        ExecutionContextBatched<Prec, Space> context) const {                                   \
+        ExecutionContextBatched<Prec, Space>& context) const {                                   \
         this->check_qubit_mask_within_bounds(context.states);                                   \
         if (context.classical_register.batch_size() != context.states.batch_size()) {           \
             throw std::runtime_error(                                                           \

--- a/src/gate/gate_pauli.cpp
+++ b/src/gate/gate_pauli.cpp
@@ -17,7 +17,7 @@ std::string PauliGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_PAULI_GATE_UPDATE(ContextClass, state_member, Space)                                               \
     template <Precision Prec>                                                                \
-    void PauliGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const {                     \
+    void PauliGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const {                     \
         auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();         \
         apply_pauli(this->_control_mask,                                                     \
                     this->_control_value_mask,                                               \
@@ -62,7 +62,7 @@ std::string PauliRotationGateImpl<Prec>::to_string(const std::string& indent) co
 }
 #define DEFINE_PAULI_ROTATION_GATE_UPDATE(ContextClass, state_member, Space)                                      \
     template <Precision Prec>                                                                \
-    void PauliRotationGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) \
+    void PauliRotationGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) \
         const {                                                                              \
         auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();         \
         apply_pauli_rotation(this->_control_mask,                                            \

--- a/src/gate/gate_probabilistic.cpp
+++ b/src/gate/gate_probabilistic.cpp
@@ -6,7 +6,7 @@ namespace scaluq::internal {
 namespace {
 template <Precision Prec, ExecutionSpace Space>
 std::uint64_t select_probabilistic_gate_index(const std::vector<double>& cumulative_distribution,
-                                              ExecutionContext<Prec, Space> context) {
+                                              ExecutionContext<Prec, Space>& context) {
     std::uniform_real_distribution<double> dist(0., 1.);
     std::uint64_t i = std::distance(cumulative_distribution.begin(),
                                     std::ranges::upper_bound(cumulative_distribution,
@@ -100,7 +100,7 @@ std::string ProbabilisticGateImpl<Prec>::to_string(const std::string& indent) co
 }
 #define DEFINE_PROBABILISTIC_GATE_CONTEXT_UPDATE(Space)                                           \
     template <Precision Prec>                                                                     \
-    void ProbabilisticGateImpl<Prec>::update_quantum_state(ExecutionContext<Prec, Space> context) \
+    void ProbabilisticGateImpl<Prec>::update_quantum_state(ExecutionContext<Prec, Space>& context) \
         const {                                                                                   \
         const std::uint64_t i =                                                                   \
             select_probabilistic_gate_index(_cumulative_distribution, context);                   \
@@ -108,11 +108,14 @@ std::string ProbabilisticGateImpl<Prec>::to_string(const std::string& indent) co
     }                                                                                             \
     template <Precision Prec>                                                                     \
     void ProbabilisticGateImpl<Prec>::update_quantum_state(                                       \
-        ExecutionContextBatched<Prec, Space> context) const {                                     \
+        ExecutionContextBatched<Prec, Space>& context) const {                                     \
         for (std::size_t i = 0; i < context.states.batch_size(); ++i) {                           \
             auto state_vector = context.states.view_state_vector_at(i);                           \
-            this->update_quantum_state(ExecutionContext<Prec, Space>{                             \
-                state_vector, context.classical_register[i], context.random_engine});             \
+            ExecutionContext<Prec, Space> state_context{                                          \
+                state_vector,                                                                      \
+                context.classical_register[i],                                                     \
+                context.random_engine};                                                            \
+            this->update_quantum_state(state_context);                                             \
         }                                                                                         \
     }
 DEFINE_PROBABILISTIC_GATE_CONTEXT_UPDATE(ExecutionSpace::Host)

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -17,7 +17,7 @@ std::string IGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_I_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                             \
-    void IGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void IGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         i_gate(this->_target_mask,                                                        \
                this->_control_mask,                                                       \
                this->_control_value_mask,                                                 \
@@ -48,7 +48,7 @@ std::string GlobalPhaseGateImpl<Prec>::to_string(const std::string& indent) cons
 }
 #define DEFINE_GLOBAL_PHASE_GATE_UPDATE(ContextClass, state_member, Space)                  \
     template <Precision Prec>                                                               \
-    void GlobalPhaseGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) \
+    void GlobalPhaseGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) \
         const {                                                                             \
         this->check_qubit_mask_within_bounds(context.state_member);                         \
         global_phase_gate(this->_target_mask,                                               \
@@ -83,7 +83,7 @@ std::string XGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_X_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                             \
-    void XGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void XGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                       \
         x_gate(this->_target_mask,                                                        \
                this->_control_mask,                                                       \
@@ -116,7 +116,7 @@ std::string YGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_Y_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                             \
-    void YGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void YGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                       \
         y_gate(this->_target_mask,                                                        \
                this->_control_mask,                                                       \
@@ -149,7 +149,7 @@ std::string ZGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_Z_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                             \
-    void ZGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void ZGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                       \
         z_gate(this->_target_mask,                                                        \
                this->_control_mask,                                                       \
@@ -183,7 +183,7 @@ std::string HGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_H_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                             \
-    void HGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void HGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                       \
         h_gate(this->_target_mask,                                                        \
                this->_control_mask,                                                       \
@@ -216,7 +216,7 @@ std::string SGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_S_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                             \
-    void SGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void SGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                       \
         s_gate(this->_target_mask,                                                        \
                this->_control_mask,                                                       \
@@ -249,7 +249,7 @@ std::string SdagGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_S_DAG_GATE_UPDATE(ContextClass, state_member, Space)                          \
     template <Precision Prec>                                                                \
-    void SdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void SdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                          \
         sdag_gate(this->_target_mask,                                                        \
                   this->_control_mask,                                                       \
@@ -282,7 +282,7 @@ std::string TGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_T_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                             \
-    void TGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void TGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                       \
         t_gate(this->_target_mask,                                                        \
                this->_control_mask,                                                       \
@@ -315,7 +315,7 @@ std::string TdagGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_T_DAG_GATE_UPDATE(ContextClass, state_member, Space)                          \
     template <Precision Prec>                                                                \
-    void TdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void TdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                          \
         tdag_gate(this->_target_mask,                                                        \
                   this->_control_mask,                                                       \
@@ -348,7 +348,7 @@ std::string SqrtXGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_SQRT_X_GATE_UPDATE(ContextClass, state_member, Space)                          \
     template <Precision Prec>                                                                 \
-    void SqrtXGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void SqrtXGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                           \
         sqrtx_gate(this->_target_mask,                                                        \
                    this->_control_mask,                                                       \
@@ -381,7 +381,7 @@ std::string SqrtXdagGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_SQRT_XDAG_GATE_UPDATE(ContextClass, state_member, Space)                          \
     template <Precision Prec>                                                                    \
-    void SqrtXdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void SqrtXdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                              \
         sqrtxdag_gate(this->_target_mask,                                                        \
                       this->_control_mask,                                                       \
@@ -414,7 +414,7 @@ std::string SqrtYGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_SQRT_Y_GATE_UPDATE(ContextClass, state_member, Space)                          \
     template <Precision Prec>                                                                 \
-    void SqrtYGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void SqrtYGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                           \
         sqrty_gate(this->_target_mask,                                                        \
                    this->_control_mask,                                                       \
@@ -447,7 +447,7 @@ std::string SqrtYdagGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_SQRT_YDAG_GATE_UPDATE(ContextClass, state_member, Space)                          \
     template <Precision Prec>                                                                    \
-    void SqrtYdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void SqrtYdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                              \
         sqrtydag_gate(this->_target_mask,                                                        \
                       this->_control_mask,                                                       \
@@ -480,7 +480,7 @@ std::string P0GateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_P0_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                              \
-    void P0GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void P0GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                        \
         p0_gate(this->_target_mask,                                                        \
                 this->_control_mask,                                                       \
@@ -513,7 +513,7 @@ std::string P1GateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_P1_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                              \
-    void P1GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void P1GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                        \
         p1_gate(this->_target_mask,                                                        \
                 this->_control_mask,                                                       \
@@ -549,7 +549,7 @@ std::string RXGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_RX_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                              \
-    void RXGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void RXGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                        \
         rx_gate(this->_target_mask,                                                        \
                 this->_control_mask,                                                       \
@@ -585,7 +585,7 @@ std::string RYGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_RY_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                              \
-    void RYGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void RYGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                        \
         ry_gate(this->_target_mask,                                                        \
                 this->_control_mask,                                                       \
@@ -621,7 +621,7 @@ std::string RZGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_RZ_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                              \
-    void RZGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void RZGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                        \
         rz_gate(this->_target_mask,                                                        \
                 this->_control_mask,                                                       \
@@ -656,7 +656,7 @@ std::string U1GateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_U1_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                              \
-    void U1GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void U1GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                        \
         u1_gate(this->_target_mask,                                                        \
                 this->_control_mask,                                                       \
@@ -697,7 +697,7 @@ std::string U2GateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_U2_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                              \
-    void U2GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void U2GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                        \
         u2_gate(this->_target_mask,                                                        \
                 this->_control_mask,                                                       \
@@ -742,7 +742,7 @@ std::string U3GateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_U3_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                              \
-    void U3GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void U3GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                        \
         u3_gate(this->_target_mask,                                                        \
                 this->_control_mask,                                                       \
@@ -778,7 +778,7 @@ std::string SwapGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_SWAP_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                                \
-    void SwapGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void SwapGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                          \
         swap_gate(this->_target_mask,                                                        \
                   this->_control_mask,                                                       \
@@ -847,7 +847,7 @@ std::string EcrGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 #define DEFINE_ECR_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                               \
-    void EcrGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) const { \
+    void EcrGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
         this->check_qubit_mask_within_bounds(context.state_member);                         \
         ecr_gate(this->_physical_target_mask,                                               \
                  this->_physical_control_mask,                                              \

--- a/src/gate/param_gate_pauli.cpp
+++ b/src/gate/param_gate_pauli.cpp
@@ -27,7 +27,7 @@ std::string ParamPauliRotationGateImpl<Prec>::to_string(const std::string& inden
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Host>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
@@ -40,7 +40,7 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
@@ -62,7 +62,7 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::HostSerial>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
@@ -75,7 +75,7 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
@@ -98,7 +98,7 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Default>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
@@ -111,7 +111,7 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();

--- a/src/gate/param_gate_probabilistic.cpp
+++ b/src/gate/param_gate_probabilistic.cpp
@@ -9,7 +9,7 @@ using EitherGate = std::variant<Gate<Prec>, ParamGate<Prec>>;
 
 template <Precision Prec, ExecutionSpace Space>
 std::uint64_t select_probabilistic_gate_index(const std::vector<double>& cumulative_distribution,
-                                              ExecutionContext<Prec, Space> context) {
+                                              ExecutionContext<Prec, Space>& context) {
     std::uniform_real_distribution<double> dist(0., 1.);
     std::uint64_t i = std::distance(cumulative_distribution.begin(),
                                     std::ranges::upper_bound(cumulative_distribution,
@@ -126,7 +126,7 @@ std::string ParamProbabilisticGateImpl<Prec>::to_string(const std::string& inden
 }
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Host>& context, double param) const {
     const std::uint64_t i = select_probabilistic_gate_index(_cumulative_distribution, context);
     const auto& gate = _gate_list[i];
     if (gate.index() == 0) {
@@ -137,19 +137,18 @@ void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
     const std::vector<double>& params) const {
     for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
         auto state_vector = context.states.view_state_vector_at(i);
-        this->update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::Host>{
-                state_vector, context.classical_register[i], context.random_engine},
-            params[i]);
+        ExecutionContext<Prec, ExecutionSpace::Host> state_context{
+            state_vector, context.classical_register[i], context.random_engine};
+        this->update_quantum_state(state_context, params[i]);
     }
 }
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::HostSerial>& context, double param) const {
     const std::uint64_t i = select_probabilistic_gate_index(_cumulative_distribution, context);
     const auto& gate = _gate_list[i];
     if (gate.index() == 0) {
@@ -160,20 +159,19 @@ void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
     const std::vector<double>& params) const {
     for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
         auto state_vector = context.states.view_state_vector_at(i);
-        this->update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::HostSerial>{
-                state_vector, context.classical_register[i], context.random_engine},
-            params[i]);
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> state_context{
+            state_vector, context.classical_register[i], context.random_engine};
+        this->update_quantum_state(state_context, params[i]);
     }
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Default>& context, double param) const {
     const std::uint64_t i = select_probabilistic_gate_index(_cumulative_distribution, context);
     const auto& gate = _gate_list[i];
     if (gate.index() == 0) {
@@ -184,14 +182,13 @@ void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
     const std::vector<double>& params) const {
     for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
         auto state_vector = context.states.view_state_vector_at(i);
-        this->update_quantum_state(
-            ExecutionContext<Prec, ExecutionSpace::Default>{
-                state_vector, context.classical_register[i], context.random_engine},
-            params[i]);
+        ExecutionContext<Prec, ExecutionSpace::Default> state_context{
+            state_vector, context.classical_register[i], context.random_engine};
+        this->update_quantum_state(state_context, params[i]);
     }
 }
 #endif

--- a/src/gate/param_gate_standard.cpp
+++ b/src/gate/param_gate_standard.cpp
@@ -21,7 +21,7 @@ std::string ParamRXGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Host>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
@@ -31,7 +31,7 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
@@ -50,7 +50,7 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::HostSerial>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
@@ -60,7 +60,7 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
@@ -80,7 +80,7 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Default>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
@@ -90,7 +90,7 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
@@ -128,7 +128,7 @@ std::string ParamRYGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Host>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
@@ -138,7 +138,7 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
@@ -157,7 +157,7 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::HostSerial>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
@@ -167,7 +167,7 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
@@ -187,7 +187,7 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Default>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
@@ -197,7 +197,7 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
@@ -235,7 +235,7 @@ std::string ParamRZGateImpl<Prec>::to_string(const std::string& indent) const {
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::Host> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Host>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
@@ -245,7 +245,7 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::Host> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
@@ -264,7 +264,7 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::HostSerial> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::HostSerial>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
@@ -274,7 +274,7 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());
@@ -294,7 +294,7 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    ExecutionContext<Prec, ExecutionSpace::Default> context, double param) const {
+    ExecutionContext<Prec, ExecutionSpace::Default>& context, double param) const {
     this->check_qubit_mask_within_bounds(context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
@@ -304,7 +304,7 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
-    ExecutionContextBatched<Prec, ExecutionSpace::Default> context,
+    ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
     const std::vector<double>& params) const {
     this->check_qubit_mask_within_bounds(context.states);
     std::vector<Float<Prec>> params_prec(params.size());


### PR DESCRIPTION
別の機能の実装上の不都合から，ExecutionContextの受け渡しを参照渡しに統一します．