### PR TITLE
do not call random_device with explicit seed

### DIFF
--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -20,6 +20,7 @@
 #include "../gate/param_gate.hpp"
 #include "../operator/operator.hpp"
 #include "../types.hpp"
+#include "../util/random.hpp"
 
 namespace scaluq {
 
@@ -127,21 +128,21 @@ public:
     template <ExecutionSpace Space>
     void update_quantum_state(StateVector<Prec, Space>& state,
                               const std::map<std::string, double>& parameters = {},
-                              std::uint64_t seed = std::random_device{}()) const;
+                              std::optional<std::uint64_t> seed = std::nullopt) const;
     template <ExecutionSpace Space>
     void update_quantum_state(StateVector<Prec, Space>& state,
                               ClassicalRegister& classical_register,
                               const std::map<std::string, double>& parameters = {},
-                              std::uint64_t seed = std::random_device{}()) const;
+                              std::optional<std::uint64_t> seed = std::nullopt) const;
     template <ExecutionSpace Space>
     void update_quantum_state(StateVectorBatched<Prec, Space>& states,
                               const std::map<std::string, std::vector<double>>& parameters = {},
-                              std::uint64_t seed = std::random_device{}()) const;
+                              std::optional<std::uint64_t> seed = std::nullopt) const;
     template <ExecutionSpace Space>
     void update_quantum_state(StateVectorBatched<Prec, Space>& states,
                               ClassicalRegisterBatched& classical_register,
                               const std::map<std::string, std::vector<double>>& parameters = {},
-                              std::uint64_t seed = std::random_device{}()) const;
+                              std::optional<std::uint64_t> seed = std::nullopt) const;
 
     Circuit copy() const;
 
@@ -187,7 +188,7 @@ public:
         const StateVector<Prec, Space>& initial_state,
         std::uint64_t sampling_count,
         const std::map<std::string, double>& parameters = {},
-        std::uint64_t seed = 0) const;
+        std::optional<std::uint64_t> seed = std::nullopt) const;
 
     template <ExecutionSpace Space>
     std::unordered_map<std::string, double> compute_expectation_gradient_backprop(
@@ -234,8 +235,7 @@ void register_circuit_space_bindings(nb::class_<Circuit<Prec>>& c) {
                StateVector<Prec, Space>& state,
                const std::map<std::string, double>& parameters,
                std::optional<std::uint64_t> seed) {
-                circuit.update_quantum_state(
-                    state, parameters, seed.value_or(std::random_device{}()));
+                circuit.update_quantum_state(state, parameters, seed);
             },
             "state"_a,
             "params"_a = std::map<std::string, double>{},
@@ -250,8 +250,7 @@ void register_circuit_space_bindings(nb::class_<Circuit<Prec>>& c) {
                ClassicalRegister& classical_register,
                const std::map<std::string, double>& parameters,
                std::optional<std::uint64_t> seed) {
-                circuit.update_quantum_state(
-                    state, classical_register, parameters, seed.value_or(std::random_device{}()));
+                circuit.update_quantum_state(state, classical_register, parameters, seed);
             },
             "state"_a,
             "classical_register"_a,
@@ -297,8 +296,7 @@ void register_circuit_space_bindings(nb::class_<Circuit<Prec>>& c) {
                StateVectorBatched<Prec, Space>& states,
                const std::map<std::string, std::vector<double>>& parameters,
                std::optional<std::uint64_t> seed) {
-                circuit.update_quantum_state(
-                    states, parameters, seed.value_or(std::random_device{}()));
+                circuit.update_quantum_state(states, parameters, seed);
             },
             "state"_a,
             "params"_a = std::map<std::string, std::vector<double>>{},
@@ -313,8 +311,7 @@ void register_circuit_space_bindings(nb::class_<Circuit<Prec>>& c) {
                ClassicalRegisterBatched& classical_register,
                const std::map<std::string, std::vector<double>>& parameters,
                std::optional<std::uint64_t> seed) {
-                circuit.update_quantum_state(
-                    states, classical_register, parameters, seed.value_or(std::random_device{}()));
+                circuit.update_quantum_state(states, classical_register, parameters, seed);
             },
             "state"_a,
             "classical_register"_a,
@@ -352,10 +349,7 @@ void register_circuit_space_bindings(nb::class_<Circuit<Prec>>& c) {
                const std::map<std::string, double>& parameters,
                std::optional<std::uint64_t> seed) {
                 return circuit.template simulate_noise<Space>(
-                    initial_state,
-                    sampling_count,
-                    parameters,
-                    seed.value_or(std::random_device{}()));
+                    initial_state, sampling_count, parameters, seed);
             },
             "initial_state"_a,
             "sampling_count"_a,

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -288,8 +288,8 @@ public:
     }
     void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
                               ClassicalRegister& classical_register,
-                              std::uint64_t seed = std::random_device{}()) const {
-        std::mt19937_64 random_engine(seed);
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContext<Prec, ExecutionSpace::Host> context{
             state_vector, classical_register, random_engine};
         update_quantum_state(context);
@@ -303,13 +303,13 @@ public:
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
                               ClassicalRegisterBatched& classical_register,
-                              std::uint64_t seed = std::random_device{}()) const {
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
         if (classical_register.batch_size() != states.batch_size()) {
             throw std::runtime_error(
                 "GateBase::update_quantum_state(StateVectorBatched&, ClassicalRegisterBatched&, "
                 "...): batch size mismatch.");
         }
-        std::mt19937_64 random_engine(seed);
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContextBatched<Prec, ExecutionSpace::Host> context{
             states, classical_register, random_engine};
         update_quantum_state(context);
@@ -323,8 +323,8 @@ public:
     }
     void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
                               ClassicalRegister& classical_register,
