### PR TITLE
U1、U2ゲートのJSON round-trip の修正

### DIFF
--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -941,7 +941,7 @@ std::shared_ptr<const U1GateImpl<Prec>> GetGateFromJson<U1GateImpl<Prec>>::get(c
         vector_to_mask(j.at("target").get<std::vector<std::uint64_t>>()),
         vector_to_mask(control_qubits),
         vector_to_mask(control_qubits, control_values),
-        static_cast<Float<Prec>>(j.at("theta").get<double>()));
+        static_cast<Float<Prec>>(j.at("lambda").get<double>()));
 }
 template <Precision Prec>
 std::shared_ptr<const U2GateImpl<Prec>> GetGateFromJson<U2GateImpl<Prec>>::get(const Json& j) {
@@ -951,8 +951,8 @@ std::shared_ptr<const U2GateImpl<Prec>> GetGateFromJson<U2GateImpl<Prec>>::get(c
         vector_to_mask(j.at("target").get<std::vector<std::uint64_t>>()),
         vector_to_mask(control_qubits),
         vector_to_mask(control_qubits, control_values),
-        static_cast<Float<Prec>>(j.at("theta").get<double>()),
-        static_cast<Float<Prec>>(j.at("phi").get<double>()));
+        static_cast<Float<Prec>>(j.at("phi").get<double>()),
+        static_cast<Float<Prec>>(j.at("lambda").get<double>()));
 }
 template <Precision Prec>
 std::shared_ptr<const U3GateImpl<Prec>> GetGateFromJson<U3GateImpl<Prec>>::get(const Json& j) {

--- a/tests/gate/gate_test.cpp
+++ b/tests/gate/gate_test.cpp
@@ -796,6 +796,69 @@ TYPED_TEST(GateTest, MeasurementGateJsonRoundTrip) {
     EXPECT_EQ(MeasurementGate<Prec>(loaded)->classical_bit_index(), 3);
 }
 
+TYPED_TEST(GateTest, UGateJsonRoundTrip) {
+    constexpr Precision Prec = TestFixture::Prec;
+
+    {
+        Gate<Prec> gate = gate::U1<Prec>(0, 0.75, {2}, {1});
+        ASSERT_NO_THROW({
+            Gate<Prec> loaded = Json(gate).template get<Gate<Prec>>();
+            ASSERT_EQ(loaded.gate_type(), GateType::U1);
+            EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{2}));
+            EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
+            EXPECT_NEAR(U1Gate<Prec>(loaded)->lambda(), 0.75, 1e-12);
+            const auto original_matrix = gate->get_matrix();
+            const auto loaded_matrix = loaded->get_matrix();
+            ASSERT_EQ(original_matrix.rows(), loaded_matrix.rows());
+            ASSERT_EQ(original_matrix.cols(), loaded_matrix.cols());
+            for (Eigen::Index r = 0; r < original_matrix.rows(); ++r) {
+                for (Eigen::Index c = 0; c < original_matrix.cols(); ++c) {
+                    check_near<Prec>(original_matrix(r, c), loaded_matrix(r, c));
+                }
+            }
+        });
+    }
+
+    {
+        Gate<Prec> gate = gate::U2<Prec>(1, 0.25, 0.75, {3}, {1});
+        Gate<Prec> loaded = Json(gate).template get<Gate<Prec>>();
+        ASSERT_EQ(loaded.gate_type(), GateType::U2);
+        EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{3}));
+        EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
+        EXPECT_NEAR(U2Gate<Prec>(loaded)->phi(), 0.25, 1e-12);
+        EXPECT_NEAR(U2Gate<Prec>(loaded)->lambda(), 0.75, 1e-12);
+        const auto original_matrix = gate->get_matrix();
+        const auto loaded_matrix = loaded->get_matrix();
+        ASSERT_EQ(original_matrix.rows(), loaded_matrix.rows());
+        ASSERT_EQ(original_matrix.cols(), loaded_matrix.cols());
+        for (Eigen::Index r = 0; r < original_matrix.rows(); ++r) {
+            for (Eigen::Index c = 0; c < original_matrix.cols(); ++c) {
+                check_near<Prec>(original_matrix(r, c), loaded_matrix(r, c));
+            }
+        }
+    }
+
+    {
+        Gate<Prec> gate = gate::U3<Prec>(2, 0.5, 0.25, 0.75, {4}, {1});
+        Gate<Prec> loaded = Json(gate).template get<Gate<Prec>>();
+        ASSERT_EQ(loaded.gate_type(), GateType::U3);
+        EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{4}));
+        EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
+        EXPECT_NEAR(U3Gate<Prec>(loaded)->theta(), 0.5, 1e-12);
+        EXPECT_NEAR(U3Gate<Prec>(loaded)->phi(), 0.25, 1e-12);
+        EXPECT_NEAR(U3Gate<Prec>(loaded)->lambda(), 0.75, 1e-12);
+        const auto original_matrix = gate->get_matrix();
+        const auto loaded_matrix = loaded->get_matrix();
+        ASSERT_EQ(original_matrix.rows(), loaded_matrix.rows());
+        ASSERT_EQ(original_matrix.cols(), loaded_matrix.cols());
+        for (Eigen::Index r = 0; r < original_matrix.rows(); ++r) {
+            for (Eigen::Index c = 0; c < original_matrix.cols(); ++c) {
+                check_near<Prec>(original_matrix(r, c), loaded_matrix(r, c));
+            }
+        }
+    }
+}
+
 TYPED_TEST(GateTest, FlattenNestedProbabilisticGate) {
     constexpr Precision Prec = TestFixture::Prec;
     Gate<Prec> nested_gate = gate::Probabilistic<Prec>(

--- a/tests/gate/gate_test.cpp
+++ b/tests/gate/gate_test.cpp
@@ -801,27 +801,31 @@ TYPED_TEST(GateTest, UGateJsonRoundTrip) {
 
     {
         Gate<Prec> gate = gate::U1<Prec>(0, 0.75, {2}, {1});
+        Gate<Prec> loaded;
         ASSERT_NO_THROW({
-            Gate<Prec> loaded = Json(gate).template get<Gate<Prec>>();
-            ASSERT_EQ(loaded.gate_type(), GateType::U1);
-            EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{2}));
-            EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
-            EXPECT_NEAR(U1Gate<Prec>(loaded)->lambda(), 0.75, 1e-12);
-            const auto original_matrix = gate->get_matrix();
-            const auto loaded_matrix = loaded->get_matrix();
-            ASSERT_EQ(original_matrix.rows(), loaded_matrix.rows());
-            ASSERT_EQ(original_matrix.cols(), loaded_matrix.cols());
-            for (Eigen::Index r = 0; r < original_matrix.rows(); ++r) {
-                for (Eigen::Index c = 0; c < original_matrix.cols(); ++c) {
-                    check_near<Prec>(original_matrix(r, c), loaded_matrix(r, c));
-                }
-            }
+            loaded = Json(gate).template get<Gate<Prec>>();
         });
+        ASSERT_EQ(loaded.gate_type(), GateType::U1);
+        EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{2}));
+        EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
+        EXPECT_NEAR(U1Gate<Prec>(loaded)->lambda(), 0.75, 1e-12);
+        const auto original_matrix = gate->get_matrix();
+        const auto loaded_matrix = loaded->get_matrix();
+        ASSERT_EQ(original_matrix.rows(), loaded_matrix.rows());
+        ASSERT_EQ(original_matrix.cols(), loaded_matrix.cols());
+        for (Eigen::Index r = 0; r < original_matrix.rows(); ++r) {
+            for (Eigen::Index c = 0; c < original_matrix.cols(); ++c) {
+                check_near<Prec>(original_matrix(r, c), loaded_matrix(r, c));
+            }
+        }
     }
 
     {
         Gate<Prec> gate = gate::U2<Prec>(1, 0.25, 0.75, {3}, {1});
-        Gate<Prec> loaded = Json(gate).template get<Gate<Prec>>();
+        Gate<Prec> loaded;
+        ASSERT_NO_THROW({
+            loaded = Json(gate).template get<Gate<Prec>>();
+        });
         ASSERT_EQ(loaded.gate_type(), GateType::U2);
         EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{3}));
         EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
