### PR TITLE
Reordering

### DIFF
--- a/include/scaluq/all.hpp
+++ b/include/scaluq/all.hpp
@@ -226,6 +226,9 @@
         return ::scaluq::gate::SparseMatrix<Prec, Space>(                                      \
             targets, matrix, controls, control_values);                                        \
     }                                                                                          \
+    inline Gate Permutation(const std::vector<std::uint64_t>& destination_indices) {           \
+        return ::scaluq::gate::Permutation<Prec, Space>(destination_indices);                  \
+    }                                                                                          \
     inline auto& Probabilistic = ::scaluq::gate::Probabilistic<Prec>;                          \
     inline auto& BitFlipNoise = ::scaluq::gate::BitFlipNoise<Prec>;                            \
     inline auto& DephasingNoise = ::scaluq::gate::DephasingNoise<Prec>;                        \

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -68,6 +68,8 @@ class SwapGateImpl;
 template <Precision Prec>
 class EcrGateImpl;
 template <Precision Prec>
+class PermutationGateImpl;
+template <Precision Prec>
 class PauliGateImpl;
 template <Precision Prec>
 class PauliRotationGateImpl;
@@ -107,6 +109,7 @@ enum class GateType {
     U3,
     Swap,
     Ecr,
+    Permutation,
     Pauli,
     PauliRotation,
     SparseMatrix,
@@ -169,6 +172,8 @@ constexpr GateType get_gate_type() {
         return GateType::Swap;
     else if constexpr (std::is_same_v<TWithoutConst, internal::EcrGateImpl<Prec>>)
         return GateType::Ecr;
+    else if constexpr (std::is_same_v<TWithoutConst, internal::PermutationGateImpl<Prec>>)
+        return GateType::Permutation;
     else if constexpr (std::is_same_v<TWithoutConst, internal::PauliGateImpl<Prec>>)
         return GateType::Pauli;
     else if constexpr (std::is_same_v<TWithoutConst, internal::PauliRotationGateImpl<Prec>>)
@@ -450,6 +455,7 @@ DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(U2GateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(U3GateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(SwapGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(EcrGateImpl)
+DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(PermutationGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(PauliGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(PauliRotationGateImpl)
 DECLARE_GET_FROM_JSON_PARTIAL_SPECIALIZATION(ProbabilisticGateImpl)
@@ -552,6 +558,7 @@ public:
         else if (type == "U3") gate = GetGateFromJson<U3GateImpl<Prec>>::get(j);
         else if (type == "Swap") gate = GetGateFromJson<SwapGateImpl<Prec>>::get(j);
         else if (type == "Ecr") gate = GetGateFromJson<EcrGateImpl<Prec>>::get(j);
+        else if (type == "Permutation") gate = GetGateFromJson<PermutationGateImpl<Prec>>::get(j);
         else if (type == "Pauli") gate = GetGateFromJson<PauliGateImpl<Prec>>::get(j);
         else if (type == "PauliRotation") gate = GetGateFromJson<PauliRotationGateImpl<Prec>>::get(j);
         else if (type == "Probabilistic") gate = GetGateFromJson<ProbabilisticGateImpl<Prec>>::get(j);

--- a/include/scaluq/gate/gate_factory.hpp
+++ b/include/scaluq/gate/gate_factory.hpp
@@ -393,6 +393,22 @@ inline Gate<Prec> Probabilistic(const std::vector<double>& distribution,
                                                                                      gate_list);
 }
 
+template <Precision Prec, ExecutionSpace Space>
+inline Gate<Prec> Permutation(const std::vector<std::uint64_t>& dst_indices) {
+    const std::uint64_t n_qubits = dst_indices.size();
+    if (n_qubits >= sizeof(std::uint64_t) * 8) {
+        throw std::runtime_error(
+            "gate::Permutation: the size of the qubit system must be less than 64.");
+    }
+
+    const std::uint64_t expected_mask = n_qubits == 0 ? 0ULL : ((1ULL << n_qubits) - 1);
+    if (internal::vector_to_mask(dst_indices) != expected_mask) {
+        throw std::runtime_error(
+            "gate::Permutation: dst_indices must be a permutation of 0 to n_qubits - 1.");
+    }
+    return internal::GateFactory::create_gate<internal::PermutationGateImpl<Prec>>(dst_indices);
+}
+
 // corresponding to XGate
 template <Precision Prec>
 inline Gate<Prec> BitFlipNoise(std::int64_t target, double error_rate) {
@@ -1158,6 +1174,19 @@ void bind_gate_gate_factory_hpp(nb::module_& mgate) {
 
 template <Precision Prec, ExecutionSpace Space>
 void bind_gate_gate_factory_hpp(nb::module_& mgate) {
+    mgate.def(
+        "Permutation",
+        &gate::Permutation<Prec, Space>,
+        "destination_indices"_a,
+        DocString()
+            .desc("Generate a gate that permutes qubit positions according to destination indices.")
+            .arg("destination_indices",
+                 "list[int]",
+                 "Packed destination index array where element i is the destination of qubit i")
+            .ret("Gate", "Qubit reordering gate instance")
+            .ex(DocString::Code({">>> gate = Permutation([2, 0, 3, 1])"}))
+            .build_as_google_style()
+            .c_str());
     mgate.def(
         "DenseMatrix",
         &gate::DenseMatrix<Prec, Space>,

--- a/include/scaluq/gate/gate_matrix.hpp
+++ b/include/scaluq/gate/gate_matrix.hpp
@@ -28,7 +28,7 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
         ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
@@ -74,7 +74,7 @@ public:
 
     SparseComplexMatrix get_sparse_matrix() const { return get_matrix().sparseView(); }
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
         ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(

--- a/include/scaluq/gate/gate_matrix.hpp
+++ b/include/scaluq/gate/gate_matrix.hpp
@@ -28,8 +28,7 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
         ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
@@ -75,8 +74,7 @@ public:
 
     SparseComplexMatrix get_sparse_matrix() const { return get_matrix().sparseView(); }
 
-    void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
         ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -18,7 +18,7 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
         ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
@@ -58,7 +58,7 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
         ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
@@ -1010,18 +1010,18 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContext<Prec, ExecutionSpace::Default>& context) const override;
     void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context) const override;
 #endif  // SCALUQ_USE_CUDA
 
     std::string to_string(const std::string& indent) const override;

--- a/include/scaluq/gate/gate_standard.hpp
+++ b/include/scaluq/gate/gate_standard.hpp
@@ -18,8 +18,7 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
         ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
@@ -59,8 +58,7 @@ public:
     }
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
     void update_quantum_state(
         ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
@@ -977,6 +975,60 @@ public:
                  {"control_value", this->control_value_list()},
                  {"physical_control", this->physical_control_indices()},
                  {"physical_target", this->physical_target_indices()}};
+    }
+};
+
+template <Precision Prec>
+class PermutationGateImpl : public GateBase<Prec> {
+    std::vector<std::uint64_t> _dst;
+    std::vector<std::pair<std::uint64_t, std::uint64_t>> _swap_schedule;
+
+public:
+    PermutationGateImpl(const std::vector<std::uint64_t>& dst_indices)
+        : GateBase<Prec>(internal::vector_to_mask(dst_indices), 0, 0), _dst(dst_indices) {
+        if (this->_target_mask != (1ULL << _dst.size()) - 1) {
+            throw std::invalid_argument(
+                "PermutationGateImpl: dst_indices must be the permutation of [0, "
+                "dst_indices.size())");
+        }
+
+        std::vector<bool> seen(_dst.size(), false);
+        for (std::uint64_t i = 0; i < _dst.size(); ++i) {
+            if (seen[i]) continue;
+            seen[i] = true;
+            std::uint64_t pos = i;
+            while (!seen[pos = _dst[pos]]) {
+                seen[pos] = true;
+                _swap_schedule.emplace_back(pos, i);
+            }
+        }
+    }
+
+    using GateBase<Prec>::update_quantum_state;
+
+    std::shared_ptr<const GateBase<Prec>> get_inverse() const override;
+
+    ComplexMatrix get_matrix() const override;
+
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Host> context) const override;
+    void update_quantum_state(
+        ExecutionContext<Prec, ExecutionSpace::HostSerial> context) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context) const override;
+#ifdef SCALUQ_USE_CUDA
+    void update_quantum_state(
+        ExecutionContext<Prec, ExecutionSpace::Default> context) const override;
+    void update_quantum_state(
+        ExecutionContextBatched<Prec, ExecutionSpace::Default> context) const override;
+#endif  // SCALUQ_USE_CUDA
+
+    std::string to_string(const std::string& indent) const override;
+
+    void get_as_json(Json& j) const override {
+        j = Json{
+            {"type", "Permutation"}, {"target", this->target_qubit_list()}, {"dst", this->_dst}};
     }
 };
 

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -866,6 +866,53 @@ DEFINE_ECR_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
 #undef DEFINE_ECR_GATE_UPDATE
 template class EcrGateImpl<Prec>;
 
+template <Precision Prec>
+ComplexMatrix PermutationGateImpl<Prec>::get_matrix() const {
+    const std::uint64_t n_qubits = _dst.size();
+    const std::uint64_t dim = 1ULL << n_qubits;
+    ComplexMatrix matrix = ComplexMatrix::Zero(dim, dim);
+    for (std::uint64_t src = 0; src < dim; ++src) {
+        std::uint64_t dst_index = 0;
+        for (std::uint64_t qubit = 0; qubit < n_qubits; ++qubit) {
+            dst_index |= ((src >> qubit) & 1ULL) << _dst[qubit];
+        }
+        matrix(dst_index, src) = 1.;
+    }
+    return matrix;
+}
+template <Precision Prec>
+std::shared_ptr<const GateBase<Prec>> PermutationGateImpl<Prec>::get_inverse() const {
+    std::vector<std::uint64_t> inv(_dst.size());
+    for (std::uint64_t i = 0; i < _dst.size(); ++i) {
+        inv[_dst[i]] = i;
+    }
+    return std::make_shared<const PermutationGateImpl<Prec>>(inv);
+}
+template <Precision Prec>
+std::string PermutationGateImpl<Prec>::to_string(const std::string& indent) const {
+    std::ostringstream ss;
+    ss << indent << "Gate Type: Permutation\n";
+    ss << this->get_qubit_info_as_string(indent);
+    return ss.str();
+}
+#define DEFINE_PERMUTATION_GATE_UPDATE(ContextClass, state_member, Space)                    \
+    template <Precision Prec>                                                                \
+    void PermutationGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context)  \
+        const {                                                                              \
+        this->check_qubit_mask_within_bounds(context.state_member);                          \
+        permutation_gate(this->_swap_schedule, context.state_member);                        \
+    }
+DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
+DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
+DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::HostSerial)
+DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::HostSerial)
+#ifdef SCALUQ_USE_CUDA
+DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Default)
+DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Default)
+#endif
+#undef DEFINE_PERMUTATION_GATE_UPDATE
+template class PermutationGateImpl<Prec>;
+
 // I
 template <Precision Prec>
 std::shared_ptr<const IGateImpl<Prec>> GetGateFromJson<IGateImpl<Prec>>::get(const Json&) {
@@ -995,5 +1042,13 @@ std::shared_ptr<const EcrGateImpl<Prec>> GetGateFromJson<EcrGateImpl<Prec>>::get
         vector_to_mask(j.at("physical_target").get<std::vector<std::uint64_t>>()));
 }
 template struct GetGateFromJson<EcrGateImpl<Prec>>;