-                              std::uint64_t seed = std::random_device{}()) const {
-        std::mt19937_64 random_engine(seed);
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContext<Prec, ExecutionSpace::HostSerial> context{
             state_vector, classical_register, random_engine};
         update_quantum_state(context);
@@ -338,13 +338,13 @@ public:
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
                               ClassicalRegisterBatched& classical_register,
-                              std::uint64_t seed = std::random_device{}()) const {
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
         if (classical_register.batch_size() != states.batch_size()) {
             throw std::runtime_error(
                 "GateBase::update_quantum_state(StateVectorBatched&, ClassicalRegisterBatched&, "
                 "...): batch size mismatch.");
         }
-        std::mt19937_64 random_engine(seed);
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context{
             states, classical_register, random_engine};
         update_quantum_state(context);
@@ -359,8 +359,8 @@ public:
     }
     void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
                               ClassicalRegister& classical_register,
-                              std::uint64_t seed = std::random_device{}()) const {
-        std::mt19937_64 random_engine(seed);
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContext<Prec, ExecutionSpace::Default> context{
             state_vector, classical_register, random_engine};
         update_quantum_state(context);
@@ -374,13 +374,13 @@ public:
     }
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
                               ClassicalRegisterBatched& classical_register,
-                              std::uint64_t seed = std::random_device{}()) const {
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
         if (classical_register.batch_size() != states.batch_size()) {
             throw std::runtime_error(
                 "GateBase::update_quantum_state(StateVectorBatched&, ClassicalRegisterBatched&, "
                 "...): batch size mismatch.");
         }
-        std::mt19937_64 random_engine(seed);
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContextBatched<Prec, ExecutionSpace::Default> context{
             states, classical_register, random_engine};
         update_quantum_state(context);
@@ -837,8 +837,7 @@ void register_gate_common_methods(nb::class_<GateT>& c) {
                StateVector<Prec, ExecutionSpace::Host>& sv,
                ClassicalRegister& classical_register,
                std::optional<std::uint64_t> seed) {
-                gate->update_quantum_state(
-                    sv, classical_register, seed.value_or(std::random_device{}()));
+                gate->update_quantum_state(sv, classical_register, resolve_seed(seed));
             },
             "state_vector"_a,
             "classical_register"_a,
@@ -857,8 +856,7 @@ void register_gate_common_methods(nb::class_<GateT>& c) {
                StateVectorBatched<Prec, ExecutionSpace::Host>& sv,
                ClassicalRegisterBatched& classical_register,
                std::optional<std::uint64_t> seed) {
-                gate->update_quantum_state(
-                    sv, classical_register, seed.value_or(std::random_device{}()));
+                gate->update_quantum_state(sv, classical_register, resolve_seed(seed));
             },
             "states"_a,
             "classical_register"_a,
@@ -877,8 +875,7 @@ void register_gate_common_methods(nb::class_<GateT>& c) {
                StateVector<Prec, ExecutionSpace::HostSerial>& sv,
                ClassicalRegister& classical_register,
                std::optional<std::uint64_t> seed) {
-                gate->update_quantum_state(
-                    sv, classical_register, seed.value_or(std::random_device{}()));
+                gate->update_quantum_state(sv, classical_register, resolve_seed(seed));
             },
             "state_vector"_a,
             "classical_register"_a,
@@ -897,8 +894,7 @@ void register_gate_common_methods(nb::class_<GateT>& c) {
                StateVectorBatched<Prec, ExecutionSpace::HostSerial>& sv,
                ClassicalRegisterBatched& classical_register,
                std::optional<std::uint64_t> seed) {
-                gate->update_quantum_state(
-                    sv, classical_register, seed.value_or(std::random_device{}()));
+                gate->update_quantum_state(sv, classical_register, resolve_seed(seed));
             },
             "states"_a,
             "classical_register"_a,
@@ -919,8 +915,7 @@ void register_gate_common_methods(nb::class_<GateT>& c) {
                StateVector<Prec, ExecutionSpace::Default>& sv,
                ClassicalRegister& classical_register,
                std::optional<std::uint64_t> seed) {
-                gate->update_quantum_state(
-                    sv, classical_register, seed.value_or(std::random_device{}()));
+                gate->update_quantum_state(sv, classical_register, resolve_seed(seed));
             },
             "state_vector"_a,
             "classical_register"_a,
@@ -939,8 +934,7 @@ void register_gate_common_methods(nb::class_<GateT>& c) {
                StateVectorBatched<Prec, ExecutionSpace::Default>& sv,
                ClassicalRegisterBatched& classical_register,
                std::optional<std::uint64_t> seed) {
-                gate->update_quantum_state(
-                    sv, classical_register, seed.value_or(std::random_device{}()));
+                gate->update_quantum_state(sv, classical_register, resolve_seed(seed));
             },
             "states"_a,
             "classical_register"_a,

--- a/include/scaluq/gate/param_gate.hpp
+++ b/include/scaluq/gate/param_gate.hpp
@@ -124,8 +124,8 @@ public:
     void update_quantum_state(StateVector<Prec, ExecutionSpace::Host>& state_vector,
                               ClassicalRegister& classical_register,
                               double param,
-                              std::uint64_t seed = std::random_device{}()) const {
-        std::mt19937_64 random_engine(seed);
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContext<Prec, ExecutionSpace::Host> context{
             state_vector, classical_register, random_engine};
         update_quantum_state(context, param);
@@ -141,7 +141,7 @@ public:
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Host>& states,
                               ClassicalRegisterBatched& classical_register,
                               const std::vector<double>& params,
-                              std::uint64_t seed = std::random_device{}()) const {
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
         if (classical_register.batch_size() != states.batch_size()) {
             throw std::runtime_error(
                 "ParamGateBase::update_quantum_state(StateVectorBatched&, "
@@ -152,7 +152,7 @@ public:
                 "ParamGateBase::update_quantum_state(StateVectorBatched&, "
                 "ClassicalRegisterBatched&, ...): parameter size mismatch.");
         }
-        std::mt19937_64 random_engine(seed);
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContextBatched<Prec, ExecutionSpace::Host> context{
             states, classical_register, random_engine};
         update_quantum_state(context, params);
@@ -168,8 +168,8 @@ public:
     void update_quantum_state(StateVector<Prec, ExecutionSpace::HostSerial>& state_vector,
                               ClassicalRegister& classical_register,
                               double param,
-                              std::uint64_t seed = std::random_device{}()) const {
-        std::mt19937_64 random_engine(seed);
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContext<Prec, ExecutionSpace::HostSerial> context{
             state_vector, classical_register, random_engine};
         update_quantum_state(context, param);
@@ -185,7 +185,7 @@ public:
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::HostSerial>& states,
                               ClassicalRegisterBatched& classical_register,
                               const std::vector<double>& params,
-                              std::uint64_t seed = std::random_device{}()) const {
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
         if (classical_register.batch_size() != states.batch_size()) {
             throw std::runtime_error(
                 "ParamGateBase::update_quantum_state(StateVectorBatched&, "
@@ -196,7 +196,7 @@ public:
                 "ParamGateBase::update_quantum_state(StateVectorBatched&, "
                 "ClassicalRegisterBatched&, ...): parameter size mismatch.");
         }
-        std::mt19937_64 random_engine(seed);
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContextBatched<Prec, ExecutionSpace::HostSerial> context{
             states, classical_register, random_engine};
         update_quantum_state(context, params);
@@ -213,8 +213,8 @@ public:
     void update_quantum_state(StateVector<Prec, ExecutionSpace::Default>& state_vector,
                               ClassicalRegister& classical_register,
                               double param,
-                              std::uint64_t seed = std::random_device{}()) const {
-        std::mt19937_64 random_engine(seed);
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContext<Prec, ExecutionSpace::Default> context{
             state_vector, classical_register, random_engine};
         update_quantum_state(context, param);
@@ -230,7 +230,7 @@ public:
     void update_quantum_state(StateVectorBatched<Prec, ExecutionSpace::Default>& states,
                               ClassicalRegisterBatched& classical_register,
                               const std::vector<double>& params,
-                              std::uint64_t seed = std::random_device{}()) const {
+                              std::optional<std::uint64_t> seed = std::nullopt) const {
         if (classical_register.batch_size() != states.batch_size()) {
             throw std::runtime_error(
                 "ParamGateBase::update_quantum_state(StateVectorBatched&, "
@@ -241,7 +241,7 @@ public:
                 "ParamGateBase::update_quantum_state(StateVectorBatched&, "
                 "ClassicalRegisterBatched&, ...): parameter size mismatch.");
         }
-        std::mt19937_64 random_engine(seed);
+        std::mt19937_64 random_engine(resolve_seed(seed));
         ExecutionContextBatched<Prec, ExecutionSpace::Default> context{
             states, classical_register, random_engine};
         update_quantum_state(context, params);
@@ -435,7 +435,7 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
                double param,
                std::optional<std::uint64_t> seed) {
                 gate->update_quantum_state(
-                    state_vector, classical_register, param, seed.value_or(std::random_device{}()));
+                    state_vector, classical_register, param, resolve_seed(seed));
             },
             "state"_a,
             "classical_register"_a,
@@ -458,7 +458,7 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
                const std::vector<double>& params,
                std::optional<std::uint64_t> seed) {
                 gate->update_quantum_state(
-                    states, classical_register, params, seed.value_or(std::random_device{}()));
+                    states, classical_register, params, resolve_seed(seed));
             },
             "states"_a,
             "classical_register"_a,
@@ -482,7 +482,7 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
                double param,
                std::optional<std::uint64_t> seed) {
                 gate->update_quantum_state(
-                    state_vector, classical_register, param, seed.value_or(std::random_device{}()));
+                    state_vector, classical_register, param, resolve_seed(seed));
             },
             "state"_a,
             "classical_register"_a,
