### PR TITLE
Fix missing bindings

### DIFF
--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -616,6 +616,15 @@ void bind_circuit_circuit_hpp(nb::module_& m) {
                                      "True"})
                  .build_as_google_style()
                  .c_str())
+        .def("get_classical_condition_at",
+             &Circuit<Prec>::get_classical_condition_at,
+             "index"_a,
+             DocString()
+                 .desc("Get classical register condition.")
+                 .arg("index", "int", "index of classical register")
+                 .ret("bool", "classical bit")
+                 .build_as_google_style()
+                 .c_str())
         .def("calculate_depth",
              &Circuit<Prec>::calculate_depth,
              DocString()

--- a/include/scaluq/classical_register/classical_register.hpp
+++ b/include/scaluq/classical_register/classical_register.hpp
@@ -47,6 +47,7 @@ inline void bind_classical_register_hpp(nb::module_& m) {
     nb::class_<ClassicalRegister>(m, "ClassicalRegister", "Classical register.")
         .def(nb::init<std::uint64_t>(), "register_size"_a, "Initialize classical register.")
         .def("register_size", &ClassicalRegister::register_size, "Get register size.")
+        .def("empty", &ClassicalRegister::empty, "Get register binary.")
         .def("__len__", &ClassicalRegister::register_size, "Get register size.")
         .def(
             "__getitem__",

--- a/include/scaluq/gate/gate_pauli.hpp
+++ b/include/scaluq/gate/gate_pauli.hpp
@@ -31,8 +31,7 @@ public:
     }
     ComplexMatrix get_matrix() const override { return this->_pauli.get_matrix(); }
 
-    void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
         ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
@@ -84,8 +83,7 @@ public:
 
     ComplexMatrix get_matrix() const override;
 
-    void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
         ExecutionContextBatched<Prec, ExecutionSpace::Host>& context) const override;
     void update_quantum_state(
@@ -126,13 +124,33 @@ void bind_gate_gate_pauli_hpp(nb::module_& m, nb::class_<Gate<Prec>>& gate_base_
         "PauliGate",
         "Specific class of multi-qubit pauli gate, which applies single-qubit Pauli "
         "gate to "
-        "each of qubit.");
+        "each of qubit.")
+        .def(
+            "pauli",
+            [](const PauliGate<Prec>& gate) { return gate->pauli(); },
+            nb::rv_policy::reference)
+        .def(
+            "pauli_id_list",
+            [](const PauliGate<Prec>& gate) { return gate->pauli_id_list(); },
+            nb::rv_policy::reference);
     bind_specific_gate<PauliRotationGate<Prec>, Prec>(
         m,
         gate_base_def,
         "PauliRotationGate",
         "Specific class of multi-qubit pauli-rotation gate, represented as "
-        "$e^{-i\\frac{\\theta}{2}P}$.");
+        "$e^{-i\\frac{\\theta}{2}P}$.")
+        .def(
+            "pauli",
+            [](const PauliRotationGate<Prec>& gate) { return gate->pauli(); },
+            nb::rv_policy::reference)
+        .def(
+            "pauli_id_list",
+            [](const PauliRotationGate<Prec>& gate) { return gate->pauli_id_list(); },
+            nb::rv_policy::reference)
+        .def(
+            "angle",
+            [](const PauliRotationGate<Prec>& gate) { return gate->angle(); },
+            nb::rv_policy::reference);
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/gate/param_gate.hpp
+++ b/include/scaluq/gate/param_gate.hpp
@@ -464,6 +464,10 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
             [](const GateT& gate) { return gate->control_qubit_list(); },
             "Get control qubits as `list[int]`.")
         .def(
+            "control_value_list",
+            [](const GateT& gate) { return gate->control_value_list(); },
+            "Get control value as `list[int]`.")
+        .def(
             "operand_qubit_list",
             [](const GateT& gate) { return gate->operand_qubit_list(); },
             "Get target and control qubits as `list[int]`.")
@@ -475,6 +479,10 @@ void register_param_gate_common_methods(nb::class_<GateT>& c) {
             "control_qubit_mask",
             [](const GateT& gate) { return gate->control_qubit_mask(); },
             "Get control qubits as mask.")
+        .def(
+            "control_value_mask",
+            [](const GateT& gate) { return gate->control_value_mask(); },
+            "Get control value as mask.")
         .def(
             "operand_qubit_mask",
             [](const GateT& gate) { return gate->operand_qubit_mask(); },

--- a/include/scaluq/gate/param_gate_pauli.hpp
+++ b/include/scaluq/gate/param_gate_pauli.hpp
@@ -35,20 +35,16 @@ public:
     ComplexMatrix get_matrix(double param) const override;
     void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Host>& context,
                               double param) const override;
