### PR TITLE
Add many-to-many execution

### DIFF
--- a/include/scaluq/operator/operator_batched.hpp
+++ b/include/scaluq/operator/operator_batched.hpp
@@ -70,6 +70,8 @@ public:
 
     [[nodiscard]] std::vector<StdComplex> get_expectation_value(
         const StateVector<Prec, Space>& state_vector) const;
+    [[nodiscard]] std::vector<StdComplex> get_expectation_value(
+        const StateVectorBatched<Prec, Space>& states) const;
 
     [[nodiscard]] std::vector<StdComplex> get_transition_amplitude(
         const StateVector<Prec, Space>& state_vector_bra,
@@ -207,11 +209,21 @@ void bind_operator_operator_batched_hpp(nb::module_& m) {
                  .build_as_google_style()
                  .c_str())
         .def("get_expectation_value",
-             &OperatorBatched<Prec, Space>::get_expectation_value,
+             nb::overload_cast<const StateVector<Prec, Space>&>(
+                 &OperatorBatched<Prec, Space>::get_expectation_value),
              "state_vector"_a,
              DocString()
                  .desc("Return a vector of expectation values for each operator.")
                  .arg("state_vector", "A state vector to compute expectation values.")
+                 .build_as_google_style()
+                 .c_str())
+        .def("get_expectation_value",
+             nb::overload_cast<const StateVectorBatched<Prec, Space>&>(
+                 &OperatorBatched<Prec, Space>::get_expectation_value),
+             "states" _a,
+             DocString()
+                 .desc("Return a vector of expectation values for each operator.")
+                 .arg("states", "State Vector Batched to compute expectation values.")
                  .build_as_google_style()
                  .c_str())
         .def("get_transition_amplitude",

--- a/include/scaluq/operator/operator_batched.hpp
+++ b/include/scaluq/operator/operator_batched.hpp
@@ -76,6 +76,9 @@ public:
     [[nodiscard]] std::vector<StdComplex> get_transition_amplitude(
         const StateVector<Prec, Space>& state_vector_bra,
         const StateVector<Prec, Space>& state_vector_ket) const;
+    [[nodiscard]] std::vector<StdComplex> get_transition_amplitude(
+        const StateVectorBatched<Prec, Space>& states_bra,
+        const StateVectorBatched<Prec, Space>& states_ket) const;
 
     // // not implemented yet
     [[nodiscard]] StdComplex solve_ground_state_eigenvalue_by_arnoldi_method(
@@ -232,16 +235,36 @@ void bind_operator_operator_batched_hpp(nb::module_& m) {
                 .arg("states", "State Vector Batched to compute expectation values.")
                 .build_as_google_style()
                 .c_str())
-        .def("get_transition_amplitude",
-             &OperatorBatched<Prec, Space>::get_transition_amplitude,
-             "state_vector_bra"_a,
-             "state_vector_ket"_a,
-             DocString()
-                 .desc("Return a vector of transition amplitudes for each operator.")
-                 .arg("state_vector_bra", "A bra state vector.")
-                 .arg("state_vector_ket", "A ket state vector.")
-                 .build_as_google_style()
-                 .c_str())
+        .def(
+            "get_transition_amplitude",
+            [](const OperatorBatched<Prec, Space>& op,
+               const StateVector<Prec, Space>& state_vector_bra,
+               const StateVector<Prec, Space>& state_vector_ket) {
+                return op.get_transition_amplitude(state_vector_bra, state_vector_ket);
+            },
+            "state_vector_bra"_a,
+            "state_vector_ket"_a,
+            DocString()
+                .desc("Return a vector of transition amplitudes for each operator.")
+                .arg("state_vector_bra", "A bra state vector.")
+                .arg("state_vector_ket", "A ket state vector.")
+                .build_as_google_style()
+                .c_str())
+        .def(
+            "get_transition_amplitude",
+            [](const OperatorBatched<Prec, Space>& op,
+               const StateVectorBatched<Prec, Space>& states_bra,
+               const StateVectorBatched<Prec, Space>& states_ket) {
+                return op.get_transition_amplitude(states_bra, states_ket);
+            },
+            "states_bra"_a,
+            "states_ket"_a,
+            DocString()
+                .desc("Return a vector of transition amplitudes for each operator.")
+                .arg("states_bra", "Batched bra state vector.")
+                .arg("states_ket", "Batched ket state vector.")
+                .build_as_google_style()
+                .c_str())
         // .def("solve_ground_state_eigenvalue_by_arnoldi_method",
         //      &OperatorBatched<Prec, Space>::solve_ground_state_eigenvalue_by_arnoldi_method,
         //      "state"_a,

--- a/include/scaluq/operator/operator_batched.hpp
+++ b/include/scaluq/operator/operator_batched.hpp
@@ -208,24 +208,30 @@ void bind_operator_operator_batched_hpp(nb::module_& m) {
                       "In the update process, the batch size to be processed simultaneously.")
                  .build_as_google_style()
                  .c_str())
-        .def("get_expectation_value",
-             nb::overload_cast<const StateVector<Prec, Space>&>(
-                 &OperatorBatched<Prec, Space>::get_expectation_value),
-             "state_vector"_a,
-             DocString()
-                 .desc("Return a vector of expectation values for each operator.")
-                 .arg("state_vector", "A state vector to compute expectation values.")
-                 .build_as_google_style()
-                 .c_str())
-        .def("get_expectation_value",
-             nb::overload_cast<const StateVectorBatched<Prec, Space>&>(
-                 &OperatorBatched<Prec, Space>::get_expectation_value),
-             "states" _a,
-             DocString()
-                 .desc("Return a vector of expectation values for each operator.")
-                 .arg("states", "State Vector Batched to compute expectation values.")
-                 .build_as_google_style()
-                 .c_str())
+        .def(
+            "get_expectation_value",
+            [](const OperatorBatched<Prec, Space>& op,
+               const StateVector<Prec, Space>& state_vector) {
+                return op.get_expectation_value(state_vector);
+            },
+            "state_vector"_a,
+            DocString()
+                .desc("Return a vector of expectation values for each operator.")
+                .arg("state_vector", "A state vector to compute expectation values.")
+                .build_as_google_style()
+                .c_str())
+        .def(
+            "get_expectation_value",
+            [](const OperatorBatched<Prec, Space>& op,
+               const StateVectorBatched<Prec, Space>& states) {
+                return op.get_expectation_value(states);
+            },
+            "states"_a,
+            DocString()
+                .desc("Return a vector of expectation values for each operator.")
+                .arg("states", "State Vector Batched to compute expectation values.")
+                .build_as_google_style()
+                .c_str())
         .def("get_transition_amplitude",
              &OperatorBatched<Prec, Space>::get_transition_amplitude,
              "state_vector_bra"_a,

--- a/src/operator/operator_batched.cpp
+++ b/src/operator/operator_batched.cpp
@@ -257,6 +257,79 @@ std::vector<StdComplex> OperatorBatched<internal::Prec, internal::Space>::get_tr
 }
 
 template <>
+std::vector<StdComplex> OperatorBatched<internal::Prec, internal::Space>::get_transition_amplitude(
+    const StateVectorBatched<internal::Prec, internal::Space>& states_bra,
+    const StateVectorBatched<internal::Prec, internal::Space>& states_ket) const {
+    if (states_bra.n_qubits() != states_ket.n_qubits()) {
+        throw std::runtime_error(
+            "Operator::get_transition_amplitude: n_qubits of states_bra and "
+            "states_ket must be same");
+    }
+    if (states_bra.batch_size() != states_ket.batch_size()) {
+        throw std::runtime_error(
+            "Operator::get_transition_amplitude: batch_size of states_bra and "
+            "states_ket must be same");
+    }
+    Kokkos::View<Kokkos::complex<double>*, ExecutionSpaceType> res(
+        Kokkos::ViewAllocateWithoutInitializing("expectation_value"), _row_ptr.extent(0) - 1);
+    std::uint64_t dim = states_bra.dim();
+
+    Kokkos::parallel_for(
+        "get_transition_amplitude",
+        Kokkos::TeamPolicy<ExecutionSpaceType>(_row_ptr.extent(0) - 1, Kokkos::AUTO),
+        KOKKOS_CLASS_LAMBDA(const Kokkos::TeamPolicy<ExecutionSpaceType>::member_type& team) {
+            std::uint64_t batch_id = team.league_rank();
+            ComplexType res_lcl = 0;
+            Kokkos::parallel_reduce(
+                Kokkos::TeamThreadMDRange(
+                    team, _row_ptr[batch_id + 1] - _row_ptr[batch_id], dim >> 1),
+                [&](std::uint64_t term_id, std::uint64_t state_idx, ComplexType& res_lcl) {
+                    term_id += _row_ptr[batch_id];
+                    auto bit_flip_mask = _ops[term_id]._bit_flip_mask;
+                    auto phase_flip_mask = _ops[term_id]._phase_flip_mask;
+                    ComplexType coef = _ops[term_id]._coef;
+                    if (bit_flip_mask == 0) {
+                        std::uint64_t state_idx1 = state_idx << 1;
+                        ComplexType tmp1 =
+                            (scaluq::internal::conj(states_bra._raw(batch_id, state_idx1)) *
+                             states_ket._raw(batch_id, state_idx1));
+                        if (Kokkos::popcount(state_idx1 & phase_flip_mask) & 1) tmp1 = -tmp1;
+                        std::uint64_t state_idx2 = state_idx1 | 1;
+                        ComplexType tmp2 =
+                            (scaluq::internal::conj(states_bra._raw(batch_id, state_idx2)) *
+                             states_ket._raw(batch_id, state_idx2));
+                        if (Kokkos::popcount(state_idx2 & phase_flip_mask) & 1) tmp2 = -tmp2;
+                        res_lcl += coef * (tmp1 + tmp2);
+                    } else {
+                        std::uint64_t pivot = Kokkos::bit_width(bit_flip_mask) - 1;
+                        std::uint64_t global_phase_90rot_count =
+                            Kokkos::popcount(bit_flip_mask & phase_flip_mask);
+                        ComplexType global_phase =
+                            internal::PHASE_90ROT<internal::Prec>()[global_phase_90rot_count % 4];
+                        std::uint64_t basis_0 =
+                            internal::insert_zero_to_basis_index(state_idx, pivot);
+                        std::uint64_t basis_1 = basis_0 ^ bit_flip_mask;
+                        ComplexType tmp1 =
+                            scaluq::internal::conj(states_bra._raw(batch_id, basis_1)) *
+                            states_ket._raw(batch_id, basis_0) * global_phase;
+                        if (Kokkos::popcount(basis_0 & phase_flip_mask) & 1) tmp1 = -tmp1;
+                        ComplexType tmp2 =
+                            scaluq::internal::conj(states_bra._raw(batch_id, basis_0)) *
+                            states_ket._raw(batch_id, basis_1) * global_phase;
+                        if (Kokkos::popcount(basis_1 & phase_flip_mask) & 1) tmp2 = -tmp2;
+                        res_lcl += coef * (tmp1 + tmp2);
+                    }
+                },
+                res_lcl);
+            Kokkos::single(Kokkos::PerTeam(team), [&] {
+                res[batch_id] = Kokkos::complex<double>(res_lcl.real(), res_lcl.imag());
+            });
+        });
+    auto res_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), res);
+    return std::vector<StdComplex>(res_h.data(), res_h.data() + res_h.size());
+}
+
+template <>
 OperatorBatched<internal::Prec, internal::Space>
 OperatorBatched<internal::Prec, internal::Space>::get_dagger() const {
     OperatorBatched<internal::Prec, internal::Space> res = this->copy();

--- a/src/operator/operator_batched.cpp
+++ b/src/operator/operator_batched.cpp
@@ -126,6 +126,71 @@ std::vector<StdComplex> OperatorBatched<internal::Prec, internal::Space>::get_ex
 }
 
 template <>