@@ -506,7 +506,7 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
                const std::vector<double>& params,
                std::optional<std::uint64_t> seed) {
                 gate->update_quantum_state(
-                    states, classical_register, params, seed.value_or(std::random_device{}()));
+                    states, classical_register, params, resolve_seed(seed));
             },
             "states"_a,
             "classical_register"_a,
@@ -531,7 +531,7 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
                double param,
                std::optional<std::uint64_t> seed) {
                 gate->update_quantum_state(
-                    state_vector, classical_register, param, seed.value_or(std::random_device{}()));
+                    state_vector, classical_register, param, resolve_seed(seed));
             },
             "state"_a,
             "classical_register"_a,
@@ -555,7 +555,7 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
                const std::vector<double>& params,
                std::optional<std::uint64_t> seed) {
                 gate->update_quantum_state(
-                    states, classical_register, params, seed.value_or(std::random_device{}()));
+                    states, classical_register, params, resolve_seed(seed));
             },
             "states"_a,
             "classical_register"_a,

--- a/include/scaluq/state/density_matrix.hpp
+++ b/include/scaluq/state/density_matrix.hpp
@@ -63,12 +63,12 @@ public:
     [[nodiscard]] static DensityMatrix uninitialized_state(std::uint64_t n_qubits);
 
     [[nodiscard]] static DensityMatrix Haar_random_state(
-        std::uint64_t n_qubits, std::uint64_t seed = std::random_device()());
+        std::uint64_t n_qubits, std::optional<std::uint64_t> seed = std::nullopt);
 
     void set_zero_state();
     void set_zero_norm_state();
     void set_computational_basis(std::uint64_t basis);