+
+template <Precision Prec>
+std::shared_ptr<const PermutationGateImpl<Prec>>
+GetGateFromJson<PermutationGateImpl<Prec>>::get(const Json& j) {
+    return std::make_shared<const PermutationGateImpl<Prec>>(
+        j.at("dst").get<std::vector<std::uint64_t>>());
+}
+template struct GetGateFromJson<PermutationGateImpl<Prec>>;
 
 }  // namespace scaluq::internal

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -901,12 +901,12 @@ std::string PermutationGateImpl<Prec>::to_string(const std::string& indent) cons
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_PERMUTATION_GATE_UPDATE(ContextClass, state_member, Space)                   \
-    template <Precision Prec>                                                               \
-    void PermutationGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) \
-        const {                                                                             \
-        this->check_qubit_mask_within_bounds(context.state_member);                         \
-        permutation_gate(this->_swap_schedule, context.state_member);                       \
+#define DEFINE_PERMUTATION_GATE_UPDATE(ContextClass, state_member, Space)                    \
+    template <Precision Prec>                                                                \
+    void PermutationGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) \
+        const {                                                                              \
+        this->check_qubit_mask_within_bounds(context.state_member);                          \
+        permutation_gate(this->_swap_schedule, context.state_member);                        \
     }
 DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -15,13 +15,13 @@ std::string IGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_I_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                             \