+std::vector<StdComplex> OperatorBatched<internal::Prec, internal::Space>::get_expectation_value(
+    const StateVectorBatched<internal::Prec, internal::Space>& states) const {
+    std::uint64_t op_batch_size = _row_ptr.extent(0) - 1;
+    if (op_batch_size != states.batch_size()) {
+        throw std::runtime_error(
+            "Batch size mismatch between OperatorBatched and StateVectorBatched.");
+    }
+    std::uint64_t dim = states.dim();
+    Kokkos::View<Kokkos::complex<double>*, ExecutionSpaceType> res(
+        Kokkos::ViewAllocateWithoutInitializing("expectation_value"), _row_ptr.extent(0) - 1);
+    Kokkos::parallel_for(
+        "get_expectation_value_batched",
+        Kokkos::TeamPolicy<ExecutionSpaceType>(_row_ptr.extent(0) - 1, Kokkos::AUTO),
+        KOKKOS_CLASS_LAMBDA(const Kokkos::TeamPolicy<ExecutionSpaceType>::member_type& team) {
+            std::uint64_t batch_id = team.league_rank();
+            ComplexType res_lcl = 0;
+            Kokkos::parallel_reduce(
+                Kokkos::TeamThreadMDRange(
+                    team, _row_ptr[batch_id + 1] - _row_ptr[batch_id], dim >> 1),
+                [&](std::uint64_t term_id, std::uint64_t state_idx, ComplexType& res_lcl) {
+                    term_id += _row_ptr[batch_id];
+                    auto bit_flip_mask = _ops[term_id]._bit_flip_mask;
+                    auto phase_flip_mask = _ops[term_id]._phase_flip_mask;
+                    ComplexType coef = _ops[term_id]._coef;
+                    if (bit_flip_mask == 0) {
+                        std::uint64_t state_idx1 = state_idx << 1;
+                        ComplexType tmp1 =
+                            (scaluq::internal::conj(states._raw(batch_id, state_idx1)) *
+                             states._raw(batch_id, state_idx1));
+                        if (Kokkos::popcount(state_idx1 & phase_flip_mask) & 1) tmp1 = -tmp1;
+                        std::uint64_t state_idx2 = state_idx1 | 1;
+                        ComplexType tmp2 =
+                            (scaluq::internal::conj(states._raw(batch_id, state_idx2)) *
+                             states._raw(batch_id, state_idx2));
+                        if (Kokkos::popcount(state_idx2 & phase_flip_mask) & 1) tmp2 = -tmp2;
+                        res_lcl += coef * (tmp1 + tmp2);
+                    } else {
+                        std::uint64_t pivot = Kokkos::bit_width(bit_flip_mask) - 1;
+                        std::uint64_t global_phase_90rot_count =
+                            Kokkos::popcount(bit_flip_mask & phase_flip_mask);
+                        ComplexType global_phase =
+                            internal::PHASE_90ROT<internal::Prec>()[global_phase_90rot_count % 4];
+                        std::uint64_t basis_0 =
+                            internal::insert_zero_to_basis_index(state_idx, pivot);
+                        std::uint64_t basis_1 = basis_0 ^ bit_flip_mask;
+                        ComplexType tmp1 = scaluq::internal::conj(states._raw(batch_id, basis_1)) *
+                                           states._raw(batch_id, basis_0) * global_phase;
+                        if (Kokkos::popcount(basis_0 & phase_flip_mask) & 1) tmp1 = -tmp1;
+                        ComplexType tmp2 = scaluq::internal::conj(states._raw(batch_id, basis_0)) *
+                                           states._raw(batch_id, basis_1) * global_phase;
+                        if (Kokkos::popcount(basis_1 & phase_flip_mask) & 1) tmp2 = -tmp2;
+                        res_lcl += coef * (tmp1 + tmp2);
+                    }
+                },
+                res_lcl);
+            Kokkos::single(Kokkos::PerTeam(team), [&] {
+                res[batch_id] = Kokkos::complex<double>(res_lcl.real(), res_lcl.imag());
+            });
+        });
+    Kokkos::fence();
+    auto res_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), res);
+    return std::vector<StdComplex>(res_h.data(), res_h.data() + res_h.size());
+}
+
+template <>
 std::vector<StdComplex> OperatorBatched<internal::Prec, internal::Space>::get_transition_amplitude(
     const StateVector<internal::Prec, internal::Space>& state_vector_bra,
     const StateVector<internal::Prec, internal::Space>& state_vector_ket) const {

--- a/src/operator/operator_batched.cpp
+++ b/src/operator/operator_batched.cpp
@@ -131,13 +131,14 @@ std::vector<StdComplex> OperatorBatched<internal::Prec, internal::Space>::get_ex
     std::uint64_t op_batch_size = _row_ptr.extent(0) - 1;
     if (op_batch_size != states.batch_size()) {
         throw std::runtime_error(
-            "Batch size mismatch between OperatorBatched and StateVectorBatched.");
+            "Operator::get_expectation_value: batch_size of OperatorBatched and "
+            "StateVectorBatched must be same");
     }
     std::uint64_t dim = states.dim();
     Kokkos::View<Kokkos::complex<double>*, ExecutionSpaceType> res(
         Kokkos::ViewAllocateWithoutInitializing("expectation_value"), _row_ptr.extent(0) - 1);
     Kokkos::parallel_for(
-        "get_expectation_value_batched",
+        "get_expectation_value",
         Kokkos::TeamPolicy<ExecutionSpaceType>(_row_ptr.extent(0) - 1, Kokkos::AUTO),
         KOKKOS_CLASS_LAMBDA(const Kokkos::TeamPolicy<ExecutionSpaceType>::member_type& team) {
             std::uint64_t batch_id = team.league_rank();
@@ -200,7 +201,7 @@ std::vector<StdComplex> OperatorBatched<internal::Prec, internal::Space>::get_tr
             "state_vector_ket must be same");
     }
     Kokkos::View<Kokkos::complex<double>*, ExecutionSpaceType> res(
-        Kokkos::ViewAllocateWithoutInitializing("expectation_value"), _row_ptr.extent(0) - 1);
+        Kokkos::ViewAllocateWithoutInitializing("transition_amplitude"), _row_ptr.extent(0) - 1);
     std::uint64_t dim = state_vector_bra.dim();
 
     Kokkos::parallel_for(
@@ -270,8 +271,14 @@ std::vector<StdComplex> OperatorBatched<internal::Prec, internal::Space>::get_tr
             "Operator::get_transition_amplitude: batch_size of states_bra and "
             "states_ket must be same");
     }
