### PR TITLE
Refactor 202607-2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,11 +318,18 @@ if(CLANG_TIDY)
     file(GLOB_RECURSE ALL_CXX_TIDY_SOURCE_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp
     )
+    # clang-tidy may not use the same default header search paths as the
+    # configured compiler. Pass the paths detected by CMake explicitly so that
+    # clang-tidy can find the toolchain's C++ standard library headers.
+    set(_tidy_args -p=${CMAKE_BINARY_DIR})
+    foreach(_include_dir IN LISTS CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
+        list(APPEND _tidy_args "--extra-arg=-isystem${_include_dir}")
+    endforeach()
     set(_tidy_commands "")
     foreach(_src ${ALL_CXX_TIDY_SOURCE_FILES})
         list(APPEND _tidy_commands
             COMMAND ${CMAKE_COMMAND} -E echo "[clang-tidy] ${_src}"
-            COMMAND ${CLANG_TIDY} -p=${CMAKE_BINARY_DIR} ${_src}
+            COMMAND ${CLANG_TIDY} ${_tidy_args} ${_src}
         )
     endforeach()
     add_custom_target(

--- a/include/scaluq/circuit/circuit.hpp
+++ b/include/scaluq/circuit/circuit.hpp
@@ -123,6 +123,8 @@ public:
     }
 
     void add_circuit(const Circuit<Prec>& circuit);
+    // The circuit is consumed by moving its elements individually.
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
     void add_circuit(Circuit<Prec>&& circuit);
 
     template <ExecutionSpace Space>

--- a/include/scaluq/gate/gate.hpp
+++ b/include/scaluq/gate/gate.hpp
@@ -243,10 +243,10 @@ struct ExecutionContextDensityMatrix {
 };
 
 // GateBase テンプレートクラス
-template <Precision _Prec>
-class GateBase : public std::enable_shared_from_this<GateBase<_Prec>> {
+template <Precision PrecVal>
+class GateBase : public std::enable_shared_from_this<GateBase<PrecVal>> {
 public:
-    constexpr static Precision Prec = _Prec;
+    constexpr static Precision Prec = PrecVal;
     using FloatType = Float<Prec>;
     using ComplexType = Complex<Prec>;
 

--- a/include/scaluq/gate/param_gate.hpp
+++ b/include/scaluq/gate/param_gate.hpp
@@ -55,10 +55,10 @@ constexpr ParamGateType get_param_gate_type() {
 }
 
 namespace internal {
-template <Precision _Prec>
-class ParamGateBase : public std::enable_shared_from_this<ParamGateBase<_Prec>> {
+template <Precision PrecVal>
+class ParamGateBase : public std::enable_shared_from_this<ParamGateBase<PrecVal>> {
 public:
-    constexpr static Precision Prec = _Prec;
+    constexpr static Precision Prec = PrecVal;
     using FloatType = Float<Prec>;
     using ComplexType = Complex<Prec>;
 

--- a/script/configure
+++ b/script/configure
@@ -30,5 +30,5 @@ for var in $variables; do
   fi
 done
 
-mkdir -p ./build
+mkdir -p ${BUILD:-build}
 cmake -B ${BUILD:-build} -G Ninja ${CMAKE_OPS}

--- a/src/circuit/circuit.cpp
+++ b/src/circuit/circuit.cpp
@@ -61,6 +61,8 @@ void Circuit<Prec>::add_circuit(const Circuit<Prec>& circuit) {
     }
 }
 template <Precision Prec>
+// The circuit is consumed by moving its elements individually.
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
 void Circuit<Prec>::add_circuit(Circuit<Prec>&& circuit) {
     _gate_list.reserve(_gate_list.size() + circuit._gate_list.size());
     _classical_conditions.reserve(_classical_conditions.size() +

--- a/src/operator/operator.cpp
+++ b/src/operator/operator.cpp
@@ -46,7 +46,7 @@ void Operator<internal::Prec, internal::Space>::load(
     auto host_view = internal::wrapped_host_view(terms);
     Kokkos::deep_copy(_terms, host_view);
     _is_hermitian = true;
-    for (auto& term : terms) {
+    for (const auto& term : terms) {
         if (term.coef().imag() != 0) {
             _is_hermitian = false;
             break;

--- a/src/operator/pauli_operator.cpp
+++ b/src/operator/pauli_operator.cpp
@@ -9,8 +9,8 @@ template <Precision Prec>
 PauliOperator<Prec>::PauliOperator(std::string_view pauli_string, StdComplex coef) : _coef(coef) {
     auto ss = std::stringstream(std::string(pauli_string));
     while (1) {
-        char pauli;
-        std::uint64_t target;
+        char pauli{};
+        std::uint64_t target{};
         ss >> pauli;
         if (ss.fail()) break;
         ss >> target;

--- a/src/qasm/qasm2.cpp
+++ b/src/qasm/qasm2.cpp
@@ -909,6 +909,7 @@ template <Precision Prec>
         throw std::runtime_error("unsupported controlled gate for OpenQASM 2.0 export");
     }
     std::vector<std::string> params;
+    params.reserve(op.params.size());
     for (double param : op.params) params.push_back(format_angle(param));
     if (op.controls.empty()) {
         return {OpenQasm2Op::Kind::Gate, std::string(op.name), params, {op.target}, std::nullopt};


### PR DESCRIPTION
# PR Summary

## 概要

clang-tidy をローカル環境でも実行できるようにし、結果から安全に対応できる軽微な警告を修正しました。

主な対象:

- clang-tidy と設定済みコンパイラで標準ヘッダーの検索パスが異なる場合の解析エラー
- Pauli文字列解析の未初期化変数
- 要素単位で意図的にmoveする右辺値Circuit
- 読み取り専用参照の明示
- QASMパラメータvectorの事前容量確保
- 予約済み識別子に該当するテンプレート引数名

## 変更内容

- CMakeが検出したC++の暗黙include pathをclang-tidyへ明示的に渡し、設定済みコンパイラとclang-tidyの既定検索パスが異なる環境でも標準ライブラリヘッダーを解決できるようにしました。
- configureスクリプトがBUILD環境変数で指定されたビルドディレクトリを作成するようにしました。
- Pauli文字列解析で使用するローカル変数を値初期化しました。
- add_circuitの右辺値オーバーロードはCircuitの要素を個別にmoveして消費する実装であるため、理由を記載した局所的なNOLINTを追加しました。
- const vectorを走査する参照をconst auto&として明示しました。
- OpenQASM 2.0出力のパラメータvectorに必要な容量を事前確保しました。
- 予約済み識別子である_PrecをPrecValへ変更しました。

## コミット

- 61fe1e5 build: improve local configuration support
- d515331 fix: initialize Pauli parser variables
- a16b5e4 chore: suppress intentional partial circuit move
- bcad51f style: qualify read-only operator term
- 5c6d992 perf: reserve QASM parameter storage
- 57f8fbd style: rename reserved precision parameters

## 確認

- clang-tidyを変更対象のチェックに絞って実行し、プロジェクト側の該当警告が解消または意図どおり局所抑制されたことを確認しました。
- clang-tidyターゲット全体が標準ライブラリヘッダーの解析エラーなく完走することを確認しました。
- git diff --checkが成功することを確認しました。
- 通常ビルドは今回省略しています。