+#define DEFINE_I_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                              \
     void IGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        i_gate(this->_target_mask,                                                        \
-               this->_control_mask,                                                       \
-               this->_control_value_mask,                                                 \
-               context.state_member);                                                     \
+        i_gate(this->_target_mask,                                                         \
+               this->_control_mask,                                                        \
+               this->_control_value_mask,                                                  \
+               context.state_member);                                                      \
     }
 DEFINE_I_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_I_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -46,16 +46,16 @@ std::string GlobalPhaseGateImpl<Prec>::to_string(const std::string& indent) cons
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_GLOBAL_PHASE_GATE_UPDATE(ContextClass, state_member, Space)                  \
-    template <Precision Prec>                                                               \
+#define DEFINE_GLOBAL_PHASE_GATE_UPDATE(ContextClass, state_member, Space)                   \
+    template <Precision Prec>                                                                \
     void GlobalPhaseGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) \
-        const {                                                                             \
-        this->check_qubit_mask_within_bounds(context.state_member);                         \
-        global_phase_gate(this->_target_mask,                                               \
-                          this->_control_mask,                                              \
-                          this->_control_value_mask,                                        \
-                          this->_phase,                                                     \
-                          context.state_member);                                            \
+        const {                                                                              \
+        this->check_qubit_mask_within_bounds(context.state_member);                          \
+        global_phase_gate(this->_target_mask,                                                \
+                          this->_control_mask,                                               \
+                          this->_control_value_mask,                                         \
+                          this->_phase,                                                      \
+                          context.state_member);                                             \
     }
 DEFINE_GLOBAL_PHASE_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_GLOBAL_PHASE_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -81,14 +81,14 @@ std::string XGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_X_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                             \
+#define DEFINE_X_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                              \
     void XGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                       \
-        x_gate(this->_target_mask,                                                        \
-               this->_control_mask,                                                       \
-               this->_control_value_mask,                                                 \
-               context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        x_gate(this->_target_mask,                                                         \
+               this->_control_mask,                                                        \
+               this->_control_value_mask,                                                  \
+               context.state_member);                                                      \
     }
 DEFINE_X_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_X_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -114,14 +114,14 @@ std::string YGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_Y_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                             \
+#define DEFINE_Y_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                              \
     void YGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                       \
-        y_gate(this->_target_mask,                                                        \
-               this->_control_mask,                                                       \
-               this->_control_value_mask,                                                 \
-               context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        y_gate(this->_target_mask,                                                         \
+               this->_control_mask,                                                        \
+               this->_control_value_mask,                                                  \
+               context.state_member);                                                      \
     }
 DEFINE_Y_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_Y_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -147,14 +147,14 @@ std::string ZGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_Z_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                             \
+#define DEFINE_Z_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                              \
     void ZGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                       \
-        z_gate(this->_target_mask,                                                        \
-               this->_control_mask,                                                       \
-               this->_control_value_mask,                                                 \
-               context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        z_gate(this->_target_mask,                                                         \
+               this->_control_mask,                                                        \
+               this->_control_value_mask,                                                  \
+               context.state_member);                                                      \
     }
 DEFINE_Z_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_Z_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -181,14 +181,14 @@ std::string HGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_H_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                             \
+#define DEFINE_H_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                              \
     void HGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                       \
-        h_gate(this->_target_mask,                                                        \
-               this->_control_mask,                                                       \
-               this->_control_value_mask,                                                 \
-               context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        h_gate(this->_target_mask,                                                         \
+               this->_control_mask,                                                        \
+               this->_control_value_mask,                                                  \
+               context.state_member);                                                      \
     }
 DEFINE_H_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_H_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -214,14 +214,14 @@ std::string SGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_S_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                             \
+#define DEFINE_S_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                              \
     void SGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                       \
-        s_gate(this->_target_mask,                                                        \
-               this->_control_mask,                                                       \
-               this->_control_value_mask,                                                 \
-               context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        s_gate(this->_target_mask,                                                         \
+               this->_control_mask,                                                        \
+               this->_control_value_mask,                                                  \
+               context.state_member);                                                      \
     }
 DEFINE_S_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_S_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -247,14 +247,14 @@ std::string SdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_S_DAG_GATE_UPDATE(ContextClass, state_member, Space)                          \
-    template <Precision Prec>                                                                \
+#define DEFINE_S_DAG_GATE_UPDATE(ContextClass, state_member, Space)                           \
+    template <Precision Prec>                                                                 \
     void SdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                          \
-        sdag_gate(this->_target_mask,                                                        \
-                  this->_control_mask,                                                       \
-                  this->_control_value_mask,                                                 \
-                  context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                           \
+        sdag_gate(this->_target_mask,                                                         \
+                  this->_control_mask,                                                        \
+                  this->_control_value_mask,                                                  \
+                  context.state_member);                                                      \
     }
 DEFINE_S_DAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_S_DAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -280,14 +280,14 @@ std::string TGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_T_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                             \
+#define DEFINE_T_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                              \
     void TGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                       \
-        t_gate(this->_target_mask,                                                        \
-               this->_control_mask,                                                       \
-               this->_control_value_mask,                                                 \
-               context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        t_gate(this->_target_mask,                                                         \
+               this->_control_mask,                                                        \
+               this->_control_value_mask,                                                  \
+               context.state_member);                                                      \
     }
 DEFINE_T_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_T_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -313,14 +313,14 @@ std::string TdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_T_DAG_GATE_UPDATE(ContextClass, state_member, Space)                          \
-    template <Precision Prec>                                                                \
+#define DEFINE_T_DAG_GATE_UPDATE(ContextClass, state_member, Space)                           \
+    template <Precision Prec>                                                                 \
     void TdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                          \
-        tdag_gate(this->_target_mask,                                                        \
-                  this->_control_mask,                                                       \
-                  this->_control_value_mask,                                                 \
-                  context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                           \
+        tdag_gate(this->_target_mask,                                                         \
+                  this->_control_mask,                                                        \
+                  this->_control_value_mask,                                                  \
+                  context.state_member);                                                      \
     }
 DEFINE_T_DAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_T_DAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -346,14 +346,14 @@ std::string SqrtXGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_X_GATE_UPDATE(ContextClass, state_member, Space)                          \
-    template <Precision Prec>                                                                 \
+#define DEFINE_SQRT_X_GATE_UPDATE(ContextClass, state_member, Space)                           \
+    template <Precision Prec>                                                                  \
     void SqrtXGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                           \
-        sqrtx_gate(this->_target_mask,                                                        \
-                   this->_control_mask,                                                       \
-                   this->_control_value_mask,                                                 \
-                   context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                            \
+        sqrtx_gate(this->_target_mask,                                                         \
+                   this->_control_mask,                                                        \
+                   this->_control_value_mask,                                                  \
+                   context.state_member);                                                      \
     }
 DEFINE_SQRT_X_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_SQRT_X_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -379,14 +379,14 @@ std::string SqrtXdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_XDAG_GATE_UPDATE(ContextClass, state_member, Space)                          \
-    template <Precision Prec>                                                                    \
+#define DEFINE_SQRT_XDAG_GATE_UPDATE(ContextClass, state_member, Space)                           \
+    template <Precision Prec>                                                                     \
     void SqrtXdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                              \
-        sqrtxdag_gate(this->_target_mask,                                                        \
-                      this->_control_mask,                                                       \
-                      this->_control_value_mask,                                                 \
-                      context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                               \
+        sqrtxdag_gate(this->_target_mask,                                                         \
+                      this->_control_mask,                                                        \
+                      this->_control_value_mask,                                                  \
+                      context.state_member);                                                      \
     }
 DEFINE_SQRT_XDAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_SQRT_XDAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -412,14 +412,14 @@ std::string SqrtYGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_Y_GATE_UPDATE(ContextClass, state_member, Space)                          \
-    template <Precision Prec>                                                                 \
+#define DEFINE_SQRT_Y_GATE_UPDATE(ContextClass, state_member, Space)                           \
+    template <Precision Prec>                                                                  \
     void SqrtYGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                           \
-        sqrty_gate(this->_target_mask,                                                        \
-                   this->_control_mask,                                                       \
-                   this->_control_value_mask,                                                 \
-                   context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                            \
+        sqrty_gate(this->_target_mask,                                                         \
+                   this->_control_mask,                                                        \
+                   this->_control_value_mask,                                                  \
+                   context.state_member);                                                      \
     }
 DEFINE_SQRT_Y_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_SQRT_Y_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -445,14 +445,14 @@ std::string SqrtYdagGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SQRT_YDAG_GATE_UPDATE(ContextClass, state_member, Space)                          \
-    template <Precision Prec>                                                                    \
+#define DEFINE_SQRT_YDAG_GATE_UPDATE(ContextClass, state_member, Space)                           \
+    template <Precision Prec>                                                                     \
     void SqrtYdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                              \
-        sqrtydag_gate(this->_target_mask,                                                        \
-                      this->_control_mask,                                                       \
-                      this->_control_value_mask,                                                 \
-                      context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                               \
+        sqrtydag_gate(this->_target_mask,                                                         \
+                      this->_control_mask,                                                        \
+                      this->_control_value_mask,                                                  \
+                      context.state_member);                                                      \
     }
 DEFINE_SQRT_YDAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_SQRT_YDAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -478,14 +478,14 @@ std::string P0GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_P0_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                              \
+#define DEFINE_P0_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                               \
     void P0GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
-        p0_gate(this->_target_mask,                                                        \
-                this->_control_mask,                                                       \
-                this->_control_value_mask,                                                 \
-                context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        p0_gate(this->_target_mask,                                                         \
+                this->_control_mask,                                                        \
+                this->_control_value_mask,                                                  \
+                context.state_member);                                                      \
     }
 DEFINE_P0_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_P0_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -511,14 +511,14 @@ std::string P1GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_P1_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                              \
+#define DEFINE_P1_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                               \
     void P1GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
-        p1_gate(this->_target_mask,                                                        \
-                this->_control_mask,                                                       \
-                this->_control_value_mask,                                                 \
-                context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        p1_gate(this->_target_mask,                                                         \
+                this->_control_mask,                                                        \
+                this->_control_value_mask,                                                  \
+                context.state_member);                                                      \
     }
 DEFINE_P1_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_P1_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -547,15 +547,15 @@ std::string RXGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_RX_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                              \
+#define DEFINE_RX_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                               \
     void RXGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
-        rx_gate(this->_target_mask,                                                        \
-                this->_control_mask,                                                       \
-                this->_control_value_mask,                                                 \
-                this->_angle,                                                              \
-                context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        rx_gate(this->_target_mask,                                                         \
+                this->_control_mask,                                                        \
+                this->_control_value_mask,                                                  \
+                this->_angle,                                                               \
+                context.state_member);                                                      \
     }
 DEFINE_RX_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_RX_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -583,15 +583,15 @@ std::string RYGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_RY_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                              \
+#define DEFINE_RY_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                               \
     void RYGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
-        ry_gate(this->_target_mask,                                                        \
-                this->_control_mask,                                                       \
-                this->_control_value_mask,                                                 \
-                this->_angle,                                                              \
-                context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        ry_gate(this->_target_mask,                                                         \
+                this->_control_mask,                                                        \
+                this->_control_value_mask,                                                  \
+                this->_angle,                                                               \
+                context.state_member);                                                      \
     }
 DEFINE_RY_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_RY_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -619,15 +619,15 @@ std::string RZGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_RZ_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                              \
+#define DEFINE_RZ_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                               \
     void RZGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
-        rz_gate(this->_target_mask,                                                        \
-                this->_control_mask,                                                       \
-                this->_control_value_mask,                                                 \
-                this->_angle,                                                              \
-                context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        rz_gate(this->_target_mask,                                                         \
+                this->_control_mask,                                                        \
+                this->_control_value_mask,                                                  \
+                this->_angle,                                                               \
+                context.state_member);                                                      \
     }
 DEFINE_RZ_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_RZ_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -654,15 +654,15 @@ std::string U1GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_U1_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                              \
+#define DEFINE_U1_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                               \
     void U1GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
-        u1_gate(this->_target_mask,                                                        \
-                this->_control_mask,                                                       \
-                this->_control_value_mask,                                                 \
-                this->_lambda,                                                             \
-                context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        u1_gate(this->_target_mask,                                                         \
+                this->_control_mask,                                                        \
+                this->_control_value_mask,                                                  \
+                this->_lambda,                                                              \
+                context.state_member);                                                      \
     }
 DEFINE_U1_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_U1_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -695,16 +695,16 @@ std::string U2GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_U2_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                              \
+#define DEFINE_U2_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                               \
     void U2GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
-        u2_gate(this->_target_mask,                                                        \
-                this->_control_mask,                                                       \
-                this->_control_value_mask,                                                 \
-                this->_phi,                                                                \
-                this->_lambda,                                                             \
-                context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        u2_gate(this->_target_mask,                                                         \
+                this->_control_mask,                                                        \
+                this->_control_value_mask,                                                  \
+                this->_phi,                                                                 \
+                this->_lambda,                                                              \
+                context.state_member);                                                      \
     }
 DEFINE_U2_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_U2_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -740,17 +740,17 @@ std::string U3GateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_U3_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                              \
+#define DEFINE_U3_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                               \
     void U3GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
-        u3_gate(this->_target_mask,                                                        \
-                this->_control_mask,                                                       \
-                this->_control_value_mask,                                                 \
-                this->_theta,                                                              \
-                this->_phi,                                                                \
-                this->_lambda,                                                             \
-                context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        u3_gate(this->_target_mask,                                                         \
+                this->_control_mask,                                                        \
+                this->_control_value_mask,                                                  \
+                this->_theta,                                                               \
+                this->_phi,                                                                 \
+                this->_lambda,                                                              \
+                context.state_member);                                                      \
     }
 DEFINE_U3_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_U3_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -776,14 +776,14 @@ std::string SwapGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_SWAP_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                                \
+#define DEFINE_SWAP_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                                 \
     void SwapGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                          \
-        swap_gate(this->_target_mask,                                                        \
-                  this->_control_mask,                                                       \
-                  this->_control_value_mask,                                                 \
-                  context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                           \
+        swap_gate(this->_target_mask,                                                         \
+                  this->_control_mask,                                                        \
+                  this->_control_value_mask,                                                  \
+                  context.state_member);                                                      \
     }
 DEFINE_SWAP_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_SWAP_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -845,15 +845,15 @@ std::string EcrGateImpl<Prec>::to_string(const std::string& indent) const {
     ss << "}";
     return ss.str();
 }
-#define DEFINE_ECR_GATE_UPDATE(ContextClass, state_member, Space)                           \
-    template <Precision Prec>                                                               \
+#define DEFINE_ECR_GATE_UPDATE(ContextClass, state_member, Space)                            \
+    template <Precision Prec>                                                                \
     void EcrGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                         \
-        ecr_gate(this->_physical_target_mask,                                               \
-                 this->_physical_control_mask,                                              \
-                 this->_control_mask,                                                       \
-                 this->_control_value_mask,                                                 \
-                 context.state_member);                                                     \
+        this->check_qubit_mask_within_bounds(context.state_member);                          \
+        ecr_gate(this->_physical_target_mask,                                                \
+                 this->_physical_control_mask,                                               \
+                 this->_control_mask,                                                        \
+                 this->_control_value_mask,                                                  \
+                 context.state_member);                                                      \
     }
 DEFINE_ECR_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_ECR_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -892,15 +892,21 @@ template <Precision Prec>
 std::string PermutationGateImpl<Prec>::to_string(const std::string& indent) const {
     std::ostringstream ss;
     ss << indent << "Gate Type: Permutation\n";
+    ss << indent << "Permutation: [";
+    for (std::uint64_t i = 0; i < _dst.size(); ++i) {
+        if (i > 0) ss << ", ";
+        ss << _dst[i];
+    }
+    ss << "]\n";
     ss << this->get_qubit_info_as_string(indent);
     return ss.str();
 }