+    std::uint64_t op_batch_size = _row_ptr.extent(0) - 1;
+    if (op_batch_size != states_bra.batch_size()) {
+        throw std::runtime_error(
+            "Operator::get_transition_amplitude: batch_size of OperatorBatched and "
+            "StateVectorBatched must be same");
+    }
     Kokkos::View<Kokkos::complex<double>*, ExecutionSpaceType> res(
-        Kokkos::ViewAllocateWithoutInitializing("expectation_value"), _row_ptr.extent(0) - 1);
+        Kokkos::ViewAllocateWithoutInitializing("transition_amplitude"), _row_ptr.extent(0) - 1);
     std::uint64_t dim = states_bra.dim();
 
     Kokkos::parallel_for(

--- a/tests/operator/test_operator_batched.cpp
+++ b/tests/operator/test_operator_batched.cpp
@@ -107,6 +107,35 @@ TYPED_TEST(OperatorBatchedTest, TransitionAmplitudes) {
     }
 }
 
+TYPED_TEST(OperatorBatchedTest, TransitionAmplitudesBB) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    std::uint64_t n = 4;
+    std::uint64_t batch_size = 3;
+    Random random;
+    auto [op_batched, ops] = generate_random_observable_with_batch_size<Prec, Space>(batch_size, n);
+    StateVectorBatched<Prec, Space> states_bra(batch_size, n);
+    states_bra.set_Haar_random_state(false);
+    StateVectorBatched<Prec, Space> states_ket(batch_size, n);
+    states_ket.set_Haar_random_state(false);
+    auto state0_bra = states_bra.get_state_vector_at(0);
+    auto state1_bra = states_bra.get_state_vector_at(1);
+    auto state2_bra = states_bra.get_state_vector_at(2);
+    auto state0_ket = states_ket.get_state_vector_at(0);
+    auto state1_ket = states_ket.get_state_vector_at(1);
+    auto state2_ket = states_ket.get_state_vector_at(2);
+
+    auto res_batched = op_batched.get_transition_amplitude(states_bra, states_ket);
+    std::vector<StdComplex> res = {};
+    res.push_back(ops[0].get_transition_amplitude(state0_bra, state0_ket));
+    res.push_back(ops[1].get_transition_amplitude(state1_bra, state1_ket));
+    res.push_back(ops[2].get_transition_amplitude(state2_bra, state2_ket));
+    for (std::uint64_t b = 0; b < op_batched.batch_size(); ++b) {
+        ASSERT_NEAR(res[b].real(), res_batched[b].real(), eps<Prec>);
+        ASSERT_NEAR(res[b].imag(), res_batched[b].imag(), eps<Prec>);
+    }
+}
+
 TYPED_TEST(OperatorBatchedTest, ExpectationValues) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;

