### PR TITLE
Free Disk

### DIFF
--- a/.github/workflows/install_merge.yml
+++ b/.github/workflows/install_merge.yml
@@ -52,6 +52,19 @@ jobs:
       SCALUQ_FLOAT64: "ON"
       SCALUQ_BFLOAT16: ${{ matrix.compiler == 'clang' && 'OFF' || 'ON' }}
     steps:
+      - name: Free Disk Space (cuda)
+        if: ${{ matrix.device == 'cuda' }}
+        run: |
+          df -h
+          echo "Remove Android library"
+          sudo rm -rf /usr/local/lib/android
+          echo "Remove .NET runtime"
+          sudo rm -rf /usr/share/dotnet
+          echo "Remove Haskell runtime"
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          df -h
+
       - uses: actions/checkout@v6
 
       - name: Setup LLVM Clang (macOS clang)
@@ -171,6 +184,19 @@ jobs:
       SCALUQ_CPU_NATIVE: "OFF"
       SCALUQ_CUDA_ARCH: "TURING75"
     steps:
+      - name: Free Disk Space (cuda)
+        if: ${{ matrix.device == 'cuda' }}
+        run: |
+          df -h
+          echo "Remove Android library"
+          sudo rm -rf /usr/local/lib/android
+          echo "Remove .NET runtime"
+          sudo rm -rf /usr/share/dotnet
+          echo "Remove Haskell runtime"
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          df -h
+
       - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -55,6 +55,19 @@ jobs:
       SCALUQ_FLOAT64: "ON"
       SCALUQ_BFLOAT16: ${{ matrix.compiler == 'clang' && 'OFF' || 'ON' }}
     steps:
+      - name: Free Disk Space (cuda)
+        if: ${{ matrix.device == 'cuda' }}
+        run: |
+          df -h
+          echo "Remove Android library"
+          sudo rm -rf /usr/local/lib/android
+          echo "Remove .NET runtime"
+          sudo rm -rf /usr/share/dotnet
+          echo "Remove Haskell runtime"
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          df -h
+
       - uses: actions/checkout@v6
 
       - name: Setup LLVM Clang (macOS clang)

--- a/.github/workflows/test_changed.yml
+++ b/.github/workflows/test_changed.yml
@@ -55,19 +55,6 @@ jobs:
       SCALUQ_FLOAT64: "ON"
       SCALUQ_BFLOAT16: ${{ matrix.compiler == 'clang' && 'OFF' || 'ON' }}
     steps:
-      - name: Free Disk Space (cuda)
-        if: ${{ matrix.device == 'cuda' }}
-        run: |
-          df -h
-          echo "Remove Android library"
-          sudo rm -rf /usr/local/lib/android
-          echo "Remove .NET runtime"
-          sudo rm -rf /usr/share/dotnet
-          echo "Remove Haskell runtime"
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/.ghcup
-          df -h
-
       - uses: actions/checkout@v6
 
       - name: Setup LLVM Clang (macOS clang)
@@ -128,6 +115,19 @@ jobs:
         with:
           key: "${{ matrix.os-arch }}-${{ matrix.compiler }}-${{ matrix.device }}"
           verbose: 2
+
+      - name: Free Disk Space (cuda)
+        if: ${{ matrix.device == 'cuda' && (steps.check-build-files.outputs.any_changed == 'true' || steps.check-source-files.outputs.any_changed == 'true') }}
+        run: |
+          df -h
+          echo "Remove Android library"
+          sudo rm -rf /usr/local/lib/android
+          echo "Remove .NET runtime"
+          sudo rm -rf /usr/share/dotnet
+          echo "Remove Haskell runtime"
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          df -h
 
       - name: Install CUDA toolkit
         if: ${{ matrix.device == 'cuda' && (steps.check-build-files.outputs.any_changed == 'true' || steps.check-source-files.outputs.any_changed == 'true') }}

--- a/.github/workflows/test_changed.yml
+++ b/.github/workflows/test_changed.yml
@@ -55,6 +55,19 @@ jobs:
       SCALUQ_FLOAT64: "ON"
       SCALUQ_BFLOAT16: ${{ matrix.compiler == 'clang' && 'OFF' || 'ON' }}
     steps:
+      - name: Free Disk Space (cuda)
+        if: ${{ matrix.device == 'cuda' }}
+        run: |
+          df -h
+          echo "Remove Android library"
+          sudo rm -rf /usr/local/lib/android
+          echo "Remove .NET runtime"
+          sudo rm -rf /usr/share/dotnet
+          echo "Remove Haskell runtime"
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
+          df -h
+
       - uses: actions/checkout@v6
 
       - name: Setup LLVM Clang (macOS clang)

--- a/code-spell-checker-dictionary.txt
+++ b/code-spell-checker-dictionary.txt
@@ -37,6 +37,7 @@ fsanitize
 genindex
 googletest
 GROUPNAME
+ghcup
 gtest
 habs
 Hadamard


### PR DESCRIPTION
## Summary
Briefly describe the changes in this PR.  

`Install CUDA toolkit`のためのディスク容量不足で
CI落ちが増えているので、action中に不要なものは捨てるようにします。

## What was changed? (変更点)
- ディスク容量確保のために、`android, .NET, Haskell`を消す。

## Why was this change needed? (変更理由)
#378 からディスク容量の監視ができるみたいだったので、調査しました。
- `CUDA toolkit`のインストールにはディスク容量が20GB必要
- ランナーの割り当てでディスク容量72GBモデルと145GBモデルがある
- 落ちているのが大体72GBランナーと判明したので、その場合でも落ちないようにディスク容量を確保する 

## Additional context (optional)
- `jlumbroso/free-disk-space`のソースコードを参考にrmコマンドを入れています。

ubuntu-20.04.4のデータで古いのですが、以下のようにディスク容量を確保できるみたいです。
```
ubuntu-20.04.4
=> Android library: Saved 14GiB
=> .NET runtime: Saved 2.7GiB
=> Haskell runtime: Saved 0B
(=> Large misc. packages: Saved 5.3GiB
=> Tool cache: Saved 5.9GiB
=> Swap storage: Saved 4.0GiB

Total: Saved 31GiB)
```