-#define DEFINE_PERMUTATION_GATE_UPDATE(ContextClass, state_member, Space)                    \
-    template <Precision Prec>                                                                \
-    void PermutationGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context)  \
-        const {                                                                              \
-        this->check_qubit_mask_within_bounds(context.state_member);                          \
-        permutation_gate(this->_swap_schedule, context.state_member);                        \
+#define DEFINE_PERMUTATION_GATE_UPDATE(ContextClass, state_member, Space)                   \
+    template <Precision Prec>                                                               \
+    void PermutationGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space> context) \
+        const {                                                                             \
+        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        permutation_gate(this->_swap_schedule, context.state_member);                       \
     }
 DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -1044,8 +1050,8 @@ std::shared_ptr<const EcrGateImpl<Prec>> GetGateFromJson<EcrGateImpl<Prec>>::get
 template struct GetGateFromJson<EcrGateImpl<Prec>>;
 
 template <Precision Prec>
-std::shared_ptr<const PermutationGateImpl<Prec>>
-GetGateFromJson<PermutationGateImpl<Prec>>::get(const Json& j) {
+std::shared_ptr<const PermutationGateImpl<Prec>> GetGateFromJson<PermutationGateImpl<Prec>>::get(
+    const Json& j) {
     return std::make_shared<const PermutationGateImpl<Prec>>(
         j.at("dst").get<std::vector<std::uint64_t>>());
 }

--- a/src/gate/merge_gate.cpp
+++ b/src/gate/merge_gate.cpp
@@ -50,6 +50,11 @@ std::pair<Gate<internal::Prec>, double> merge_gate<internal::Prec, internal::Spa
             "merge_gate(const Gate<Prec>&, const Gate<Prec>&): "
             "ProbabilisticGate is not supported.");
     }
