### PR TITLE
未定義のゲートに対するJSON復元に対しエラーを投げる

### DIFF
--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -562,6 +562,7 @@ public:
         else if (type == "Pauli") gate = GetGateFromJson<PauliGateImpl<Prec>>::get(j);
         else if (type == "PauliRotation") gate = GetGateFromJson<PauliRotationGateImpl<Prec>>::get(j);
         else if (type == "Probabilistic") gate = GetGateFromJson<ProbabilisticGateImpl<Prec>>::get(j);
+        else throw std::runtime_error("GatePtr::from_json: unsupported gate type: " + type);
         // clang-format on
     }
 };

--- a/include/scaluq/gate/param_gate.hpp
+++ b/include/scaluq/gate/param_gate.hpp
@@ -366,6 +366,7 @@ public:
         else if (type == "ParamRZ") gate = GetParamGateFromJson<ParamRZGateImpl<Prec>>::get(j);
         else if (type == "ParamPauliRotation") gate = GetParamGateFromJson<ParamPauliRotationGateImpl<Prec>>::get(j);
         else if (type == "ParamProbabilistic") gate = GetParamGateFromJson<ParamProbabilisticGateImpl<Prec>>::get(j);
+        else throw std::runtime_error("ParamGatePtr::from_json: unsupported param gate type: " + type);
         // clang-format on
     }
 };

--- a/tests/gate/gate_test.cpp
+++ b/tests/gate/gate_test.cpp
@@ -890,8 +890,7 @@ TYPED_TEST(GateTest, GateJsonRejectsUnsupportedType) {
 
     const Json j = {{"type", "UnsupportedGate"}};
 
-    EXPECT_THROW({ [[maybe_unused]] Gate<Prec> gate = j.template get<Gate<Prec>>(); },
-                 std::runtime_error);
+    EXPECT_THROW({ (void)j.template get<Gate<Prec>>(); }, std::runtime_error);
 }
 
 TYPED_TEST(GateTest, FlattenNestedProbabilisticGate) {

--- a/tests/gate/gate_test.cpp
+++ b/tests/gate/gate_test.cpp
@@ -885,6 +885,15 @@ TYPED_TEST(GateTest, UGateJsonRoundTrip) {
     }
 }
 
+TYPED_TEST(GateTest, GateJsonRejectsUnsupportedType) {
+    constexpr Precision Prec = TestFixture::Prec;
+
+    const Json j = {{"type", "UnsupportedGate"}};
+
+    EXPECT_THROW({ [[maybe_unused]] Gate<Prec> gate = j.template get<Gate<Prec>>(); },
+                 std::runtime_error);
+}
+
 TYPED_TEST(GateTest, FlattenNestedProbabilisticGate) {
     constexpr Precision Prec = TestFixture::Prec;
     Gate<Prec> nested_gate = gate::Probabilistic<Prec>(

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -138,6 +138,15 @@ TYPED_TEST(ParamGateTest, ParamGateJsonRoundtripPreservesControlValue) {
     test_param_gate_json_roundtrip_preserves_control_value<Prec, Space>(&gate::ParamRZ<Prec>);
 }
 
+TYPED_TEST(ParamGateTest, ParamGateJsonRejectsUnsupportedType) {
+    constexpr Precision Prec = TestFixture::Prec;
+
+    const Json j = {{"type", "UnsupportedParamGate"}};
+
+    EXPECT_THROW({ [[maybe_unused]] ParamGate<Prec> gate = j.template get<ParamGate<Prec>>(); },
+                 std::runtime_error);
+}
+
 TYPED_TEST(ParamGateTest, ApplyParamPauliRotationGate) {
     constexpr Precision Prec = TestFixture::Prec;
     constexpr ExecutionSpace Space = TestFixture::Space;

--- a/tests/gate/param_gate_test.cpp
+++ b/tests/gate/param_gate_test.cpp
@@ -143,8 +143,7 @@ TYPED_TEST(ParamGateTest, ParamGateJsonRejectsUnsupportedType) {
 
     const Json j = {{"type", "UnsupportedParamGate"}};
 
-    EXPECT_THROW({ [[maybe_unused]] ParamGate<Prec> gate = j.template get<ParamGate<Prec>>(); },
-                 std::runtime_error);
+    EXPECT_THROW({ (void)j.template get<ParamGate<Prec>>(); }, std::runtime_error);
 }
 
 TYPED_TEST(ParamGateTest, ApplyParamPauliRotationGate) {


### PR DESCRIPTION
## Summary
Gate / ParamGate の JSON 復元時に、未対応の `type` を明示的に拒否するようにしました。

## What was changed? (変更点)
- 未対応のゲート種別に対して `std::runtime_error` を投げる分岐を追加
- 未対応 `type` の JSON 復元が例外になることを確認するテストを追加

## Why was this change needed? (変更理由)
- 未対応 `type` が null gate として生成され、後続処理で分かりにくいエラーになるのを防ぐため