-    void set_Haar_random_state(std::uint64_t seed = std::random_device()());
+    void set_Haar_random_state(std::optional<std::uint64_t> seed = std::nullopt);
 
     [[nodiscard]] StdComplex get_trace() const;
     [[nodiscard]] DensityMatrix get_partial_trace(
@@ -82,7 +82,7 @@ public:
         const std::vector<std::uint64_t>& measured_values) const;
 
     [[nodiscard]] std::vector<std::uint64_t> sampling(
-        std::uint64_t sampling_count, std::uint64_t seed = std::random_device()()) const;
+        std::uint64_t sampling_count, std::optional<std::uint64_t> seed = std::nullopt) const;
 
     [[nodiscard]] double get_computational_basis_entropy() const;
 
@@ -419,10 +419,7 @@ void bind_state_density_matrix_hpp(nb::module_& m) {
                 .c_str())
         .def_static(
             "Haar_random_state",
-            [](std::uint64_t n_qubits, std::optional<std::uint64_t> seed) {
-                return DensityMatrix<Prec, Space>::Haar_random_state(
-                    n_qubits, seed.value_or(std::random_device()()));
-            },
+            &DensityMatrix<Prec, Space>::Haar_random_state,
             "n_qubits"_a,
             "seed"_a = std::nullopt,
             DocString()
@@ -497,7 +494,7 @@ void bind_state_density_matrix_hpp(nb::module_& m) {
         .def(
             "set_Haar_random_state",
             [](DensityMatrix<Prec, Space>& self, std::optional<std::uint64_t> seed) {
-                self.set_Haar_random_state(seed.value_or(std::random_device{}()));
+                self.set_Haar_random_state(seed);
             },
             "seed"_a = std::nullopt,
             DocString()
@@ -628,7 +625,7 @@ void bind_state_density_matrix_hpp(nb::module_& m) {
             [](const DensityMatrix<Prec, Space>& self,
                std::uint64_t sampling_count,
                std::optional<std::uint64_t> seed) {
-                return self.sampling(sampling_count, seed.value_or(std::random_device{}()));
+                return self.sampling(sampling_count, seed);
             },
             "sampling_count"_a,
             "seed"_a = std::nullopt,

--- a/include/scaluq/state/state_vector.hpp
+++ b/include/scaluq/state/state_vector.hpp
@@ -41,8 +41,8 @@ public:
      */
     [[nodiscard]] StdComplex get_amplitude_at(std::uint64_t index);
 
-    [[nodiscard]] static StateVector Haar_random_state(std::uint64_t n_qubits,
-                                                       std::uint64_t seed = std::random_device()());
+    [[nodiscard]] static StateVector Haar_random_state(
+        std::uint64_t n_qubits, std::optional<std::uint64_t> seed = std::nullopt);
     [[nodiscard]] static StateVector uninitialized_state(std::uint64_t n_qubits);
 
     /**
@@ -51,7 +51,7 @@ public:
     void set_zero_state();
     void set_zero_norm_state();
     void set_computational_basis(std::uint64_t basis);
-    void set_Haar_random_state(std::uint64_t seed = std::random_device()());
+    void set_Haar_random_state(std::optional<std::uint64_t> seed = std::nullopt);
 
     [[nodiscard]] std::uint64_t n_qubits() const { return this->_n_qubits; }
 
@@ -73,7 +73,7 @@ public:
     void multiply_coef(StdComplex coef);
 
     [[nodiscard]] std::vector<std::uint64_t> sampling(
-        std::uint64_t sampling_count, std::uint64_t seed = std::random_device()()) const;
+        std::uint64_t sampling_count, std::optional<std::uint64_t> seed = std::nullopt) const;
 
     void load(const std::vector<StdComplex>& other);
 
@@ -148,10 +148,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
                  .c_str())
         .def_static(
             "Haar_random_state",
-            [](std::uint64_t n_qubits, std::optional<std::uint64_t> seed) {
-                return StateVector<Prec, Space>::Haar_random_state(
-                    n_qubits, seed.value_or(std::random_device{}()));
-            },
+            &StateVector<Prec, Space>::Haar_random_state,
             "n_qubits"_a,
             "seed"_a = std::nullopt,
             DocString()
@@ -200,7 +197,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
         .def(
             "set_Haar_random_state",
             [](StateVector<Prec, Space>& self, std::optional<std::uint64_t> seed) {
-                self.set_Haar_random_state(seed.value_or(std::random_device{}()));
+                self.set_Haar_random_state(seed);
             },
             "seed"_a = std::nullopt,
             DocString()
@@ -481,7 +478,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
             [](const StateVector<Prec, Space>& state,
                std::uint64_t sampling_count,
                std::optional<std::uint64_t> seed) {
-                return state.sampling(sampling_count, seed.value_or(std::random_device{}()));
+                return state.sampling(sampling_count, seed);
             },
             "sampling_count"_a,
             "seed"_a = std::nullopt,

--- a/include/scaluq/state/state_vector_batched.hpp
+++ b/include/scaluq/state/state_vector_batched.hpp
@@ -41,16 +41,17 @@ public:
 
     void set_zero_norm_state();
 
-    void set_Haar_random_state(bool set_same_state, std::uint64_t seed = std::random_device()());
+    void set_Haar_random_state(bool set_same_state,
+                               std::optional<std::uint64_t> seed = std::nullopt);
 
     [[nodiscard]] std::vector<std::vector<std::uint64_t>> sampling(
-        std::uint64_t sampling_count, std::uint64_t seed = std::random_device()()) const;
+        std::uint64_t sampling_count, std::optional<std::uint64_t> seed = std::nullopt) const;
 
     [[nodiscard]] static StateVectorBatched Haar_random_state(
         std::uint64_t batch_size,
         std::uint64_t n_qubits,
         bool set_same_state,
-        std::uint64_t seed = std::random_device()());
+        std::optional<std::uint64_t> seed = std::nullopt);
     [[nodiscard]] static StateVectorBatched uninitialized_state(std::uint64_t batch_size,
                                                                 std::uint64_t n_qubits);
 
@@ -280,7 +281,7 @@ void bind_state_state_vector_batched_hpp(nb::module_& m) {
             [](StateVectorBatched<Prec, Space>& states,
                bool set_same_state,
                std::optional<std::uint64_t> seed) {
-                states.set_Haar_random_state(set_same_state, seed.value_or(std::random_device()()));
+                states.set_Haar_random_state(set_same_state, seed);
             },
             "set_same_state"_a,
             "seed"_a = std::nullopt,
@@ -300,7 +301,7 @@ void bind_state_state_vector_batched_hpp(nb::module_& m) {
                bool set_same_state,
                std::optional<std::uint64_t> seed) {
                 return StateVectorBatched<Prec, Space>::Haar_random_state(
-                    batch_size, n_qubits, set_same_state, seed.value_or(std::random_device()()));
+                    batch_size, n_qubits, set_same_state, seed);
             },
             "batch_size"_a,
             "n_qubits"_a,
@@ -369,7 +370,7 @@ void bind_state_state_vector_batched_hpp(nb::module_& m) {
             [](const StateVectorBatched<Prec, Space>& states,
                std::uint64_t sampling_count,
                std::optional<std::uint64_t> seed) {
-                return states.sampling(sampling_count, seed.value_or(std::random_device()()));
+                return states.sampling(sampling_count, seed);
             },
             "sampling_count"_a,
             "seed"_a = std::nullopt,

--- a/include/scaluq/util/random.hpp
+++ b/include/scaluq/util/random.hpp
@@ -1,19 +1,29 @@
 #pragma once
 
+#include <optional>
 #include <random>
 #include <ranges>
 
 #include "../types.hpp"
 
 namespace scaluq {
+namespace internal {
+inline std::uint64_t resolve_seed(std::optional<std::uint64_t> seed) {
+    if (seed.has_value()) {
+        return seed.value();
+    }
+    return std::random_device{}();
+}
+}  // namespace internal
+
 class Random {
     std::mt19937_64 mt;
     std::uniform_real_distribution<double> uniform_dist;
     std::normal_distribution<double> normal_dist;
 
 public:
-    Random(std::uint64_t seed = std::random_device()())
-        : mt(seed), uniform_dist(0, 1), normal_dist(0, 1) {}
+    Random(std::optional<std::uint64_t> seed = std::nullopt)
+        : mt(internal::resolve_seed(seed)), uniform_dist(0, 1), normal_dist(0, 1) {}
 
     [[nodiscard]] double uniform() { return this->uniform_dist(this->mt); }
 

--- a/src/circuit/circuit.cpp
+++ b/src/circuit/circuit.cpp
@@ -77,7 +77,7 @@ template <Precision Prec>
 template <ExecutionSpace Space>
 void Circuit<Prec>::update_quantum_state(StateVector<Prec, Space>& state,
                                          const std::map<std::string, double>& parameters,
-                                         std::uint64_t seed) const {
+                                         std::optional<std::uint64_t> seed) const {
     if (has_classical_instructions()) {
         throw std::runtime_error(
             "Circuit::update_quantum_state(StateVector&, ...): a classical register is required "
@@ -92,7 +92,7 @@ template <ExecutionSpace Space>
 void Circuit<Prec>::update_quantum_state(StateVector<Prec, Space>& state,
                                          ClassicalRegister& classical_register,
                                          const std::map<std::string, double>& parameters,
-                                         std::uint64_t seed) const {
+                                         std::optional<std::uint64_t> seed) const {
     check_state_vector_n_qubits(state.n_qubits());
     for (auto&& gate : _gate_list) {
         if (gate.index() == 0) continue;
@@ -104,7 +104,7 @@ void Circuit<Prec>::update_quantum_state(StateVector<Prec, Space>& state,
                 std::string(key) + "is not given.");
         }
     }
-    std::mt19937_64 random_engine(seed);
+    std::mt19937_64 random_engine(internal::resolve_seed(seed));
     std::uint64_t unreset_measured_qubit_mask = 0ULL;
     internal::ExecutionContext<Prec, Space> context{state, classical_register, random_engine};
     for (std::uint64_t idx = 0; idx < _gate_list.size(); ++idx) {
@@ -144,7 +144,7 @@ template <ExecutionSpace Space>
 void Circuit<Prec>::update_quantum_state(
     StateVectorBatched<Prec, Space>& states,
     const std::map<std::string, std::vector<double>>& parameters,
-    std::uint64_t seed) const {
+    std::optional<std::uint64_t> seed) const {
     if (has_classical_instructions()) {
         throw std::runtime_error(
             "Circuit::update_quantum_state(StateVectorBatched&, ...): a classical register is "
@@ -161,7 +161,7 @@ void Circuit<Prec>::update_quantum_state(
     StateVectorBatched<Prec, Space>& states,
     ClassicalRegisterBatched& classical_register,
     const std::map<std::string, std::vector<double>>& parameters,
-    std::uint64_t seed) const {
+    std::optional<std::uint64_t> seed) const {
     check_state_vector_n_qubits(states.n_qubits());
     if (classical_register.batch_size() != states.batch_size()) {
         throw std::runtime_error(
@@ -183,7 +183,7 @@ void Circuit<Prec>::update_quantum_state(
                 "std::vector<double>>&): parameter size mismatch.");
         }
     }
-    std::mt19937_64 random_engine(seed);
+    std::mt19937_64 random_engine(internal::resolve_seed(seed));
     std::uint64_t unreset_measured_qubit_mask = 0ULL;
     internal::ExecutionContextBatched<Prec, Space> context{
         states, classical_register, random_engine};
@@ -234,60 +234,60 @@ void Circuit<Prec>::update_quantum_state(
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Host>(
     StateVector<internal::Prec, ExecutionSpace::Host>& state,
     const std::map<std::string, double>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Host>(
     StateVector<internal::Prec, ExecutionSpace::Host>& state,
     ClassicalRegister& classical_register,
     const std::map<std::string, double>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Host>(
     StateVectorBatched<internal::Prec, ExecutionSpace::Host>& states,
     const std::map<std::string, std::vector<double>>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Host>(
     StateVectorBatched<internal::Prec, ExecutionSpace::Host>& states,
     ClassicalRegisterBatched& classical_register,
     const std::map<std::string, std::vector<double>>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::HostSerial>(
     StateVector<internal::Prec, ExecutionSpace::HostSerial>& state,
     const std::map<std::string, double>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::HostSerial>(
     StateVector<internal::Prec, ExecutionSpace::HostSerial>& state,
     ClassicalRegister& classical_register,
     const std::map<std::string, double>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::HostSerial>(
     StateVectorBatched<internal::Prec, ExecutionSpace::HostSerial>& states,
     const std::map<std::string, std::vector<double>>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::HostSerial>(
     StateVectorBatched<internal::Prec, ExecutionSpace::HostSerial>& states,
     ClassicalRegisterBatched& classical_register,
     const std::map<std::string, std::vector<double>>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 
 #ifdef SCALUQ_USE_CUDA
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Default>(
     StateVector<internal::Prec, ExecutionSpace::Default>& state,
     const std::map<std::string, double>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Default>(
     StateVector<internal::Prec, ExecutionSpace::Default>& state,
     ClassicalRegister& classical_register,
     const std::map<std::string, double>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Default>(
     StateVectorBatched<internal::Prec, ExecutionSpace::Default>& states,
     const std::map<std::string, std::vector<double>>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 template void Circuit<internal::Prec>::update_quantum_state<ExecutionSpace::Default>(
     StateVectorBatched<internal::Prec, ExecutionSpace::Default>& states,
     ClassicalRegisterBatched& classical_register,
     const std::map<std::string, std::vector<double>>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 #endif  // SCALUQ_USE_CUDA
 
 template <Precision Prec>
@@ -504,9 +504,9 @@ std::vector<std::pair<StateVector<Prec, Space>, std::int64_t>> Circuit<Prec>::si
     const StateVector<Prec, Space>& initial_state,
     std::uint64_t sampling_count,
     const std::map<std::string, double>& parameters,
-    std::uint64_t seed) const {
+    std::optional<std::uint64_t> seed) const {
     check_state_vector_n_qubits(initial_state.n_qubits());
-    std::mt19937 mt(seed);
+    std::mt19937 mt(internal::resolve_seed(seed));
     StateVectorBatched<Prec, Space> states(1, initial_state.n_qubits()), new_states;
     states.set_state_vector_at(0, initial_state);
     std::vector<std::uint64_t> scounts{sampling_count}, new_scounts;
@@ -604,7 +604,7 @@ Circuit<internal::Prec>::simulate_noise<ExecutionSpace::Host>(
     const StateVector<internal::Prec, ExecutionSpace::Host>& initial_state,
     std::uint64_t sampling_count,
     const std::map<std::string, double>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 
 template std::vector<
     std::pair<StateVector<internal::Prec, ExecutionSpace::HostSerial>, std::int64_t>>
@@ -612,14 +612,14 @@ Circuit<internal::Prec>::simulate_noise<ExecutionSpace::HostSerial>(
     const StateVector<internal::Prec, ExecutionSpace::HostSerial>& initial_state,
     std::uint64_t sampling_count,
     const std::map<std::string, double>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 #ifdef SCALUQ_USE_CUDA
 template std::vector<std::pair<StateVector<internal::Prec, ExecutionSpace::Default>, std::int64_t>>
 Circuit<internal::Prec>::simulate_noise<ExecutionSpace::Default>(
     const StateVector<internal::Prec, ExecutionSpace::Default>& initial_state,
     std::uint64_t sampling_count,
     const std::map<std::string, double>& parameters,
-    std::uint64_t seed) const;
+    std::optional<std::uint64_t> seed) const;
 #endif  // SCALUQ_USE_CUDA
 
 template <Precision Prec>

--- a/src/state/density_matrix.cpp
+++ b/src/state/density_matrix.cpp
@@ -175,7 +175,7 @@ template <Precision Prec, ExecutionSpace Space>
 
 template <Precision Prec, ExecutionSpace Space>
 [[nodiscard]] DensityMatrix<Prec, Space> DensityMatrix<Prec, Space>::Haar_random_state(
-    std::uint64_t n_qubits, std::uint64_t seed) {
+    std::uint64_t n_qubits, std::optional<std::uint64_t> seed) {
     auto state(DensityMatrix<Prec, Space>::uninitialized_state(n_qubits));
     state.set_Haar_random_state(seed);
     return state;
@@ -214,7 +214,7 @@ void DensityMatrix<Prec, Space>::set_computational_basis(std::uint64_t basis) {
 }
 
 template <Precision Prec, ExecutionSpace Space>
-void DensityMatrix<Prec, Space>::set_Haar_random_state(std::uint64_t seed) {
+void DensityMatrix<Prec, Space>::set_Haar_random_state(std::optional<std::uint64_t> seed) {
     auto random_pure_state = StateVector<Prec, Space>::Haar_random_state(this->_n_qubits, seed);
     this->_is_hermitian = true;
     this->load(random_pure_state);
@@ -384,8 +384,8 @@ double DensityMatrix<Prec, Space>::get_marginal_probability(
 }
 
 template <Precision Prec, ExecutionSpace Space>
-std::vector<std::uint64_t> DensityMatrix<Prec, Space>::sampling(std::uint64_t sampling_count,
-                                                                std::uint64_t seed) const {
+std::vector<std::uint64_t> DensityMatrix<Prec, Space>::sampling(
+    std::uint64_t sampling_count, std::optional<std::uint64_t> seed) const {
     if (!this->_is_hermitian) {
         throw std::runtime_error(
             "DensityMatrix::sampling: Sampling is only defined for hermitian density matrices.");
@@ -402,7 +402,8 @@ std::vector<std::uint64_t> DensityMatrix<Prec, Space>::sampling(std::uint64_t sa
             }
         });
 
-    Kokkos::Random_XorShift64_Pool<internal::SpaceType<Space>> rand_pool(seed);
+    Kokkos::Random_XorShift64_Pool<internal::SpaceType<Space>> rand_pool(
+        internal::resolve_seed(seed));
     std::vector<std::uint64_t> result(sampling_count);
     std::vector<std::uint64_t> todo(sampling_count);
     std::iota(todo.begin(), todo.end(), 0);

--- a/src/state/state_vector.cpp
+++ b/src/state/state_vector.cpp
@@ -29,8 +29,8 @@ StdComplex StateVector<Prec, Space>::get_amplitude_at(std::uint64_t index) {
     return StdComplex(static_cast<double>(val.real()), static_cast<double>(val.imag()));
 }
 template <Precision Prec, ExecutionSpace Space>
-StateVector<Prec, Space> StateVector<Prec, Space>::Haar_random_state(std::uint64_t n_qubits,
-                                                                     std::uint64_t seed) {
+StateVector<Prec, Space> StateVector<Prec, Space>::Haar_random_state(
+    std::uint64_t n_qubits, std::optional<std::uint64_t> seed) {
     auto state(StateVector<Prec, Space>::uninitialized_state(n_qubits));
     state.set_Haar_random_state(seed);
     return state;
@@ -68,9 +68,10 @@ void StateVector<Prec, Space>::set_computational_basis(std::uint64_t basis) {
         KOKKOS_CLASS_LAMBDA(std::uint64_t i) { _raw[i] = (i == basis); });
 }
 template <Precision Prec, ExecutionSpace Space>
-void StateVector<Prec, Space>::set_Haar_random_state(std::uint64_t seed) {
+void StateVector<Prec, Space>::set_Haar_random_state(std::optional<std::uint64_t> seed) {
+    std::uint64_t actual_seed = internal::resolve_seed(seed);
     if constexpr (Space == ExecutionSpace::HostSerial) {
-        Kokkos::Random_XorShift64_Pool<Kokkos::DefaultHostExecutionSpace> rand_pool(seed);
+        Kokkos::Random_XorShift64_Pool<Kokkos::DefaultHostExecutionSpace> rand_pool(actual_seed);
         Kokkos::View<ComplexType*, Kokkos::HostSpace> host_raw("host_raw", _dim);
         Kokkos::parallel_for(
             "Haar_random_state_host",
@@ -83,7 +84,7 @@ void StateVector<Prec, Space>::set_Haar_random_state(std::uint64_t seed) {
             });
         Kokkos::deep_copy(_raw, host_raw);
     } else {
-        Kokkos::Random_XorShift64_Pool<internal::SpaceType<Space>> rand_pool(seed);
+        Kokkos::Random_XorShift64_Pool<internal::SpaceType<Space>> rand_pool(actual_seed);
         Kokkos::parallel_for(
             "Haar_random_state",
             Kokkos::RangePolicy<internal::SpaceType<Space>>(0, _dim),
@@ -220,8 +221,9 @@ void StateVector<Prec, Space>::multiply_coef(StdComplex coef) {
         KOKKOS_CLASS_LAMBDA(std::uint64_t i) { this->_raw[i] *= coef; });
 }
 template <Precision Prec, ExecutionSpace Space>
-std::vector<std::uint64_t> StateVector<Prec, Space>::sampling(std::uint64_t sampling_count,
-                                                              std::uint64_t seed) const {
+std::vector<std::uint64_t> StateVector<Prec, Space>::sampling(
+    std::uint64_t sampling_count, std::optional<std::uint64_t> seed) const {
+    std::uint64_t actual_seed = internal::resolve_seed(seed);
     Kokkos::View<FloatType*, internal::SpaceType<Space>> stacked_prob("prob", _dim + 1);
     Kokkos::parallel_scan(
         "sampling (compute stacked prob)",
@@ -233,7 +235,7 @@ std::vector<std::uint64_t> StateVector<Prec, Space>::sampling(std::uint64_t samp
             }
         });
 
-    Kokkos::Random_XorShift64_Pool<internal::SpaceType<Space>> rand_pool(seed);
+    Kokkos::Random_XorShift64_Pool<internal::SpaceType<Space>> rand_pool(actual_seed);
     std::vector<std::uint64_t> result(sampling_count);
     std::vector<std::uint64_t> todo(sampling_count);
     std::iota(todo.begin(), todo.end(), 0);

--- a/src/state/state_vector_batched.cpp
+++ b/src/state/state_vector_batched.cpp
@@ -96,13 +96,13 @@ void StateVectorBatched<Prec, Space>::set_zero_norm_state() {
 
 template <Precision Prec, ExecutionSpace Space>
 void StateVectorBatched<Prec, Space>::set_Haar_random_state(bool set_same_state,
-                                                            std::uint64_t seed) {
+                                                            std::optional<std::uint64_t> seed) {
     *this = Haar_random_state(_batch_size, _n_qubits, set_same_state, seed);
 }
 
 template <Precision Prec, ExecutionSpace Space>
 std::vector<std::vector<std::uint64_t>> StateVectorBatched<Prec, Space>::sampling(
-    std::uint64_t sampling_count, std::uint64_t seed) const {
+    std::uint64_t sampling_count, std::optional<std::uint64_t> seed) const {
     Kokkos::View<FloatType**, internal::SpaceType<Space>> stacked_prob(
         "prob", _batch_size, _dim + 1);
 
@@ -123,7 +123,8 @@ std::vector<std::vector<std::uint64_t>> StateVectorBatched<Prec, Space>::samplin
         });
 
     std::vector result(_batch_size, std::vector<std::uint64_t>(sampling_count));
-    Kokkos::Random_XorShift64_Pool<internal::SpaceType<Space>> rand_pool(seed);
+    Kokkos::Random_XorShift64_Pool<internal::SpaceType<Space>> rand_pool(
+        internal::resolve_seed(seed));
     std::vector<std::uint64_t> batch_todo(_batch_size * sampling_count);
     std::vector<std::uint64_t> sample_todo(_batch_size * sampling_count);
     for (std::uint64_t i = 0; i < _batch_size; i++) {
@@ -179,11 +180,15 @@ std::vector<std::vector<std::uint64_t>> StateVectorBatched<Prec, Space>::samplin
 
 template <Precision Prec, ExecutionSpace Space>
 StateVectorBatched<Prec, Space> StateVectorBatched<Prec, Space>::Haar_random_state(
-    std::uint64_t batch_size, std::uint64_t n_qubits, bool set_same_state, std::uint64_t seed) {
-    Kokkos::Random_XorShift64_Pool<internal::SpaceType<Space>> rand_pool(seed);
+    std::uint64_t batch_size,
+    std::uint64_t n_qubits,
+    bool set_same_state,
+    std::optional<std::uint64_t> seed) {
+    std::uint64_t actual_seed = internal::resolve_seed(seed);
+    Kokkos::Random_XorShift64_Pool<internal::SpaceType<Space>> rand_pool(actual_seed);
     auto states(StateVectorBatched<Prec, Space>::uninitialized_state(batch_size, n_qubits));
     if (set_same_state) {
-        states.set_state_vector(StateVector<Prec, Space>::Haar_random_state(n_qubits, seed));
+        states.set_state_vector(StateVector<Prec, Space>::Haar_random_state(n_qubits, actual_seed));
     } else {
         Kokkos::parallel_for(
             "Haar_random_state",


### PR DESCRIPTION
<details>
<summary>For external contributor</summary>

Thanks for contributing Scaluq!  
Please write in English or Japanese.  

**PR title name examples**  
- new feature: `Add function-name`
- update: `Update sample code`
- bug: `Fix bug-name`

</details>

## Summary
- seedを渡す関数の引数をC++の段階から`std::optional`にした
- `std::optional`のseedを`value_or()`で展開していたが、これだとnulloptでなくても`std::random_device{}()`が実行されていて効率が悪いので、nulloptのときだけ呼び出すようにした


## What was changed? (変更点)
- 

## Why was this change needed? (変更理由)
- 

## Additional context (optional)
- Circuit::update_quantum_stateについては、今後、「回路に乱数が必要かどうかを先に判定して、不要ならmt19937_64自体構築しない」というアップデートも考慮の余地がある。