+    if (gate_type1 == GateType::Permutation || gate_type2 == GateType::Permutation) {
+        throw std::runtime_error(
+            "merge_gate(const Gate<Prec>&, const Gate<Prec>&): "
+            "PermutationGate is not supported.");
+    }
 
     if (gate_type1 == GateType::I) return {gate2, 0.};
     if (gate_type2 == GateType::I) return {gate1, 0.};

--- a/src/gate/update_ops.hpp
+++ b/src/gate/update_ops.hpp
@@ -517,6 +517,12 @@ void ecr_gate(std::uint64_t physical_target_mask,
               std::uint64_t control_mask,
               std::uint64_t control_value_mask,
               StateVectorBatched<Prec, Space>& states);
+template <Precision Prec, ExecutionSpace Space>
+void permutation_gate(const std::vector<std::pair<std::uint64_t, std::uint64_t>>& swap_schedule,
+                      StateVector<Prec, Space>& state);
+template <Precision Prec, ExecutionSpace Space>
+void permutation_gate(const std::vector<std::pair<std::uint64_t, std::uint64_t>>& swap_schedule,
+                      StateVectorBatched<Prec, Space>& states);
 
 template <Precision Prec, ExecutionSpace Space>
 void sparse_matrix_gate(std::uint64_t target_mask,

--- a/src/gate/update_ops_standard.cpp
+++ b/src/gate/update_ops_standard.cpp
@@ -766,7 +766,9 @@ void ecr_gate(std::uint64_t physical_target_mask,
 template <>
 void permutation_gate(const std::vector<std::pair<std::uint64_t, std::uint64_t>>& swap_schedule,
                       StateVector<Prec, Space>& state) {
-    for (auto [src, dst] : swap_schedule) {
+    for (const auto& pair : swap_schedule) {
+        const std::uint64_t src = pair.first;
+        const std::uint64_t dst = pair.second;
         const std::uint64_t target_mask = (1ULL << src) | (1ULL << dst);
         const std::uint64_t span = state.dim() >> 2;
         Kokkos::parallel_for(
@@ -783,7 +785,9 @@ void permutation_gate(const std::vector<std::pair<std::uint64_t, std::uint64_t>>
 template <>
 void permutation_gate(const std::vector<std::pair<std::uint64_t, std::uint64_t>>& swap_schedule,
                       StateVectorBatched<Prec, Space>& states) {
-    for (auto [src, dst] : swap_schedule) {
+    for (const auto& pair : swap_schedule) {
+        const std::uint64_t src = pair.first;
+        const std::uint64_t dst = pair.second;
         const std::uint64_t target_mask = (1ULL << src) | (1ULL << dst);
         const std::uint64_t span = states.dim() >> 2;
         Kokkos::parallel_for(

--- a/src/gate/update_ops_standard.cpp
+++ b/src/gate/update_ops_standard.cpp
@@ -763,4 +763,39 @@ void ecr_gate(std::uint64_t physical_target_mask,
         });
 }
 
+template <>
+void permutation_gate(const std::vector<std::pair<std::uint64_t, std::uint64_t>>& swap_schedule,
+                      StateVector<Prec, Space>& state) {
+    for (auto [src, dst] : swap_schedule) {
+        const std::uint64_t target_mask = (1ULL << src) | (1ULL << dst);
+        const std::uint64_t span = state.dim() >> 2;
+        Kokkos::parallel_for(
+            "permutation_gate",
+            Kokkos::RangePolicy<SpaceType<Space>>(0, span),
+            KOKKOS_LAMBDA(std::uint64_t it) {
+                const std::uint64_t basis = insert_zero_at_mask_positions(it, target_mask);
+                Kokkos::kokkos_swap(state._raw[basis | (1ULL << src)],
+                                    state._raw[basis | (1ULL << dst)]);
+            });
+    }
+}
+
+template <>
+void permutation_gate(const std::vector<std::pair<std::uint64_t, std::uint64_t>>& swap_schedule,
+                      StateVectorBatched<Prec, Space>& states) {
+    for (auto [src, dst] : swap_schedule) {
+        const std::uint64_t target_mask = (1ULL << src) | (1ULL << dst);
+        const std::uint64_t span = states.dim() >> 2;
+        Kokkos::parallel_for(
+            "permutation_gate_flat",
+            Kokkos::RangePolicy<SpaceType<Space>>(0, states.batch_size() * span),
+            KOKKOS_LAMBDA(std::uint64_t g) {
+                const std::uint64_t batch_id = g / span;
+                const std::uint64_t it = g % span;
+                const std::uint64_t basis = insert_zero_at_mask_positions(it, target_mask);
+                Kokkos::kokkos_swap(states._raw(batch_id, basis | (1ULL << src)),
+                                    states._raw(batch_id, basis | (1ULL << dst)));
+            });
+    }
+}
 }  // namespace scaluq::internal

--- a/tests/gate/gate_test.cpp
+++ b/tests/gate/gate_test.cpp
@@ -725,6 +725,31 @@ TYPED_TEST(GateTest, ApplyDenseMatrixGate) {
     run_random_gate_apply_general_dense<Prec, Space>(6);
 }
 
+TYPED_TEST(GateTest, ApplyPermutationGate) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+
+    if constexpr (Prec == Precision::F32 || Prec == Precision::F64) {
+        constexpr std::uint64_t n_qubits = 4;
+        const std::vector<std::uint64_t> destination_indices = {2, 0, 3, 1};
+        auto state = StateVector<Prec, Space>::Haar_random_state(n_qubits);
+        const auto before = state.get_amplitudes();
+
+        gate::Permutation<Prec, Space>(destination_indices)->update_quantum_state(state);
+
+        const auto after = state.get_amplitudes();
+        ComplexVector before_vec(1ULL << n_qubits);
+        for (std::uint64_t i = 0; i < (1ULL << n_qubits); ++i) {
+            before_vec[i] = before[i];
+        }
+        const ComplexVector expected =
+            get_eigen_matrix_full_qubit_reorder(destination_indices) * before_vec;
+        for (std::uint64_t i = 0; i < (1ULL << n_qubits); ++i) {
+            check_near<Prec>(after[i], expected[i]);
+        }
+    }
+}
+
 TYPED_TEST(GateTest, ApplyPauliGate) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
@@ -802,9 +827,7 @@ TYPED_TEST(GateTest, UGateJsonRoundTrip) {
     {
         Gate<Prec> gate = gate::U1<Prec>(0, 0.75, {2}, {1});
         Gate<Prec> loaded;
-        ASSERT_NO_THROW({
-            loaded = Json(gate).template get<Gate<Prec>>();
-        });
+        ASSERT_NO_THROW({ loaded = Json(gate).template get<Gate<Prec>>(); });
         ASSERT_EQ(loaded.gate_type(), GateType::U1);
         EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{2}));
         EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
@@ -823,9 +846,7 @@ TYPED_TEST(GateTest, UGateJsonRoundTrip) {
     {
         Gate<Prec> gate = gate::U2<Prec>(1, 0.25, 0.75, {3}, {1});
         Gate<Prec> loaded;
-        ASSERT_NO_THROW({
-            loaded = Json(gate).template get<Gate<Prec>>();
-        });
+        ASSERT_NO_THROW({ loaded = Json(gate).template get<Gate<Prec>>(); });
         ASSERT_EQ(loaded.gate_type(), GateType::U2);
         EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{3}));
         EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
@@ -845,9 +866,7 @@ TYPED_TEST(GateTest, UGateJsonRoundTrip) {
     {
         Gate<Prec> gate = gate::U3<Prec>(2, 0.5, 0.25, 0.75, {4}, {1});
         Gate<Prec> loaded;
-        ASSERT_NO_THROW({
-            loaded = Json(gate).template get<Gate<Prec>>();
-        });
+        ASSERT_NO_THROW({ loaded = Json(gate).template get<Gate<Prec>>(); });
         ASSERT_EQ(loaded.gate_type(), GateType::U3);
         EXPECT_EQ(loaded->control_qubit_list(), (std::vector<std::uint64_t>{4}));
         EXPECT_EQ(loaded->control_value_list(), (std::vector<std::uint64_t>{1}));
@@ -889,17 +908,14 @@ TYPED_TEST(GateTest, FlattenNestedProbabilisticGate) {
 TYPED_TEST(GateTest, ProbabilisticGateRejectsInvalidDistributionValues) {
     constexpr Precision Prec = TestFixture::Prec;
 
-    EXPECT_THROW(
-        gate::Probabilistic<Prec>({-0.2, 1.2}, {gate::X<Prec>(0), gate::I<Prec>()}),
-        std::runtime_error);
-    EXPECT_THROW(
-        gate::Probabilistic<Prec>({std::numeric_limits<double>::quiet_NaN(), 1.0},
-                                  {gate::X<Prec>(0), gate::I<Prec>()}),
-        std::runtime_error);
-    EXPECT_THROW(
-        gate::Probabilistic<Prec>({std::numeric_limits<double>::infinity(), 0.0},
-                                  {gate::X<Prec>(0), gate::I<Prec>()}),
-        std::runtime_error);
+    EXPECT_THROW(gate::Probabilistic<Prec>({-0.2, 1.2}, {gate::X<Prec>(0), gate::I<Prec>()}),
+                 std::runtime_error);
+    EXPECT_THROW(gate::Probabilistic<Prec>({std::numeric_limits<double>::quiet_NaN(), 1.0},
+                                           {gate::X<Prec>(0), gate::I<Prec>()}),
+                 std::runtime_error);
+    EXPECT_THROW(gate::Probabilistic<Prec>({std::numeric_limits<double>::infinity(), 0.0},
+                                           {gate::X<Prec>(0), gate::I<Prec>()}),
+                 std::runtime_error);
 }
 
 template <Precision Prec, ExecutionSpace Space>

--- a/tests/util/util.hpp
+++ b/tests/util/util.hpp
@@ -208,6 +208,21 @@ inline ComplexMatrix get_eigen_matrix_full_qubit_Swap(std::uint64_t target_qubit
     return result;
 }
 
+inline ComplexMatrix get_eigen_matrix_full_qubit_reorder(
+    const std::vector<std::uint64_t>& destination_indices) {
+    const std::uint64_t qubit_count = destination_indices.size();
+    const std::uint64_t dim = 1ULL << qubit_count;
+    ComplexMatrix result = ComplexMatrix::Zero(dim, dim);
+    for (std::uint64_t src = 0; src < dim; ++src) {
+        std::uint64_t dst = 0;
+        for (std::uint64_t qubit = 0; qubit < qubit_count; ++qubit) {
+            dst |= ((src >> qubit) & 1ULL) << destination_indices[qubit];
+        }
+        result(dst, src) = 1;
+    }
+    return result;
+}
+
 inline ComplexMatrix get_eigen_matrix_full_qubit_Ecr(std::uint64_t physical_control_qubit_index,
                                                      std::uint64_t physical_target_qubit_index,
                                                      std::uint64_t qubit_count) {
@@ -238,7 +253,7 @@ inline ComplexMatrix get_eigen_matrix_full_qubit_Ecr(std::uint64_t physical_cont
             matrix = get_eigen_matrix_single_Pauli(0);
             beta = internal::kronecker_product(matrix, beta).eval();
         }
-    } // Ecr gate matrix representation (IX-XY)/sqrt(2)
+    }  // Ecr gate matrix representation (IX-XY)/sqrt(2)
     return (alpha - beta) / std::sqrt(2);
 }
 


### PR DESCRIPTION
キュービットを指定した順列で並べ替えるゲートを追加します．
メモリを追加で必要としない手法を採用しているため，少しオーバヘッドのある並べ替えアルゴリズムになっています．
もっと良い方法があれば意見をお願いします．