-    void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
+    void update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::Host>& context,
                               const std::vector<double>& params) const override;
-    void update_quantum_state(
-        ExecutionContext<Prec, ExecutionSpace::HostSerial>& context,
+    void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::HostSerial>& context,
                               double param) const override;
-    void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
+    void update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::HostSerial>& context,
                               const std::vector<double>& params) const override;
 #ifdef SCALUQ_USE_CUDA
     void update_quantum_state(ExecutionContext<Prec, ExecutionSpace::Default>& context,
                               double param) const override;
-    void update_quantum_state(
-        ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
+    void update_quantum_state(ExecutionContextBatched<Prec, ExecutionSpace::Default>& context,
                               const std::vector<double>& params) const override;
 #endif  // SCALUQ_USE_CUDA
     std::string to_string(const std::string& indent) const override;
@@ -76,7 +72,15 @@ void bind_gate_param_gate_pauli_hpp(nb::module_& m,
         param_gate_base_def,
         "ParamPauliRotationGate",
         "Parametric multi-qubit pauli-rotation gate, represented as $e^{-i\\frac{\\theta}{2}P}$. "
-        "`theta` is given as `param * param_coef`.");
+        "`theta` is given as `param * param_coef`.")
+        .def(
+            "pauli",
+            [](ParamPauliRotationGate<Prec>& gate) { return gate->pauli(); },
+            nb::rv_policy::reference)
+        .def(
+            "pauli_id_list",
+            [](ParamPauliRotationGate<Prec>& gate) { return gate->pauli_id_list(); },
+            nb::rv_policy::reference);
 }
 }  // namespace internal
 #endif

