### PR TITLE
Refactor 202607

### DIFF
--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -488,7 +488,8 @@ public:
         } else {
             // downcast
             _gate_type = get_gate_type<T, Prec>();
-            if (!(_gate_ptr = std::dynamic_pointer_cast<const T>(gate_ptr))) {
+            _gate_ptr = std::dynamic_pointer_cast<const T>(gate_ptr);
+            if (!_gate_ptr) {
                 throw std::runtime_error("invalid gate cast");
             }
         }

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -258,6 +258,10 @@ public:
              std::uint64_t control_mask,
              std::uint64_t control_value_mask);
     virtual ~GateBase() = default;
+    GateBase(const GateBase&) = delete;
+    GateBase(GateBase&&) = delete;
+    GateBase& operator=(const GateBase&) = delete;
+    GateBase& operator=(GateBase&&) = delete;
 
     [[nodiscard]] virtual std::vector<std::uint64_t> target_qubit_list() const {
         return mask_to_vector(_target_mask);

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -203,26 +203,28 @@ constexpr GateType get_gate_type() {
 namespace internal {
 template <Precision Prec, ExecutionSpace Space>
 struct ExecutionContext {
-    StateVector<Prec, Space>& state;
-    ClassicalRegister& classical_register;
-    std::mt19937_64& random_engine;
+    StateVector<Prec, Space>* state;
+    ClassicalRegister* classical_register;
+    std::mt19937_64* random_engine;
 
     ExecutionContext(StateVector<Prec, Space>& state_,
                      ClassicalRegister& classical_register_,
                      std::mt19937_64& random_engine_)
-        : state(state_), classical_register(classical_register_), random_engine(random_engine_) {}
+        : state(&state_), classical_register(&classical_register_), random_engine(&random_engine_) {}
 };
 
 template <Precision Prec, ExecutionSpace Space>
 struct ExecutionContextBatched {
-    StateVectorBatched<Prec, Space>& states;
-    ClassicalRegisterBatched& classical_register;
-    std::mt19937_64& random_engine;
+    StateVectorBatched<Prec, Space>* states;
+    ClassicalRegisterBatched* classical_register;
+    std::mt19937_64* random_engine;
 
     ExecutionContextBatched(StateVectorBatched<Prec, Space>& states_,
                             ClassicalRegisterBatched& classical_register_,
                             std::mt19937_64& random_engine_)
-        : states(states_), classical_register(classical_register_), random_engine(random_engine_) {}
+        : states(&states_),
+          classical_register(&classical_register_),
+          random_engine(&random_engine_) {}
 };
 
 // GateBase テンプレートクラス

--- a/include/scaluq/gate/gate_pauli.hpp
+++ b/include/scaluq/gate/gate_pauli.hpp
@@ -11,7 +11,7 @@ namespace internal {
 
 template <Precision Prec>
 class PauliGateImpl : public GateBase<Prec> {
-    const PauliOperator<Prec> _pauli;
+    PauliOperator<Prec> _pauli;
 
 public:
     PauliGateImpl(std::uint64_t control_mask,
@@ -58,8 +58,8 @@ public:
 
 template <Precision Prec>
 class PauliRotationGateImpl : public GateBase<Prec> {
-    const PauliOperator<Prec> _pauli;
-    const Float<Prec> _angle;
+    PauliOperator<Prec> _pauli;
+    Float<Prec> _angle;
 
 public:
     PauliRotationGateImpl(std::uint64_t control_mask,

--- a/include/scaluq/gate/param_gate.hpp
+++ b/include/scaluq/gate/param_gate.hpp
@@ -88,6 +88,10 @@ public:
                   std::uint64_t control_value_mask,
                   Float<Prec> param_coef = 1);
     virtual ~ParamGateBase() = default;
+    ParamGateBase(const ParamGateBase&) = delete;
+    ParamGateBase(ParamGateBase&&) = delete;
+    ParamGateBase& operator=(const ParamGateBase&) = delete;
+    ParamGateBase& operator=(ParamGateBase&&) = delete;
 
     [[nodiscard]] double param_coef() const { return _pcoef; }
 

--- a/include/scaluq/gate/param_gate.hpp
+++ b/include/scaluq/gate/param_gate.hpp
@@ -317,7 +317,8 @@ public:
         } else {
             // downcast
             _param_gate_type = get_param_gate_type<T, Prec>();
-            if (!(_param_gate_ptr = std::dynamic_pointer_cast<const T>(param_gate_ptr))) {
+            _param_gate_ptr = std::dynamic_pointer_cast<const T>(param_gate_ptr);
+            if (!_param_gate_ptr) {
                 throw std::runtime_error("invalid gate cast");
             }
         }

--- a/include/scaluq/gate/param_gate_pauli.hpp
+++ b/include/scaluq/gate/param_gate_pauli.hpp
@@ -10,7 +10,7 @@ namespace scaluq {
 namespace internal {
 template <Precision Prec>
 class ParamPauliRotationGateImpl : public ParamGateBase<Prec> {
-    const PauliOperator<Prec> _pauli;
+    PauliOperator<Prec> _pauli;
 
 public:
     ParamPauliRotationGateImpl(std::uint64_t control_mask,

--- a/include/scaluq/operator/operator_batched.hpp
+++ b/include/scaluq/operator/operator_batched.hpp
@@ -136,8 +136,8 @@ public:
     }
 
 private:
-    Kokkos::View<PauliOperator<Prec>*, ExecutionSpaceType> _ops;
-    Kokkos::View<std::uint64_t*, Kokkos::SharedSpace> _row_ptr;
+    Kokkos::View<PauliOperator<Prec>*, ExecutionSpaceType> _ops{};
+    Kokkos::View<std::uint64_t*, Kokkos::SharedSpace> _row_ptr{};
 };
 
 #ifdef SCALUQ_USE_NANOBIND

--- a/include/scaluq/state/density_matrix.hpp
+++ b/include/scaluq/state/density_matrix.hpp
@@ -7,9 +7,9 @@ namespace scaluq {
 
 template <Precision Prec, ExecutionSpace Space>
 class DensityMatrix {
-    std::uint64_t _n_qubits;
-    std::uint64_t _dim;
-    bool _is_hermitian;
+    std::uint64_t _n_qubits = 0;
+    std::uint64_t _dim = 0;
+    bool _is_hermitian = false;
     using FloatType = internal::Float<Prec>;
     using ComplexType = internal::Complex<Prec>;
     using ExecutionSpaceType = internal::SpaceType<Space>;

--- a/include/scaluq/state/density_matrix.hpp
+++ b/include/scaluq/state/density_matrix.hpp
@@ -24,9 +24,6 @@ public:
     DensityMatrix(std::uint64_t n_qubits);
     DensityMatrix(Kokkos::View<ComplexType**, ExecutionSpaceType> view, bool is_hermitian = false);
     DensityMatrix(const StateVector<Prec, Space>& other);
-    DensityMatrix(const DensityMatrix& other) = default;
-
-    DensityMatrix& operator=(const DensityMatrix& other) = default;
 
     [[nodiscard]] std::uint64_t n_qubits() const { return this->_n_qubits; }
 

--- a/include/scaluq/state/state_vector.hpp
+++ b/include/scaluq/state/state_vector.hpp
@@ -16,8 +16,8 @@ namespace scaluq {
 
 template <Precision Prec, ExecutionSpace Space>
 class StateVector {
-    std::uint64_t _n_qubits;
-    std::uint64_t _dim;
+    std::uint64_t _n_qubits = 0;
+    std::uint64_t _dim = 0;
     using FloatType = internal::Float<Prec>;
     using ComplexType = internal::Complex<Prec>;
     using ExecutionSpaceType = internal::SpaceType<Space>;

--- a/include/scaluq/state/state_vector.hpp
+++ b/include/scaluq/state/state_vector.hpp
@@ -28,9 +28,6 @@ public:
     StateVector() = default;
     StateVector(std::uint64_t n_qubits);
     StateVector(Kokkos::View<ComplexType*, ExecutionSpaceType> view);
-    StateVector(const StateVector& other) = default;
-
-    StateVector& operator=(const StateVector& other) = default;
 
     /**
      * @attention Very slow. You should use load() instead if you can.

--- a/include/scaluq/state/state_vector_batched.hpp
+++ b/include/scaluq/state/state_vector_batched.hpp
@@ -9,9 +9,9 @@ namespace scaluq {
 
 template <Precision Prec, ExecutionSpace Space>
 class StateVectorBatched {
-    std::uint64_t _batch_size;
-    std::uint64_t _n_qubits;
-    std::uint64_t _dim;
+    std::uint64_t _batch_size = 0;
+    std::uint64_t _n_qubits = 0;
+    std::uint64_t _dim = 0;
     using FloatType = internal::Float<Prec>;
     using ComplexType = internal::Complex<Prec>;
     using ExecutionSpaceType = internal::SpaceType<Space>;

--- a/include/scaluq/state/state_vector_batched.hpp
+++ b/include/scaluq/state/state_vector_batched.hpp
@@ -20,9 +20,6 @@ public:
     Kokkos::View<ComplexType**, Kokkos::LayoutRight, ExecutionSpaceType> _raw;
     StateVectorBatched() = default;
     StateVectorBatched(std::uint64_t batch_size, std::uint64_t n_qubits);
-    StateVectorBatched(const StateVectorBatched& other) = default;
-
-    StateVectorBatched& operator=(const StateVectorBatched& other) = default;
 
     [[nodiscard]] std::uint64_t n_qubits() const { return this->_n_qubits; }
 

--- a/include/scaluq/type/complex.hpp
+++ b/include/scaluq/type/complex.hpp
@@ -24,16 +24,9 @@ public:
          std::is_same_v<Scalar2, int>)KOKKOS_INLINE_FUNCTION Complex(Scalar1 real, Scalar2 imag)
         : _real(static_cast<FloatType>(real)),
     _imag(static_cast<FloatType>(imag)) {}
-    KOKKOS_INLINE_FUNCTION Complex(const Complex& other)
-        : _real(other.real()), _imag(other.imag()) {}
     KOKKOS_INLINE_FUNCTION Complex(const std::complex<double>& c)
         : _real(static_cast<FloatType>(c.real())), _imag(static_cast<FloatType>(c.imag())) {}
 
-    KOKKOS_INLINE_FUNCTION Complex& operator=(const Complex& other) {
-        _real = other._real;
-        _imag = other._imag;
-        return *this;
-    }
     KOKKOS_INLINE_FUNCTION Complex& operator=(const std::complex<double>& c) {
         _real = static_cast<FloatType>(c.real());
         _imag = static_cast<FloatType>(c.imag());

--- a/include/scaluq/util/utility.hpp
+++ b/include/scaluq/util/utility.hpp
@@ -230,14 +230,12 @@ inline SparseComplexMatrix transform_sparse_matrix_by_order(
 
 template <Precision Prec>
 constexpr double get_epsilon() {
-    if constexpr (Prec == Precision::F16)
+    if constexpr (Prec == Precision::F16 || Prec == Precision::BF16)
         return 1.;
     else if constexpr (Prec == Precision::F32)
         return 1e-4;
     else if constexpr (Prec == Precision::F64)
         return 1e-12;
-    else if constexpr (Prec == Precision::BF16)
-        return 1.;
     else
         static_assert(internal::lazy_false_v<internal::Float<Prec>>, "unknown Precision");
 }

--- a/src/circuit/circuit.cpp
+++ b/src/circuit/circuit.cpp
@@ -108,8 +108,8 @@ void Circuit<Prec>::update_quantum_state(StateVector<Prec, Space>& state,
     std::uint64_t unreset_measured_qubit_mask = 0ULL;
     internal::ExecutionContext<Prec, Space> context{state, classical_register, random_engine};
     for (std::uint64_t idx = 0; idx < _gate_list.size(); ++idx) {
-        if (_classical_conditions[idx].has_value() &&
-            !_classical_conditions[idx].value()(classical_register)) {
+        const auto& classical_condition = _classical_conditions[idx];
+        if (classical_condition && !(*classical_condition)(classical_register)) {
             continue;
         }
         auto&& gate = _gate_list[idx];

--- a/src/gate/gate_matrix.cpp
+++ b/src/gate/gate_matrix.cpp
@@ -47,12 +47,12 @@ std::string DenseMatrixGateImpl<Prec, Space>::to_string(const std::string& inden
     void DenseMatrixGateImpl<Prec, GateSpace>::update_quantum_state(                        \
         ContextClass<Prec, TargetSpace>& context) const {                                    \
         if constexpr (GateSpace == TargetSpace) {                                           \
-            this->check_qubit_mask_within_bounds(context.state_member);                     \
+            this->check_qubit_mask_within_bounds(*context.state_member);                     \
             dense_matrix_gate(this->_target_mask,                                           \
                               this->_control_mask,                                          \
                               this->_control_value_mask,                                    \
                               _matrix,                                                      \
-                              context.state_member);                                        \
+                              *context.state_member);                                        \
         } else {                                                                            \
             throw std::runtime_error(                                                       \
                 "Error: DenseMatrixGateImpl::update_quantum_state(" #ContextClass           \
@@ -116,12 +116,12 @@ std::string SparseMatrixGateImpl<Prec, Space>::to_string(const std::string& inde
     void SparseMatrixGateImpl<Prec, GateSpace>::update_quantum_state(                       \
         ContextClass<Prec, TargetSpace>& context) const {                                    \
         if constexpr (GateSpace == TargetSpace) {                                           \
-            this->check_qubit_mask_within_bounds(context.state_member);                     \
+            this->check_qubit_mask_within_bounds(*context.state_member);                     \
             sparse_matrix_gate(this->_target_mask,                                          \
                                this->_control_mask,                                         \
                                this->_control_value_mask,                                   \
                                _matrix,                                                     \
-                               context.state_member);                                       \
+                               *context.state_member);                                       \
         } else {                                                                            \
             throw std::runtime_error(                                                       \
                 "Error: SparseMatrixGateImpl::update_quantum_state(" #ContextClass          \

--- a/src/gate/gate_measurement.cpp
+++ b/src/gate/gate_measurement.cpp
@@ -46,35 +46,35 @@ bool apply_measurement_update(StateVector<Prec, Space>& state,
     template <Precision Prec>                                                                   \
     void MeasurementGateImpl<Prec>::update_quantum_state(ExecutionContext<Prec, Space>& context) \
         const {                                                                                 \
-        this->check_qubit_mask_within_bounds(context.state);                                    \
-        if (context.classical_register.register_size() <= _classical_bit_index) {               \
+        this->check_qubit_mask_within_bounds(*context.state);                                   \
+        if (context.classical_register->register_size() <= _classical_bit_index) {              \
             throw std::runtime_error(                                                           \
                 "MeasurementGate::update_quantum_state(): classical register size is too "      \
                 "small for the requested classical bit index.");                                \
         }                                                                                       \
         const bool measured_zero = apply_measurement_update(                                    \
-            context.state, context.random_engine, this->_target_mask, _reset);                  \
-        context.classical_register[_classical_bit_index] = !measured_zero;                      \
+            *context.state, *context.random_engine, this->_target_mask, _reset);                \
+        (*context.classical_register)[_classical_bit_index] = !measured_zero;                   \
     }                                                                                           \
     template <Precision Prec>                                                                   \
     void MeasurementGateImpl<Prec>::update_quantum_state(                                       \
         ExecutionContextBatched<Prec, Space>& context) const {                                   \
-        this->check_qubit_mask_within_bounds(context.states);                                   \
-        if (context.classical_register.batch_size() != context.states.batch_size()) {           \
+        this->check_qubit_mask_within_bounds(*context.states);                                  \
+        if (context.classical_register->batch_size() != context.states->batch_size()) {         \
             throw std::runtime_error(                                                           \
                 "MeasurementGate::update_quantum_state(): batch size mismatch.");               \
         }                                                                                       \
-        if (context.classical_register.register_size() <= _classical_bit_index) {               \
+        if (context.classical_register->register_size() <= _classical_bit_index) {              \
             throw std::runtime_error(                                                           \
                 "MeasurementGate::update_quantum_state(): classical register size is too "      \
                 "small for the requested classical bit index.");                                \
         }                                                                                       \
-        for (std::uint64_t batch_index = 0; batch_index < context.states.batch_size();          \
+        for (std::uint64_t batch_index = 0; batch_index < context.states->batch_size();         \
              ++batch_index) {                                                                   \
-            auto state = context.states.view_state_vector_at(batch_index);                      \
+            auto state = context.states->view_state_vector_at(batch_index);                     \
             const bool measured_zero = apply_measurement_update(                                \
-                state, context.random_engine, this->_target_mask, _reset);                      \
-            context.classical_register[batch_index][_classical_bit_index] = !measured_zero;     \
+                state, *context.random_engine, this->_target_mask, _reset);                     \
+            (*context.classical_register)[batch_index][_classical_bit_index] = !measured_zero;  \
         }                                                                                       \
     }
 DEFINE_MEASUREMENT_GATE_UPDATE(ExecutionSpace::Host)

--- a/src/gate/gate_pauli.cpp
+++ b/src/gate/gate_pauli.cpp
@@ -24,7 +24,7 @@ std::string PauliGateImpl<Prec>::to_string(const std::string& indent) const {
                     bit_flip_mask,                                                           \
                     phase_flip_mask,                                                         \
                     Complex<Prec>(_pauli.coef()),                                            \
-                    context.state_member);                                                   \
+                    *context.state_member);                                                   \
     }
 DEFINE_PAULI_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_PAULI_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -71,7 +71,7 @@ std::string PauliRotationGateImpl<Prec>::to_string(const std::string& indent) co
                              phase_flip_mask,                                                \
                              Complex<Prec>(_pauli.coef()),                                   \
                              _angle,                                                         \
-                             context.state_member);                                          \
+                             *context.state_member);                                          \
     }
 DEFINE_PAULI_ROTATION_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_PAULI_ROTATION_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)

--- a/src/gate/gate_probabilistic.cpp
+++ b/src/gate/gate_probabilistic.cpp
@@ -10,7 +10,7 @@ std::uint64_t select_probabilistic_gate_index(const std::vector<double>& cumulat
     std::uniform_real_distribution<double> dist(0., 1.);
     std::uint64_t i = std::distance(cumulative_distribution.begin(),
                                     std::ranges::upper_bound(cumulative_distribution,
-                                                             dist(context.random_engine))) -
+                                                             dist(*context.random_engine))) -
                       1;
     return std::min<std::uint64_t>(i, cumulative_distribution.size() - 2);
 }
@@ -109,12 +109,12 @@ std::string ProbabilisticGateImpl<Prec>::to_string(const std::string& indent) co
     template <Precision Prec>                                                                     \
     void ProbabilisticGateImpl<Prec>::update_quantum_state(                                       \
         ExecutionContextBatched<Prec, Space>& context) const {                                     \
-        for (std::size_t i = 0; i < context.states.batch_size(); ++i) {                           \
-            auto state_vector = context.states.view_state_vector_at(i);                           \
+        for (std::size_t i = 0; i < context.states->batch_size(); ++i) {                           \
+            auto state_vector = context.states->view_state_vector_at(i);                           \
             ExecutionContext<Prec, Space> state_context{                                          \
                 state_vector,                                                                      \
-                context.classical_register[i],                                                     \
-                context.random_engine};                                                            \
+                (*context.classical_register)[i],                                                     \
+                *context.random_engine};                                                            \
             this->update_quantum_state(state_context);                                             \
         }                                                                                         \
     }

--- a/src/gate/gate_standard.cpp
+++ b/src/gate/gate_standard.cpp
@@ -21,7 +21,7 @@ std::string IGateImpl<Prec>::to_string(const std::string& indent) const {
         i_gate(this->_target_mask,                                                         \
                this->_control_mask,                                                        \
                this->_control_value_mask,                                                  \
-               context.state_member);                                                      \
+               *context.state_member);                                                      \
     }
 DEFINE_I_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_I_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -50,12 +50,12 @@ std::string GlobalPhaseGateImpl<Prec>::to_string(const std::string& indent) cons
     template <Precision Prec>                                                                \
     void GlobalPhaseGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) \
         const {                                                                              \
-        this->check_qubit_mask_within_bounds(context.state_member);                          \
+        this->check_qubit_mask_within_bounds(*context.state_member);                          \
         global_phase_gate(this->_target_mask,                                                \
                           this->_control_mask,                                               \
                           this->_control_value_mask,                                         \
                           this->_phase,                                                      \
-                          context.state_member);                                             \
+                          *context.state_member);                                             \
     }
 DEFINE_GLOBAL_PHASE_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_GLOBAL_PHASE_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -84,11 +84,11 @@ std::string XGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_X_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                              \
     void XGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        this->check_qubit_mask_within_bounds(*context.state_member);                        \
         x_gate(this->_target_mask,                                                         \
                this->_control_mask,                                                        \
                this->_control_value_mask,                                                  \
-               context.state_member);                                                      \
+               *context.state_member);                                                      \
     }
 DEFINE_X_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_X_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -117,11 +117,11 @@ std::string YGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_Y_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                              \
     void YGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        this->check_qubit_mask_within_bounds(*context.state_member);                        \
         y_gate(this->_target_mask,                                                         \
                this->_control_mask,                                                        \
                this->_control_value_mask,                                                  \
-               context.state_member);                                                      \
+               *context.state_member);                                                      \
     }
 DEFINE_Y_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_Y_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -150,11 +150,11 @@ std::string ZGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_Z_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                              \
     void ZGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        this->check_qubit_mask_within_bounds(*context.state_member);                        \
         z_gate(this->_target_mask,                                                         \
                this->_control_mask,                                                        \
                this->_control_value_mask,                                                  \
-               context.state_member);                                                      \
+               *context.state_member);                                                      \
     }
 DEFINE_Z_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_Z_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -184,11 +184,11 @@ std::string HGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_H_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                              \
     void HGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        this->check_qubit_mask_within_bounds(*context.state_member);                        \
         h_gate(this->_target_mask,                                                         \
                this->_control_mask,                                                        \
                this->_control_value_mask,                                                  \
-               context.state_member);                                                      \
+               *context.state_member);                                                      \
     }
 DEFINE_H_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_H_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -217,11 +217,11 @@ std::string SGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_S_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                              \
     void SGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        this->check_qubit_mask_within_bounds(*context.state_member);                        \
         s_gate(this->_target_mask,                                                         \
                this->_control_mask,                                                        \
                this->_control_value_mask,                                                  \
-               context.state_member);                                                      \
+               *context.state_member);                                                      \
     }
 DEFINE_S_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_S_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -250,11 +250,11 @@ std::string SdagGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_S_DAG_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                                 \
     void SdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                           \
+        this->check_qubit_mask_within_bounds(*context.state_member);                           \
         sdag_gate(this->_target_mask,                                                         \
                   this->_control_mask,                                                        \
                   this->_control_value_mask,                                                  \
-                  context.state_member);                                                      \
+                  *context.state_member);                                                      \
     }
 DEFINE_S_DAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_S_DAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -283,11 +283,11 @@ std::string TGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_T_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                              \
     void TGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                        \
+        this->check_qubit_mask_within_bounds(*context.state_member);                        \
         t_gate(this->_target_mask,                                                         \
                this->_control_mask,                                                        \
                this->_control_value_mask,                                                  \
-               context.state_member);                                                      \
+               *context.state_member);                                                      \
     }
 DEFINE_T_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_T_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -316,11 +316,11 @@ std::string TdagGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_T_DAG_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                                 \
     void TdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                           \
+        this->check_qubit_mask_within_bounds(*context.state_member);                           \
         tdag_gate(this->_target_mask,                                                         \
                   this->_control_mask,                                                        \
                   this->_control_value_mask,                                                  \
-                  context.state_member);                                                      \
+                  *context.state_member);                                                      \
     }
 DEFINE_T_DAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_T_DAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -349,11 +349,11 @@ std::string SqrtXGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_SQRT_X_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                                  \
     void SqrtXGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                            \
+        this->check_qubit_mask_within_bounds(*context.state_member);                            \
         sqrtx_gate(this->_target_mask,                                                         \
                    this->_control_mask,                                                        \
                    this->_control_value_mask,                                                  \
-                   context.state_member);                                                      \
+                   *context.state_member);                                                      \
     }
 DEFINE_SQRT_X_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_SQRT_X_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -382,11 +382,11 @@ std::string SqrtXdagGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_SQRT_XDAG_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                                     \
     void SqrtXdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                               \
+        this->check_qubit_mask_within_bounds(*context.state_member);                               \
         sqrtxdag_gate(this->_target_mask,                                                         \
                       this->_control_mask,                                                        \
                       this->_control_value_mask,                                                  \
-                      context.state_member);                                                      \
+                      *context.state_member);                                                      \
     }
 DEFINE_SQRT_XDAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_SQRT_XDAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -415,11 +415,11 @@ std::string SqrtYGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_SQRT_Y_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                                  \
     void SqrtYGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                            \
+        this->check_qubit_mask_within_bounds(*context.state_member);                            \
         sqrty_gate(this->_target_mask,                                                         \
                    this->_control_mask,                                                        \
                    this->_control_value_mask,                                                  \
-                   context.state_member);                                                      \
+                   *context.state_member);                                                      \
     }
 DEFINE_SQRT_Y_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_SQRT_Y_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -448,11 +448,11 @@ std::string SqrtYdagGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_SQRT_YDAG_GATE_UPDATE(ContextClass, state_member, Space)                           \
     template <Precision Prec>                                                                     \
     void SqrtYdagGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                               \
+        this->check_qubit_mask_within_bounds(*context.state_member);                               \
         sqrtydag_gate(this->_target_mask,                                                         \
                       this->_control_mask,                                                        \
                       this->_control_value_mask,                                                  \
-                      context.state_member);                                                      \
+                      *context.state_member);                                                      \
     }
 DEFINE_SQRT_YDAG_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_SQRT_YDAG_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -481,11 +481,11 @@ std::string P0GateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_P0_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                               \
     void P0GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        this->check_qubit_mask_within_bounds(*context.state_member);                         \
         p0_gate(this->_target_mask,                                                         \
                 this->_control_mask,                                                        \
                 this->_control_value_mask,                                                  \
-                context.state_member);                                                      \
+                *context.state_member);                                                      \
     }
 DEFINE_P0_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_P0_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -514,11 +514,11 @@ std::string P1GateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_P1_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                               \
     void P1GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        this->check_qubit_mask_within_bounds(*context.state_member);                         \
         p1_gate(this->_target_mask,                                                         \
                 this->_control_mask,                                                        \
                 this->_control_value_mask,                                                  \
-                context.state_member);                                                      \
+                *context.state_member);                                                      \
     }
 DEFINE_P1_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_P1_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -550,12 +550,12 @@ std::string RXGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_RX_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                               \
     void RXGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        this->check_qubit_mask_within_bounds(*context.state_member);                         \
         rx_gate(this->_target_mask,                                                         \
                 this->_control_mask,                                                        \
                 this->_control_value_mask,                                                  \
                 this->_angle,                                                               \
-                context.state_member);                                                      \
+                *context.state_member);                                                      \
     }
 DEFINE_RX_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_RX_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -586,12 +586,12 @@ std::string RYGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_RY_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                               \
     void RYGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        this->check_qubit_mask_within_bounds(*context.state_member);                         \
         ry_gate(this->_target_mask,                                                         \
                 this->_control_mask,                                                        \
                 this->_control_value_mask,                                                  \
                 this->_angle,                                                               \
-                context.state_member);                                                      \
+                *context.state_member);                                                      \
     }
 DEFINE_RY_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_RY_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -622,12 +622,12 @@ std::string RZGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_RZ_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                               \
     void RZGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        this->check_qubit_mask_within_bounds(*context.state_member);                         \
         rz_gate(this->_target_mask,                                                         \
                 this->_control_mask,                                                        \
                 this->_control_value_mask,                                                  \
                 this->_angle,                                                               \
-                context.state_member);                                                      \
+                *context.state_member);                                                      \
     }
 DEFINE_RZ_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_RZ_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -657,12 +657,12 @@ std::string U1GateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_U1_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                               \
     void U1GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        this->check_qubit_mask_within_bounds(*context.state_member);                         \
         u1_gate(this->_target_mask,                                                         \
                 this->_control_mask,                                                        \
                 this->_control_value_mask,                                                  \
                 this->_lambda,                                                              \
-                context.state_member);                                                      \
+                *context.state_member);                                                      \
     }
 DEFINE_U1_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_U1_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -698,13 +698,13 @@ std::string U2GateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_U2_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                               \
     void U2GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        this->check_qubit_mask_within_bounds(*context.state_member);                         \
         u2_gate(this->_target_mask,                                                         \
                 this->_control_mask,                                                        \
                 this->_control_value_mask,                                                  \
                 this->_phi,                                                                 \
                 this->_lambda,                                                              \
-                context.state_member);                                                      \
+                *context.state_member);                                                      \
     }
 DEFINE_U2_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_U2_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -743,14 +743,14 @@ std::string U3GateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_U3_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                               \
     void U3GateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                         \
+        this->check_qubit_mask_within_bounds(*context.state_member);                         \
         u3_gate(this->_target_mask,                                                         \
                 this->_control_mask,                                                        \
                 this->_control_value_mask,                                                  \
                 this->_theta,                                                               \
                 this->_phi,                                                                 \
                 this->_lambda,                                                              \
-                context.state_member);                                                      \
+                *context.state_member);                                                      \
     }
 DEFINE_U3_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_U3_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -779,11 +779,11 @@ std::string SwapGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_SWAP_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                                 \
     void SwapGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                           \
+        this->check_qubit_mask_within_bounds(*context.state_member);                           \
         swap_gate(this->_target_mask,                                                         \
                   this->_control_mask,                                                        \
                   this->_control_value_mask,                                                  \
-                  context.state_member);                                                      \
+                  *context.state_member);                                                      \
     }
 DEFINE_SWAP_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_SWAP_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -848,12 +848,12 @@ std::string EcrGateImpl<Prec>::to_string(const std::string& indent) const {
 #define DEFINE_ECR_GATE_UPDATE(ContextClass, state_member, Space)                            \
     template <Precision Prec>                                                                \
     void EcrGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) const { \
-        this->check_qubit_mask_within_bounds(context.state_member);                          \
+        this->check_qubit_mask_within_bounds(*context.state_member);                          \
         ecr_gate(this->_physical_target_mask,                                                \
                  this->_physical_control_mask,                                               \
                  this->_control_mask,                                                        \
                  this->_control_value_mask,                                                  \
-                 context.state_member);                                                      \
+                 *context.state_member);                                                      \
     }
 DEFINE_ECR_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_ECR_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)
@@ -905,8 +905,8 @@ std::string PermutationGateImpl<Prec>::to_string(const std::string& indent) cons
     template <Precision Prec>                                                                \
     void PermutationGateImpl<Prec>::update_quantum_state(ContextClass<Prec, Space>& context) \
         const {                                                                              \
-        this->check_qubit_mask_within_bounds(context.state_member);                          \
-        permutation_gate(this->_swap_schedule, context.state_member);                        \
+        this->check_qubit_mask_within_bounds(*context.state_member);                          \
+        permutation_gate(this->_swap_schedule, *context.state_member);                        \
     }
 DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContext, state, ExecutionSpace::Host)
 DEFINE_PERMUTATION_GATE_UPDATE(ExecutionContextBatched, states, ExecutionSpace::Host)

--- a/src/gate/param_gate_pauli.cpp
+++ b/src/gate/param_gate_pauli.cpp
@@ -28,7 +28,7 @@ std::string ParamPauliRotationGateImpl<Prec>::to_string(const std::string& inden
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::Host>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
                          this->_control_value_mask,
@@ -36,13 +36,13 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          phase_flip_mask,
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef * static_cast<Float<Prec>>(param),
-                         context.state);
+                         *context.state);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
@@ -58,12 +58,12 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef,
                          params_view,
-                         context.states);
+                         *context.states);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::HostSerial>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
                          this->_control_value_mask,
@@ -71,13 +71,13 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          phase_flip_mask,
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef * static_cast<Float<Prec>>(param),
-                         context.state);
+                         *context.state);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
@@ -93,13 +93,13 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef,
                          params_view,
-                         context.states);
+                         *context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::Default>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     apply_pauli_rotation(this->_control_mask,
                          this->_control_value_mask,
@@ -107,13 +107,13 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          phase_flip_mask,
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef * static_cast<Float<Prec>>(param),
-                         context.state);
+                         *context.state);
 }
 template <Precision Prec>
 void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     auto [bit_flip_mask, phase_flip_mask] = _pauli.get_XZ_mask_representation();
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
@@ -130,7 +130,7 @@ void ParamPauliRotationGateImpl<Prec>::update_quantum_state(
                          Complex<Prec>(_pauli.coef()),
                          this->_pcoef,
                          params_view,
-                         context.states);
+                         *context.states);
 }
 #endif
 template class ParamPauliRotationGateImpl<Prec>;

--- a/src/gate/param_gate_probabilistic.cpp
+++ b/src/gate/param_gate_probabilistic.cpp
@@ -13,7 +13,7 @@ std::uint64_t select_probabilistic_gate_index(const std::vector<double>& cumulat
     std::uniform_real_distribution<double> dist(0., 1.);
     std::uint64_t i = std::distance(cumulative_distribution.begin(),
                                     std::ranges::upper_bound(cumulative_distribution,
-                                                             dist(context.random_engine))) -
+                                                             dist(*context.random_engine))) -
                       1;
     return std::min<std::uint64_t>(i, cumulative_distribution.size() - 2);
 }
@@ -139,10 +139,10 @@ template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
     const std::vector<double>& params) const {
-    for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
-        auto state_vector = context.states.view_state_vector_at(i);
+    for (std::size_t i = 0; i < context.states->batch_size(); ++i) {
+        auto state_vector = context.states->view_state_vector_at(i);
         ExecutionContext<Prec, ExecutionSpace::Host> state_context{
-            state_vector, context.classical_register[i], context.random_engine};
+            state_vector, (*context.classical_register)[i], *context.random_engine};
         this->update_quantum_state(state_context, params[i]);
     }
 }
@@ -161,10 +161,10 @@ template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
     const std::vector<double>& params) const {
-    for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
-        auto state_vector = context.states.view_state_vector_at(i);
+    for (std::size_t i = 0; i < context.states->batch_size(); ++i) {
+        auto state_vector = context.states->view_state_vector_at(i);
         ExecutionContext<Prec, ExecutionSpace::HostSerial> state_context{
-            state_vector, context.classical_register[i], context.random_engine};
+            state_vector, (*context.classical_register)[i], *context.random_engine};
         this->update_quantum_state(state_context, params[i]);
     }
 }
@@ -184,10 +184,10 @@ template <Precision Prec>
 void ParamProbabilisticGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
     const std::vector<double>& params) const {
-    for (std::size_t i = 0; i < context.states.batch_size(); ++i) {
-        auto state_vector = context.states.view_state_vector_at(i);
+    for (std::size_t i = 0; i < context.states->batch_size(); ++i) {
+        auto state_vector = context.states->view_state_vector_at(i);
         ExecutionContext<Prec, ExecutionSpace::Default> state_context{
-            state_vector, context.classical_register[i], context.random_engine};
+            state_vector, (*context.classical_register)[i], *context.random_engine};
         this->update_quantum_state(state_context, params[i]);
     }
 }

--- a/src/gate/param_gate_standard.cpp
+++ b/src/gate/param_gate_standard.cpp
@@ -22,18 +22,18 @@ std::string ParamRXGateImpl<Prec>::to_string(const std::string& indent) const {
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::Host>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            context.state);
+            *context.state);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -46,23 +46,23 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            context.states);
+            *context.states);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::HostSerial>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            context.state);
+            *context.state);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -75,24 +75,24 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            context.states);
+            *context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::Default>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     rx_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            context.state);
+            *context.state);
 }
 template <Precision Prec>
 void ParamRXGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -106,7 +106,7 @@ void ParamRXGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            context.states);
+            *context.states);
 }
 #endif  // SCALUQ_USE_CUDA
 template class ParamRXGateImpl<Prec>;
@@ -129,18 +129,18 @@ std::string ParamRYGateImpl<Prec>::to_string(const std::string& indent) const {
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::Host>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            context.state);
+            *context.state);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -153,23 +153,23 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            context.states);
+            *context.states);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::HostSerial>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            context.state);
+            *context.state);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -182,24 +182,24 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            context.states);
+            *context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::Default>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     ry_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            context.state);
+            *context.state);
 }
 template <Precision Prec>
 void ParamRYGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -213,7 +213,7 @@ void ParamRYGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            context.states);
+            *context.states);
 }
 #endif  // SCALUQ_USE_CUDA
 template class ParamRYGateImpl<Prec>;
@@ -236,18 +236,18 @@ std::string ParamRZGateImpl<Prec>::to_string(const std::string& indent) const {
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::Host>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            context.state);
+            *context.state);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -260,23 +260,23 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            context.states);
+            *context.states);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::HostSerial>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            context.state);
+            *context.state);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -289,24 +289,24 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            context.states);
+            *context.states);
 }
 #ifdef SCALUQ_USE_CUDA
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
     ExecutionContext<Prec, ExecutionSpace::Default>& context, double param) const {
-    this->check_qubit_mask_within_bounds(context.state);
+    this->check_qubit_mask_within_bounds(*context.state);
     rz_gate(this->_target_mask,
             this->_control_mask,
             this->_control_value_mask,
             this->_pcoef * static_cast<Float<Prec>>(param),
-            context.state);
+            *context.state);
 }
 template <Precision Prec>
 void ParamRZGateImpl<Prec>::update_quantum_state(
     ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
     const std::vector<double>& params) const {
-    this->check_qubit_mask_within_bounds(context.states);
+    this->check_qubit_mask_within_bounds(*context.states);
     std::vector<Float<Prec>> params_prec(params.size());
     std::ranges::transform(
         params, params_prec.begin(), [](double p) { return static_cast<Float<Prec>>(p); });
@@ -320,7 +320,7 @@ void ParamRZGateImpl<Prec>::update_quantum_state(
             this->_control_value_mask,
             this->_pcoef,
             params_view,
-            context.states);
+            *context.states);
 }
 #endif  // SCALUQ_USE_CUDA
 template class ParamRZGateImpl<Prec>;

--- a/src/operator/operator.cpp
+++ b/src/operator/operator.cpp
@@ -446,7 +446,7 @@ Operator<internal::Prec, internal::Space>::copy_to_host_space() const {
 
 template <>
 StdComplex Operator<internal::Prec, internal::Space>::calculate_default_mu() const {
-    FloatType mu;
+    FloatType mu{0};
     std::uint64_t nterms = _terms.size();
     Kokkos::parallel_reduce(
         "calculate_default_mu",

--- a/src/operator/pauli_operator.cpp
+++ b/src/operator/pauli_operator.cpp
@@ -139,7 +139,7 @@ StdComplex PauliOperator<Prec>::get_expectation_value(
     std::uint64_t bit_flip_mask = _bit_flip_mask;
     std::uint64_t phase_flip_mask = _phase_flip_mask;
     if (bit_flip_mask == 0) {
-        FloatType res;
+        FloatType res{0};
         Kokkos::parallel_reduce(
             "get_expectation_value",
             Kokkos::RangePolicy<internal::SpaceType<Space>>(0, state_vector.dim()),
@@ -156,7 +156,7 @@ StdComplex PauliOperator<Prec>::get_expectation_value(
     std::uint64_t pivot = std::bit_width(bit_flip_mask) - 1;
     std::uint64_t global_phase_90rot_count = std::popcount(bit_flip_mask & phase_flip_mask);
     ComplexType global_phase = internal::PHASE_90ROT<Prec>()[global_phase_90rot_count % 4];
-    FloatType res;
+    FloatType res{0};
     Kokkos::parallel_reduce(
         "get_expectation_value",
         Kokkos::RangePolicy<internal::SpaceType<Space>>(0, state_vector.dim() >> 1),

--- a/src/qasm/qasm2.cpp
+++ b/src/qasm/qasm2.cpp
@@ -953,6 +953,9 @@ template <Precision Prec>
 // already-lowered QASM2 operations, not Scaluq gate internals.
 [[nodiscard]] std::string write_qasm2_op(const OpenQasm2Op& op) {
     if (op.kind == OpenQasm2Op::Kind::Measure) {
+        if (!op.classical_bit) {
+            throw std::runtime_error("measure operation is missing a classical bit");
+        }
         return "measure " + q(op.qubits[0]) + " -> " + c(*op.classical_bit) + ";";
     }
     std::ostringstream out;

--- a/src/state/density_matrix.cpp
+++ b/src/state/density_matrix.cpp
@@ -299,7 +299,7 @@ double DensityMatrix<Prec, Space>::get_purity() const {
             "DensityMatrix::get_purity: Purity is only defined for hermitian "
             "density matrices.");
     }
-    FloatType purity;
+    FloatType purity{0};
     Kokkos::parallel_reduce(
         "get_purity",
         Kokkos::MDRangePolicy<internal::SpaceType<Space>, Kokkos::Rank<2>>(

--- a/src/state/state_vector.cpp
+++ b/src/state/state_vector.cpp
@@ -108,7 +108,7 @@ template <Precision Prec, ExecutionSpace Space>
 }
 template <Precision Prec, ExecutionSpace Space>
 double StateVector<Prec, Space>::get_squared_norm() const {
-    FloatType norm;
+    FloatType norm{0};
     Kokkos::parallel_reduce(
         "get_squared_norm",
         Kokkos::RangePolicy<internal::SpaceType<Space>>(0, this->_dim),


### PR DESCRIPTION
# PR Summary

## 概要

clang-tidy 結果から、実害が出やすい警告と rule-of-zero 周辺の警告を種類ごとに修正しました。

主な対象:

- 未初期化の reduction 出力
- optional の未確認アクセス
- `if` 条件内代入
- 重複分岐
- special member functions / default member initialization
- `const` / reference data members

## 変更内容

- `Kokkos::parallel_reduce` の出力変数を明示的にゼロ初期化し、未定義値返却・未初期化値使用の解析警告を解消しました。
- `GatePtr` / `ParamGatePtr` の downcast で、代入と null チェックを分離しました。
- `std::optional` 参照前のチェックを明示し、measure QASM 出力では classical bit 欠落時に例外を投げるようにしました。
- `get_epsilon` の `F16` / `BF16` 同一分岐を統合しました。
- `Complex`, `StateVector`, `StateVectorBatched`, `DensityMatrix` を暗黙生成の special members に寄せました。
- `GateBase` / `ParamGateBase` は polymorphic base として copy/move を明示的に禁止しました。
- default constructor 経由で使われる state / batched operator のメンバを default member initializer で初期化しました。
- `ExecutionContext` / `ExecutionContextBatched` の参照メンバを非所有ポインタへ変更し、参照データメンバをなくしました。
- Pauli 系 gate が保持する `const` 値メンバを通常の private 値メンバに変更しました。

## コミット

- `6c08151` Initialize reduction outputs before returning
- `51a2335` Initialize operator reduction outputs
- `d76e902` Split casts from null checks
- `bf44b3c` Check optionals before access
- `9a87095` Combine identical precision branches
- `10730bd` Apply rule-of-zero special member cleanup
- `53ca9b9` Initialize default-constructed records
- `c08df33` Replace reference context members
- `4dfdd12` Remove const from stored gate values

## 確認

- `clang-tidy` を対象チェックに絞って実行し、プロジェクト側の該当警告が解消されたことを確認しました。
- `ninja -C build-tidy scaluq_default_f64` が成功することを確認しました。
- `git diff --check` が成功することを確認しました。