@@ -840,7 +844,10 @@ TYPED_TEST(GateTest, UGateJsonRoundTrip) {
 
     {
         Gate<Prec> gate = gate::U3<Prec>(2, 0.5, 0.25, 0.75, {4}, {1});
-        Gate<Prec> loaded = Json(gate).template get<Gate<Prec>>();
+        Gate<Prec> loaded;
+        ASSERT_NO_THROW({
+            loaded = Json(gate).template get<Gate<Prec>>();
+        });
         ASSERT_EQ(loaded.gate_type(), GateType::U3);
         EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{4}));
         EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));


### PR DESCRIPTION
## Summary
`U1` / `U2` の JSON 復元処理の不整合を修正し、JSON round-trip が正しく行えるようにしました。

## What was changed? (変更点)
- `src/gate/gate_standard.cpp` の `U1` / `U2` の JSON 復元処理を修正
- `U1` は `lambda`、`U2` は `phi` / `lambda` を正しく読むように変更
- `U1` / `U2` / `U3` の JSON round-trip テストを追加


## Why was this change needed? (変更理由)
- `U1` の復元時に `lambda` ではなく `theta` を読んでいたため、JSON round-trip が例外になっていたため
- `U2` の復元時に `phi` / `lambda` ではなく `theta` / `phi` を読んでいたため、入力によっては本来と異なる gate が生成される可能性があったため
- 保存時と復元時でパラメータ名の対応が一致しておらず、JSON round-trip の整合性が壊れていたため