--- a/tests/operator/test_operator_batched.cpp
+++ b/tests/operator/test_operator_batched.cpp
@@ -50,6 +50,44 @@ generate_random_observable(int n) {
     return {OperatorBatched<Prec, Space>(rand_observable), std::move(test_rand_observable)};
 }
 
+template <Precision Prec, ExecutionSpace Space>
+std::pair<OperatorBatched<Prec, Space>, std::vector<Operator<Prec, Space>>>
+generate_random_observable_with_batch_size(std::uint64_t batch_size, int n) {
+    Random random;
+    std::vector<std::vector<PauliOperator<Prec>>> rand_observable;
+    std::vector<Operator<Prec, Space>> test_rand_observable;
+
+    for (std::uint64_t b = 0; b < batch_size; ++b) {
+        std::vector<PauliOperator<Prec>> ops;
+        std::uint64_t term_count = random.int32() % 10 + 1;
+        for (std::uint64_t term = 0; term < term_count; ++term) {
+            std::vector<std::uint64_t> paulis(n, 0);
+            double coef = random.uniform();
+            for (std::uint64_t i = 0; i < paulis.size(); ++i) {
+                paulis[i] = random.int32() % 4;
+            }
+
+            std::string str = "";
+            for (std::uint64_t ind = 0; ind < paulis.size(); ind++) {
+                std::uint64_t val = paulis[ind];
+                if (val != 0) {
+                    if (val == 1)
+                        str += " X";
+                    else if (val == 2)
+                        str += " Y";
+                    else if (val == 3)
+                        str += " Z";
+                    str += " " + std::to_string(ind);
+                }
+            }
+            ops.push_back(PauliOperator<Prec>(str.c_str(), coef));
+        }
+        rand_observable.push_back(ops);
+        test_rand_observable.push_back(Operator<Prec, Space>(ops));
+    }
+    return {OperatorBatched<Prec, Space>(rand_observable), std::move(test_rand_observable)};
+}
+
 TYPED_TEST(OperatorBatchedTest, TransitionAmplitudes) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;