--- a/include/scaluq/operator/operator.hpp
+++ b/include/scaluq/operator/operator.hpp
@@ -157,6 +157,9 @@ void bind_operator_operator_hpp(nb::module_& m) {
         .def("is_hermitian",
              &Operator<Prec, Space>::is_hermitian,
              "Check if the operator is Hermitian.")
+        .def("force_hermitian",
+             &Operator<Prec, Space>::force_hermitian,
+             "Operator is_hermitian is true forcibly.")
         .def("load",
              &Operator<Prec, Space>::load,
              "terms"_a,
@@ -223,7 +226,7 @@ void bind_operator_operator_hpp(nb::module_& m) {
             "states_source"_a,
             "states_target"_a,
             "Get the transition amplitudes of the operator for a batch of state vectors.")
-        .def("get_matrix",
+        .def("get_full_matrix",
              &Operator<Prec, Space>::get_full_matrix,
              "Get matrix representation of the Operator. Tensor product is applied from "
              "n_qubits-1 to 0.")
@@ -318,6 +321,12 @@ void bind_operator_operator_hpp(nb::module_& m) {
              DocString()
                  .desc("Calculate a default shift value `mu` for ground state solvers.")
                  .ret("complex", "Calculated shift value `mu`.")
+                 .build_as_google_style()
+                 .c_str())
+        .def("copy",
+             &Operator<Prec, Space>::copy,
+             DocString()
+                 .desc("Return a deep copy in the same execution space.")
                  .build_as_google_style()
                  .c_str())
         .def("copy_to_default_space",

--- a/include/scaluq/operator/pauli_operator.hpp
+++ b/include/scaluq/operator/pauli_operator.hpp
@@ -172,6 +172,11 @@ void bind_operator_pauli_operator_hpp(nb::module_& m) {
              "Get single-pauli property as string representation. See description of "
              "`__init__(pauli_string: str, coef: float=1.)` for details.")
         .def("get_dagger", &PauliOperator<Prec>::get_dagger, "Get adjoint operator.")
+        .def("add_single_pauli",
+             &PauliOperator<Prec>::add_single_pauli,
+             "target_qubit"_a,
+             "pauli_id"_a,
+             "Add single pauli.")
         .def("apply_to_state",
              nb::overload_cast<StateVector<Prec, ExecutionSpace::Host>&>(
                  &PauliOperator<Prec>::template apply_to_state<ExecutionSpace::Host>, nb::const_),
@@ -183,6 +188,12 @@ void bind_operator_pauli_operator_hpp(nb::module_& m) {
                  nb::const_),
              "state"_a,
              "Get expectation value of measuring state vector. $\\bra{\\psi}P\\ket{\\psi}$.")
+        .def("get_expectation_value",
+             nb::overload_cast<const StateVectorBatched<Prec, ExecutionSpace::Host>&>(
+                 &PauliOperator<Prec>::template get_expectation_value<ExecutionSpace::Host>,
+                 nb::const_),
+             "states"_a,
+             "Get expectation value of measuring state vectors. $\\bra{\\psi}P\\ket{\\psi}$.")
         .def("get_transition_amplitude",
              nb::overload_cast<const StateVector<Prec, ExecutionSpace::Host>&,
                                const StateVector<Prec, ExecutionSpace::Host>&>(
@@ -191,6 +202,14 @@ void bind_operator_pauli_operator_hpp(nb::module_& m) {
              "source"_a,
              "target"_a,
              "Get transition amplitude of measuring state vector. $\\bra{\\chi}P\\ket{\\psi}$.")
+        .def("get_transition_amplitude",
+             nb::overload_cast<const StateVectorBatched<Prec, ExecutionSpace::Host>&,
+                               const StateVectorBatched<Prec, ExecutionSpace::Host>&>(
+                 &PauliOperator<Prec>::template get_transition_amplitude<ExecutionSpace::Host>,
+                 nb::const_),
+             "states_source"_a,
+             "states_target"_a,
+             "Get transition amplitude of measuring state vectors. $\\bra{\\chi}P\\ket{\\psi}$.")
 #ifdef SCALUQ_USE_CUDA
         .def("get_expectation_value",
              nb::overload_cast<const StateVectorBatched<Prec, ExecutionSpace::Default>&>(
@@ -234,6 +253,10 @@ void bind_operator_pauli_operator_hpp(nb::module_& m) {
              &PauliOperator<Prec>::get_full_matrix_ignoring_coef,
              "n_qubits"_a,
              "Get matrix representation of the PauliOperator, but with forcing `coef=1.`")
+        .def("get_matrix_triplets_ignoring_coef",
+             &PauliOperator<Prec>::get_matrix_triplets_ignoring_coef,
+             "Get matrix representation of the PauliOperator, but with forcing `coef=1.` and non "
+             "zero elements")
         .def(nb::self * nb::self)
         .def(nb::self * StdComplex())
         .def(

--- a/include/scaluq/state/state_vector.hpp
+++ b/include/scaluq/state/state_vector.hpp
@@ -484,9 +484,7 @@ void bind_state_state_vector_hpp(nb::module_& m) {
             "sampling",
             [](const StateVector<Prec, Space>& state,
                std::uint64_t sampling_count,
-               std::optional<std::uint64_t> seed) {
-                return state.sampling(sampling_count, seed);
-            },
+               std::optional<std::uint64_t> seed) { return state.sampling(sampling_count, seed); },
             "sampling_count"_a,
             "seed"_a = std::nullopt,
             DocString()
@@ -542,6 +540,12 @@ void bind_state_state_vector_hpp(nb::module_& m) {
                      "amplitudes with len $2^{\\mathrm{n\\_qubits}}$ or source state vector")
                 .build_as_google_style()
                 .c_str())
+        .def("copy",
+             &StateVector<Prec, Space>::copy,
+             DocString()
+                 .desc("Return a deep copy in the same execution space.")
+                 .build_as_google_style()
+                 .c_str())
         .def("copy_to_default_space",
              &StateVector<Prec, Space>::copy_to_default_space,
              DocString()

--- a/tests/circuit/circuit_test.cpp
+++ b/tests/circuit/circuit_test.cpp
@@ -280,7 +280,7 @@ void circuit_suzuki_trotter_test() {
     ComplexMatrix Y = make_Y();
     ComplexMatrix Z = make_Z();
 
-    auto state = StateVector<Prec, Space>::Haar_random_state(n);
+    auto state = StateVector<Prec, Space>::Haar_random_state(n, 1918);
     auto state_cp = state.get_amplitudes();
     ComplexVector state_eigen(dim);
     for (uint64_t i = 0; i < dim; ++i) state_eigen[i] = state_cp[i];


### PR DESCRIPTION
## Summary
Briefly describe the changes in this PR.  

c++で定義及び実装はなされているが、バインディングがされていなかったものにバインディングを追加します。

## What was changed? (変更点)
- 定義されており、実装もあるものでバインディングがなされていないものにバインディングを追加

## Why was this change needed? (変更理由)
- StateVectorのcopyがpython側から使えず不便だったため(`copy_to_default_space`, `copy_to_host_space`しか使えなかった)。

## Additional context (optional)