### PR TITLE
remove invalid library "LIBDL"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,5 +57,5 @@ foreach(LIBRARY IN LISTS SCALUQ_LIBRARIES)
 endforeach()
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/scaluq DESTINATION include/scaluq)
-install(TARGETS scaluq ${SCALUQ_LIBRARIES} kokkos kokkoscore kokkoscontainers kokkosalgorithms kokkossimd nlohmann_json LIBDL EXPORT scaluqTargets LIBRARY DESTINATION lib PUBLIC_HEADER DESTINATION include)
+install(TARGETS scaluq ${SCALUQ_LIBRARIES} kokkos kokkoscore kokkoscontainers kokkosalgorithms kokkossimd nlohmann_json EXPORT scaluqTargets LIBRARY DESTINATION lib PUBLIC_HEADER DESTINATION include)
 install(EXPORT scaluqTargets FILE scaluq-config.cmake DESTINATION share/cmake/scaluq/ NAMESPACE scaluq::)


### PR DESCRIPTION
## Summary
Briefly describe the changes in this PR.  
ソースをインストールするときの`install`分で、CMakeターゲットではない `LIBDL`というものが入っていました。
手元で、Kokkosのバージョンを上げたとき、(これはどういう因果かわからないが、使われるCMakeバージョンが変わった？) ビルド時に以下のエラーが発生したので、削除します。
```
CMake Error at src/CMakeLists.txt:60 (install):
  install TARGETS given target "LIBDL" which does not exist.
```

## What was changed? (変更点)
- 不正なライブラリ名をinstallから削除する

## Why was this change needed? (変更理由)
- 

## Additional context (optional)
-