@@ -83,6 +121,31 @@ TYPED_TEST(OperatorBatchedTest, ExpectationValues) {
         auto res = ops[b].get_expectation_value(state_vector);
         ASSERT_NEAR(res.real(), res_batched[b].real(), eps<Prec>);
         ASSERT_NEAR(res.imag(), res_batched[b].imag(), eps<Prec>);
+    }
+}
+
+TYPED_TEST(OperatorBatchedTest, ExpectationValuesBB) {
+    constexpr Precision Prec = TestFixture::Prec;
+    constexpr ExecutionSpace Space = TestFixture::Space;
+    std::uint64_t n = 4;
+    std::uint64_t batch_size = 3;
+    Random random;
+    auto [op_batched, ops] = generate_random_observable_with_batch_size<Prec, Space>(batch_size, n);
+    StateVectorBatched<Prec, Space> states(batch_size, n);
+    states.set_Haar_random_state(false);
+    auto state0 = states.get_state_vector_at(0);
+    auto state1 = states.get_state_vector_at(1);
+    auto state2 = states.get_state_vector_at(2);
+
+    auto res_batched = op_batched.get_expectation_value(states);
+    std::vector<StdComplex> res = {};
+    res.push_back(ops[0].get_expectation_value(state0));
+    res.push_back(ops[1].get_expectation_value(state1));
+    res.push_back(ops[2].get_expectation_value(state2));
+
+    for (std::uint64_t b = 0; b < op_batched.batch_size(); ++b) {
+        ASSERT_NEAR(res[b].real(), res_batched[b].real(), eps<Prec>);
+        ASSERT_NEAR(res[b].imag(), res_batched[b].imag(), eps<Prec>);
     }
 }
 


### PR DESCRIPTION
## Summary
Briefly describe the changes in this PR.  

バッチオペレータとバッチ状態ベクトルをバッチID対応で並列計算可能にした

## What was changed? (変更点)
- get_expectation_value()
- get_transition_amplitude()

に対応

## Why was this change needed? (変更理由)
- 多対多のバッチ実行を導入したい

## Additional context (optional)
- これにより異なる結合長についてのVQEを並列化できるのでは？
- ~~議論したいのでDraft~~
